### PR TITLE
Fix gradle platform plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # kotlin
 kotlin-lang = "1.9.21"
-krpc-core = "beta-5" # version for plugins and suffix for krpc-full
+krpc-core = "beta-5.1" # version for plugins and suffix for krpc-full
 
 # kotlin-dependent versions, will be replaced with the actual versions by a settings-conventions plugin
 #   from 'kotlin-versions-lookup.json' lookup table

--- a/krpc-gradle-plugin/krpc-gradle-plugin-platform/src/main/kotlin/org/jetbrains/krpc/KRPCPlatformPlugin.kt
+++ b/krpc-gradle-plugin/krpc-gradle-plugin-platform/src/main/kotlin/org/jetbrains/krpc/KRPCPlatformPlugin.kt
@@ -6,16 +6,28 @@ package org.jetbrains.krpc
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.jetbrains.krpc.KRPCPluginConst.KRPC_GROUP_ID
 import org.jetbrains.krpc.KRPCPluginConst.KRPC_BOM_ARTIFACT_ID
 import org.jetbrains.krpc.KRPCPluginConst.krpcFullVersion
 
 class KRPCPlatformPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.dependencies.apply {
-            val bomDependency = "${KRPC_GROUP_ID}:${KRPC_BOM_ARTIFACT_ID}:${krpcFullVersion}"
+        val bomDependency = "${KRPC_GROUP_ID}:${KRPC_BOM_ARTIFACT_ID}:${krpcFullVersion}"
 
-            add("implementation", platform(bomDependency))
+        val matcher: (Configuration) -> Boolean = { conf ->
+            conf.name in knownConfigurations
         }
+
+        target.configurations.matching(matcher).all {
+            target.dependencies.add(name, target.dependencies.platform(bomDependency))
+        }
+    }
+
+    companion object {
+        private const val IMPLEMENTATION = "implementation"
+        private const val COMMON_IMPLEMENTATION = "commonMainImplementation"
+
+        private val knownConfigurations = setOf(IMPLEMENTATION, COMMON_IMPLEMENTATION)
     }
 }


### PR DESCRIPTION
Fix for gradle plugin 'org.jetbrains.krpc.platform', that enables usage of this plugin with miltiplatform projects