### PR TITLE
Fix browser installation for puppeteer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ detekt/reports/**
 
 # tmp files created by tests
 *.tmp
+
+.puppeteer

--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -1,0 +1,14 @@
+const {join} = require('path');
+
+const isCI = process.env.TEAMCITY_VERSION
+
+if (isCI) {
+    /**
+     * @type {import("puppeteer").Configuration}
+     */
+    module.exports = {
+      // Changes the cache location for Puppeteer
+      // So that in docker container browsers are included
+      cacheDirectory: join(__dirname, '.puppeteer', 'browsers'),
+    };
+}


### PR DESCRIPTION
Fixes installation place for puppeteer on CI so `jsBrowserTest` is ok