### PR TITLE
Add installRPC extension for Ktor

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -735,7 +735,7 @@ To do that, the following DSL can be used:
 
 ```kotlin
 val ktorClient = HttpClient {
-    install(RPC) { // this: RPCConfigBuilder.Client
+    installRPC { // this: RPCConfigBuilder.Client
         waitForServices = true
     }
 }
@@ -795,9 +795,7 @@ interface ImageService : RPC {
 // ### CLIENT CODE ###
 
 val client = HttpClient {
-    install(WebSockets)
-
-    install(kotlinx.rpc.transport.ktor.client.RPC) {
+    installRPC {
         serialization {
             json()
         }
@@ -822,10 +820,8 @@ class ImageServiceImpl(override val coroutineContext: CoroutineContext) : ImageS
 }
 
 fun main() {
-    embeddedServer(Netty, port = 8080) {
-        install(WebSockets)
-
-        install(kotlinx.rpc.transport.ktor.server.RPC) {
+    embeddedServer(Netty, port = 8080) {  
+        install(RPC) {
             serialization {
                 json()
             }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fun main() {
 ```
 To connect to the server use the following [Ktor Client](https://ktor.io/docs/create-client.html) setup:
 ```kotlin
-val rpcClient = HttpClient { install(RPC) }.rpc {
+val rpcClient = HttpClient { installRPC() }.rpc {
     url("ws://localhost:8080/awesome")
 
     rpcConfig {

--- a/transport/transport-ktor/src/jvmTest/kotlin/kotlinx/rpc/transport/ktor/KtorTransportTest.kt
+++ b/transport/transport-ktor/src/jvmTest/kotlin/kotlinx/rpc/transport/ktor/KtorTransportTest.kt
@@ -11,12 +11,12 @@ import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.routing.*
-import io.ktor.server.websocket.*
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import kotlinx.rpc.RPC
 import kotlinx.rpc.client.withService
 import kotlinx.rpc.serialization.json
+import kotlinx.rpc.transport.ktor.client.installRPC
 import kotlinx.rpc.transport.ktor.client.rpc
 import kotlinx.rpc.transport.ktor.client.rpcConfig
 import kotlinx.rpc.transport.ktor.server.RPC
@@ -39,12 +39,7 @@ class KtorTransportTest {
     @Test
     fun testEcho() = runBlocking {
         val server = embeddedServer(Netty, port = 4242) {
-            install(WebSockets)
-            install(RPC) {
-                serialization {
-                    json()
-                }
-            }
+            install(RPC)
             routing {
                 rpc("/rpc") {
                     rpcConfig {
@@ -63,8 +58,7 @@ class KtorTransportTest {
         }.start()
 
         val clientWithGlobalConfig = HttpClient {
-            install(io.ktor.client.plugins.websocket.WebSockets)
-            install(kotlinx.rpc.transport.ktor.client.RPC) {
+            installRPC {
                 serialization {
                     json()
                 }
@@ -83,8 +77,7 @@ class KtorTransportTest {
         clientWithGlobalConfig.cancel()
 
         val clientWithNoConfig = HttpClient {
-            install(io.ktor.client.plugins.websocket.WebSockets)
-            install(kotlinx.rpc.transport.ktor.client.RPC)
+            installRPC()
         }
 
         val serviceWithLocalConfig = clientWithNoConfig.rpc("ws://localhost:4242/rpc") {

--- a/transport/transport-ktor/transport-ktor-client/api/kotlinx-rpc-transport-ktor-client.api
+++ b/transport/transport-ktor/transport-ktor-client/api/kotlinx-rpc-transport-ktor-client.api
@@ -9,5 +9,7 @@ public final class kotlinx/rpc/transport/ktor/client/KtorClientDslKt {
 
 public final class kotlinx/rpc/transport/ktor/client/RPCKt {
 	public static final fun getRPC ()Lio/ktor/client/plugins/api/ClientPlugin;
+	public static final fun installRPC (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun installRPC$default (Lio/ktor/client/HttpClientConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 

--- a/transport/transport-ktor/transport-ktor-client/src/commonMain/kotlin/kotlinx/rpc/transport/ktor/client/RPC.kt
+++ b/transport/transport-ktor/transport-ktor-client/src/commonMain/kotlin/kotlinx/rpc/transport/ktor/client/RPC.kt
@@ -4,7 +4,9 @@
 
 package kotlinx.rpc.transport.ktor.client
 
+import io.ktor.client.*
 import io.ktor.client.plugins.api.*
+import io.ktor.client.plugins.websocket.*
 import io.ktor.util.*
 import kotlinx.rpc.RPCConfigBuilder
 
@@ -15,4 +17,14 @@ internal val RPCClientPluginAttributesKey = AttributeKey<RPCConfigBuilder.Client
  */
 public val RPC: ClientPlugin<RPCConfigBuilder.Client> = createClientPlugin("RPC", { RPCConfigBuilder.Client() }) {
     client.attributes.put(RPCClientPluginAttributesKey, pluginConfig)
+}
+
+/**
+ * Installs [WebSockets] and [RPC] client plugins
+ */
+public fun HttpClientConfig<*>.installRPC(
+    configure: RPCConfigBuilder.Client.() -> Unit = {}
+) {
+    install(WebSockets)
+    install(RPC, configure)
 }

--- a/transport/transport-ktor/transport-ktor-server/src/jvmMain/kotlin/kotlinx/rpc/transport/ktor/server/RPC.kt
+++ b/transport/transport-ktor/transport-ktor-server/src/jvmMain/kotlin/kotlinx/rpc/transport/ktor/server/RPC.kt
@@ -5,6 +5,7 @@
 package kotlinx.rpc.transport.ktor.server
 
 import io.ktor.server.application.*
+import io.ktor.server.websocket.*
 import io.ktor.util.*
 import kotlinx.rpc.RPCConfigBuilder
 
@@ -17,5 +18,6 @@ public val RPC: ApplicationPlugin<RPCConfigBuilder.Server> = createApplicationPl
     name = "RPC",
     createConfiguration = { RPCConfigBuilder.Server() },
 ) {
+    application.install(WebSockets)
     application.attributes.put(RPCServerPluginAttributesKey, pluginConfig)
 }


### PR DESCRIPTION
Until now users faced a need to install WebSockets plugin manually, which can be both confusing and boilerplate. Now they may use `installRPC` extension that installs both RPC and WebSockets plugins (for server and client)