### PR TITLE
Replaced transport delegation with constructor parameter

### DIFF
--- a/krpc-runtime/krpc-runtime-client/api/krpc-runtime-client.api
+++ b/krpc-runtime/krpc-runtime-client/api/krpc-runtime-client.api
@@ -3,16 +3,17 @@ public final class org/jetbrains/krpc/client/AwaitFieldInitializationKt {
 	public static final fun awaitFieldInitialization (Lorg/jetbrains/krpc/RPC;Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract class org/jetbrains/krpc/client/KRPCClient : org/jetbrains/krpc/internal/transport/RPCEndpointBase, org/jetbrains/krpc/RPCClient, org/jetbrains/krpc/RPCTransport {
-	public fun <init> (Lorg/jetbrains/krpc/RPCConfig$Client;)V
-	public fun call (Lorg/jetbrains/krpc/RPCCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract class org/jetbrains/krpc/client/KRPCClient : org/jetbrains/krpc/internal/transport/RPCEndpointBase, org/jetbrains/krpc/RPCClient {
+	public fun <init> (Lorg/jetbrains/krpc/RPCConfig$Client;Lorg/jetbrains/krpc/RPCTransport;)V
+	public final fun call (Lorg/jetbrains/krpc/RPCCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun getConfig ()Lorg/jetbrains/krpc/RPCConfig$Client;
 	public synthetic fun getConfig ()Lorg/jetbrains/krpc/RPCConfig;
+	public final fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	protected fun getLogger ()Lorg/jetbrains/krpc/internal/logging/CommonLogger;
 	protected fun getSender ()Lorg/jetbrains/krpc/internal/transport/RPCMessageSender;
-	public fun registerPlainFlowField (Lorg/jetbrains/krpc/RPCField;)Lkotlinx/coroutines/flow/Flow;
-	public fun registerSharedFlowField (Lorg/jetbrains/krpc/RPCField;)Lkotlinx/coroutines/flow/SharedFlow;
-	public fun registerStateFlowField (Lorg/jetbrains/krpc/RPCField;)Lkotlinx/coroutines/flow/StateFlow;
+	public final fun registerPlainFlowField (Lorg/jetbrains/krpc/RPCField;)Lkotlinx/coroutines/flow/Flow;
+	public final fun registerSharedFlowField (Lorg/jetbrains/krpc/RPCField;)Lkotlinx/coroutines/flow/SharedFlow;
+	public final fun registerStateFlowField (Lorg/jetbrains/krpc/RPCField;)Lkotlinx/coroutines/flow/StateFlow;
 }
 
 public final class org/jetbrains/krpc/client/RPCClientUtilsKt {

--- a/krpc-runtime/krpc-runtime-server/api/krpc-runtime-server.api
+++ b/krpc-runtime/krpc-runtime-server/api/krpc-runtime-server.api
@@ -1,5 +1,6 @@
-public abstract class org/jetbrains/krpc/server/KRPCServer : org/jetbrains/krpc/RPCServer, org/jetbrains/krpc/RPCTransport {
-	public fun <init> (Lorg/jetbrains/krpc/RPCConfig$Server;)V
+public abstract class org/jetbrains/krpc/server/KRPCServer : org/jetbrains/krpc/RPCServer {
+	public fun <init> (Lorg/jetbrains/krpc/RPCConfig$Server;Lorg/jetbrains/krpc/RPCTransport;)V
+	public final fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun registerService (Lorg/jetbrains/krpc/RPC;Lkotlin/reflect/KClass;)V
 }
 

--- a/krpc-runtime/krpc-runtime-test/src/jvmMain/kotlin/org/jetbrains/krpc/test/KRPCTestClient.kt
+++ b/krpc-runtime/krpc-runtime-test/src/jvmMain/kotlin/org/jetbrains/krpc/test/KRPCTestClient.kt
@@ -5,9 +5,8 @@
 package org.jetbrains.krpc.test
 
 import org.jetbrains.krpc.RPCConfig
-import org.jetbrains.krpc.client.KRPCClient
 import org.jetbrains.krpc.RPCTransport
-import kotlin.coroutines.CoroutineContext
+import org.jetbrains.krpc.client.KRPCClient
 
 /**
  * Implementation of [KRPCClient] that can be used to test custom [RPCTransport].
@@ -17,6 +16,5 @@ import kotlin.coroutines.CoroutineContext
  */
 class KRPCTestClient(
     config: RPCConfig.Client,
-    override val coroutineContext: CoroutineContext,
     transport: RPCTransport,
-) : KRPCClient(config), RPCTransport by transport
+) : KRPCClient(config, transport)

--- a/krpc-runtime/krpc-runtime-test/src/jvmMain/kotlin/org/jetbrains/krpc/test/KRPCTestServer.kt
+++ b/krpc-runtime/krpc-runtime-test/src/jvmMain/kotlin/org/jetbrains/krpc/test/KRPCTestServer.kt
@@ -7,7 +7,6 @@ package org.jetbrains.krpc.test
 import org.jetbrains.krpc.RPCConfig
 import org.jetbrains.krpc.RPCTransport
 import org.jetbrains.krpc.server.KRPCServer
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Implementation of [KRPCServer] that can be used to test custom [RPCTransport].
@@ -17,6 +16,5 @@ import kotlin.coroutines.CoroutineContext
  */
 class KRPCTestServer(
     config: RPCConfig.Server,
-    override val coroutineContext: CoroutineContext,
     transport: RPCTransport,
-) : KRPCServer(config), RPCTransport by transport
+) : KRPCServer(config, transport)

--- a/krpc-runtime/krpc-runtime-test/src/jvmMain/kotlin/org/jetbrains/krpc/test/KRPCTransportTestBase.kt
+++ b/krpc-runtime/krpc-runtime-test/src/jvmMain/kotlin/org/jetbrains/krpc/test/KRPCTransportTestBase.kt
@@ -9,10 +9,12 @@ package org.jetbrains.krpc.test
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
-import org.jetbrains.krpc.*
+import org.jetbrains.krpc.RPCTransport
 import org.jetbrains.krpc.client.awaitFieldInitialization
 import org.jetbrains.krpc.client.withService
-import org.jetbrains.krpc.RPCTransport
+import org.jetbrains.krpc.registerService
+import org.jetbrains.krpc.rpcClientConfig
+import org.jetbrains.krpc.rpcServerConfig
 import org.jetbrains.krpc.serialization.RPCSerialFormatConfiguration
 import org.jetbrains.krpc.server.KRPCServer
 import org.junit.Assert.assertEquals
@@ -62,10 +64,10 @@ abstract class KRPCTransportTestBase {
     fun start() {
         service = KRPCTestServiceBackend()
 
-        backend = KRPCTestServer(serverConfig, service.coroutineContext, serverTransport)
+        backend = KRPCTestServer(serverConfig, serverTransport)
         backend.registerService<KRPCTestService>(service)
 
-        client = KRPCTestClient(clientConfig, service.coroutineContext, clientTransport).withService()
+        client = KRPCTestClient(clientConfig, clientTransport).withService()
     }
 
     @AfterTest

--- a/krpc-runtime/src/commonMain/kotlin/org/jetbrains/krpc/internal/transport/RPCEndpointBase.kt
+++ b/krpc-runtime/src/commonMain/kotlin/org/jetbrains/krpc/internal/transport/RPCEndpointBase.kt
@@ -22,7 +22,7 @@ import org.jetbrains.krpc.internal.*
 import org.jetbrains.krpc.internal.logging.CommonLogger
 
 @InternalKRPCApi
-public abstract class RPCEndpointBase : CoroutineScope {
+public abstract class RPCEndpointBase {
     protected abstract val sender: RPCMessageSender
     protected abstract val config: RPCConfig
     protected abstract val logger: CommonLogger

--- a/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/ProtocolTest.kt
+++ b/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/ProtocolTest.kt
@@ -21,12 +21,14 @@ import org.junit.Test
 class ProtocolTest : ProtocolTestBase() {
     @Test
     fun testHandshakeWithUpToDateEndpoints() = runTest {
-        // handshake is lazy
-        assertEquals(emptySet<RPCPlugin>(), defaultClient.serverPlugins)
+        // the client sends the handshake message first,
+        // so as the service is not initializaed yet here,
+        // the server should not have any handshake data yet
         assertEquals(0, defaultServer.clientPlugins.size)
 
         service.sendRequest()
 
+        // after a call is finished - all handshake data should be exchanged
         assertEquals(RPCPlugin.ALL, defaultClient.serverPlugins)
         assertEquals(RPCPlugin.ALL, defaultServer.clientPlugins[defaultClient.id])
     }

--- a/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/ProtocolTestBase.kt
+++ b/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/ProtocolTestBase.kt
@@ -104,7 +104,7 @@ private class ProtocolTestServiceImpl(
 class ProtocolTestServer(
     config: RPCConfig.Server,
     transport: LocalTransport,
-) : KRPCServer(config), RPCTransport by transport.server {
+) : KRPCServer(config, transport.server) {
     val clientPlugins: Map<Long, Set<RPCPlugin>>
 
     init {
@@ -123,7 +123,7 @@ class ProtocolTestServer(
 class ProtocolTestClient(
     config: RPCConfig.Client,
     transport: LocalTransport,
-) : KRPCClient(config), RPCTransport by transport.client {
+) : KRPCClient(config, transport.client) {
     @OptIn(ExperimentalCoroutinesApi::class)
     val serverPlugins: Set<RPCPlugin>
         get() = if (serverSupportedPluginsDeferred.isCompleted) {

--- a/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/TransportTest.kt
+++ b/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/TransportTest.kt
@@ -60,7 +60,7 @@ class TransportTest {
     }
 
     private fun clientOf(localTransport: LocalTransport): RPCClient {
-        return KRPCTestClient(clientConfig, Job(), localTransport.client)
+        return KRPCTestClient(clientConfig, localTransport.client)
     }
 
     private fun serverOf(
@@ -68,7 +68,7 @@ class TransportTest {
         config: (RPCConfigBuilder.Server.() -> Unit)? = null
     ): RPCServer {
         val serverConfig = config?.let { rpcServerConfig(it) } ?: serverConfig
-        return KRPCTestServer(serverConfig, Job(), localTransport.server)
+        return KRPCTestServer(serverConfig, localTransport.server)
     }
 
     @Test

--- a/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/api/util/SamplingEndpoints.kt
+++ b/krpc-runtime/src/jvmTest/kotlin/org/jetbrains/krpc/test/api/util/SamplingEndpoints.kt
@@ -5,7 +5,6 @@
 package org.jetbrains.krpc.test.api.util
 
 import org.jetbrains.krpc.RPCConfig
-import org.jetbrains.krpc.RPCTransport
 import org.jetbrains.krpc.client.KRPCClient
 import org.jetbrains.krpc.internal.SequentialIdCounter
 import org.jetbrains.krpc.server.KRPCServer
@@ -14,12 +13,12 @@ import org.jetbrains.krpc.test.LocalTransport
 class SamplingClient(
     config: RPCConfig.Client,
     localTransport: LocalTransport,
-) : KRPCClient(config), RPCTransport by localTransport.client
+) : KRPCClient(config, localTransport.client)
 
 class SamplingServer(
     config: RPCConfig.Server,
     localTransport: LocalTransport,
-) : KRPCServer(config), RPCTransport by localTransport.server {
+) : KRPCServer(config, localTransport.server) {
     init {
         val idCounterField = KRPCServer::class.java.declaredFields
             .single { it.name == "idCounter" }

--- a/krpc-transport/krpc-transport-ktor/krpc-transport-ktor-client/src/commonMain/kotlin/org/jetbrains/krpc/transport/ktor/client/KtorRPCClient.kt
+++ b/krpc-transport/krpc-transport-ktor/krpc-transport-ktor-client/src/commonMain/kotlin/org/jetbrains/krpc/transport/ktor/client/KtorRPCClient.kt
@@ -6,11 +6,10 @@ package org.jetbrains.krpc.transport.ktor.client
 
 import io.ktor.websocket.*
 import org.jetbrains.krpc.RPCConfig
-import org.jetbrains.krpc.RPCTransport
 import org.jetbrains.krpc.client.KRPCClient
 import org.jetbrains.krpc.transport.ktor.KtorTransport
 
 internal class KtorRPCClient(
     webSocketSession: WebSocketSession,
     config: RPCConfig.Client,
-): KRPCClient(config), RPCTransport by KtorTransport(webSocketSession)
+): KRPCClient(config, KtorTransport(webSocketSession))

--- a/krpc-transport/krpc-transport-ktor/krpc-transport-ktor-server/src/jvmMain/kotlin/org/jetbrains/krpc/transport/ktor/server/KtorRPCServer.kt
+++ b/krpc-transport/krpc-transport-ktor/krpc-transport-ktor-server/src/jvmMain/kotlin/org/jetbrains/krpc/transport/ktor/server/KtorRPCServer.kt
@@ -6,11 +6,10 @@ package org.jetbrains.krpc.transport.ktor.server
 
 import io.ktor.websocket.*
 import org.jetbrains.krpc.RPCConfig
-import org.jetbrains.krpc.RPCTransport
 import org.jetbrains.krpc.server.KRPCServer
 import org.jetbrains.krpc.transport.ktor.KtorTransport
 
 internal class KtorRPCServer(
     webSocketSession: WebSocketSession,
     config: RPCConfig.Server,
-) : KRPCServer(config), RPCTransport by KtorTransport(webSocketSession)
+) : KRPCServer(config, KtorTransport(webSocketSession))


### PR DESCRIPTION
Replaced transport delegation with constructor parameter to avoid NullPointerException for CoroutineScope.launch calls in init blocks


