### PR TITLE
Add dev mode toggle for stream scope for internal use

### DIFF
--- a/runtime/api/kotlinx-rpc-runtime.api
+++ b/runtime/api/kotlinx-rpc-runtime.api
@@ -138,6 +138,9 @@ public final class kotlinx/rpc/RPCTransportMessage$StringMessage : kotlinx/rpc/R
 	public final fun getValue ()Ljava/lang/String;
 }
 
+public final class kotlinx/rpc/internal/DevStreamScopeKt {
+}
+
 public final class kotlinx/rpc/internal/ExceptionUtilsKt {
 }
 
@@ -157,6 +160,9 @@ public final class kotlinx/rpc/internal/ScopedClientCallKt {
 }
 
 public final class kotlinx/rpc/internal/SerializationUtilsKt {
+}
+
+public final class kotlinx/rpc/internal/ServiceScopeKt {
 }
 
 public final class kotlinx/rpc/internal/StreamScopeKt {

--- a/runtime/src/commonMain/kotlin/kotlinx/rpc/internal/ServiceScope.kt
+++ b/runtime/src/commonMain/kotlin/kotlinx/rpc/internal/ServiceScope.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.coroutines.CoroutineContext
+
+@InternalRPCApi
+public class ServiceScope(public val serviceCoroutineScope: CoroutineScope) : CoroutineContext.Element {
+    internal companion object Key : CoroutineContext.Key<ServiceScope>
+
+    override val key: CoroutineContext.Key<*> = Key
+}
+
+@InternalRPCApi
+public suspend fun createServiceScope(serviceCoroutineScope: CoroutineScope): ServiceScope {
+    val context = currentCoroutineContext()
+
+    if (context[ServiceScope.Key] != null) {
+        error("serviceScoped nesting is not allowed")
+    }
+
+    return ServiceScope(serviceCoroutineScope)
+}
+
+@InternalRPCApi
+public suspend fun serviceScopeOrNull(): ServiceScope? {
+    return currentCoroutineContext()[ServiceScope.Key]
+}
+
+@InternalRPCApi
+@OptIn(ExperimentalContracts::class)
+public suspend inline fun <T> serviceScoped(
+    serviceCoroutineScope: CoroutineScope,
+    noinline block: suspend CoroutineScope.() -> T,
+): T {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+
+    return withContext(createServiceScope(serviceCoroutineScope), block)
+}

--- a/runtime/src/commonMain/kotlin/kotlinx/rpc/internal/devStreamScope.kt
+++ b/runtime/src/commonMain/kotlin/kotlinx/rpc/internal/devStreamScope.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.internal
+
+/**
+ * For legacy internal users ONLY.
+ * Special dev builds may set this value to `false`.
+ *
+ * If the value is `false`, absence of [streamScoped] for a call is replaced with service's [StreamScope]
+ * obtained via [withClientStreamScope].
+ */
+@InternalRPCApi
+public const val STREAM_SCOPES_ENABLED: Boolean = true

--- a/runtime/src/commonMain/kotlin/kotlinx/rpc/internal/scopedClientCall.kt
+++ b/runtime/src/commonMain/kotlin/kotlinx/rpc/internal/scopedClientCall.kt
@@ -14,14 +14,16 @@ import kotlinx.coroutines.*
 @InternalRPCApi
 @OptIn(InternalCoroutinesApi::class)
 @Suppress("unused")
-public suspend inline fun <T> scopedClientCall(serviceScope: CoroutineScope, body: () -> T): T {
+public suspend inline fun <T> scopedClientCall(serviceScope: CoroutineScope, crossinline body: suspend () -> T): T {
     val requestJob = currentCoroutineContext().job
     val handle = serviceScope.coroutineContext.job.invokeOnCompletion(onCancelling = true) {
         requestJob.cancel(it as CancellationException)
     }
 
     try {
-        return body()
+        return serviceScoped(serviceScope) {
+            body()
+        }
     } finally {
         handle.dispose()
     }

--- a/runtime/src/jvmTest/kotlin/kotlinx/rpc/test/cancellation/CancellationTest.kt
+++ b/runtime/src/jvmTest/kotlin/kotlinx/rpc/test/cancellation/CancellationTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
 import kotlinx.rpc.client.withService
+import kotlinx.rpc.internal.STREAM_SCOPES_ENABLED
 import kotlinx.rpc.internal.invokeOnStreamScopeCompletion
 import kotlinx.rpc.internal.streamScoped
 import kotlin.test.*
@@ -203,7 +204,11 @@ class CancellationTest {
     fun testStreamScopeAbsentForOutgoingStream() = runCancellationTest {
         val fence = CompletableDeferred<Unit>()
 
-        assertFailsWith<IllegalStateException> {
+        if (STREAM_SCOPES_ENABLED) {
+            assertFailsWith<IllegalStateException> {
+                service.outgoingStream(resumableFlow(fence))
+            }
+        } else {
             service.outgoingStream(resumableFlow(fence))
         }
 
@@ -212,7 +217,11 @@ class CancellationTest {
 
     @Test
     fun testStreamScopeAbsentForIncomingStream() = runCancellationTest {
-        assertFailsWith<IllegalStateException> {
+        if (STREAM_SCOPES_ENABLED) {
+            assertFailsWith<IllegalStateException> {
+                service.incomingStream()
+            }
+        } else {
             service.incomingStream()
         }
 


### PR DESCRIPTION
Some of our internal users rely on absence of `StreamScope`s
This PR adds ability to provide release with relaxed rules for stream API, but toggling one parameter