### PR TITLE
Fix call cancellation

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -121,7 +121,12 @@ public abstract interface class kotlinx/rpc/RPCServer : kotlinx/coroutines/Corou
 
 public abstract interface class kotlinx/rpc/RPCTransport : kotlinx/coroutines/CoroutineScope {
 	public abstract fun receive (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun receiveCatching-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun send (Lkotlinx/rpc/RPCTransportMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class kotlinx/rpc/RPCTransport$DefaultImpls {
+	public static fun receiveCatching-IoAF18A (Lkotlinx/rpc/RPCTransport;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class kotlinx/rpc/RPCTransportMessage {

--- a/core/src/commonMain/kotlin/kotlinx/rpc/RPCTransport.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/RPCTransport.kt
@@ -43,4 +43,13 @@ public interface RPCTransport : CoroutineScope {
      * @return received RPC message.
      */
     public suspend fun receive(): RPCTransportMessage
+
+    /**
+     * Suspends until next RPC message from a peer endpoint is received and then returns it.
+     *
+     * @return received RPC message as a [Result].
+     */
+    public suspend fun receiveCatching(): Result<RPCTransportMessage> {
+        return runCatching { receive() }
+    }
 }

--- a/core/src/commonMain/kotlin/kotlinx/rpc/internal/scopedClientCall.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/internal/scopedClientCall.kt
@@ -4,27 +4,17 @@
 
 package kotlinx.rpc.internal
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
 
 /**
- * Bounds coroutine scopes of the request and provided RPC service.
+ * Scopes client RPC call from a service with [serviceScope].
  *
  * Used by code generators.
  */
 @InternalRPCApi
-@OptIn(InternalCoroutinesApi::class)
 @Suppress("unused")
 public suspend inline fun <T> scopedClientCall(serviceScope: CoroutineScope, crossinline body: suspend () -> T): T {
-    val requestJob = currentCoroutineContext().job
-    val handle = serviceScope.coroutineContext.job.invokeOnCompletion(onCancelling = true) {
-        requestJob.cancel(it as CancellationException)
-    }
-
-    try {
-        return serviceScoped(serviceScope) {
-            body()
-        }
-    } finally {
-        handle.dispose()
+    return serviceScoped(serviceScope) {
+        body()
     }
 }

--- a/core/src/commonMain/kotlin/kotlinx/rpc/internal/transport/RPCConnector.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/internal/transport/RPCConnector.kt
@@ -97,7 +97,7 @@ public class RPCConnector<SubscriptionKey>(
     init {
         launch {
             while (true) {
-                processMessage(transport.receive())
+                processMessage(transport.receiveCatching().getOrNull() ?: break)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ ktor-websockets = { module = "io.ktor:ktor-websockets", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
@@ -64,6 +65,7 @@ kotlin-logging = { module = "io.github.oshai:kotlin-logging", version.ref = "kot
 kotlin-logging-legacy = { module = "io.github.microutils:kotlin-logging", version.ref = "kotlin-logging" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+coroutines-debug = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-debug", version.ref = "coroutines" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt-gradle-plugin" }
 kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kover" }
 

--- a/krpc/krpc-ktor/krpc-ktor-core/build.gradle.kts
+++ b/krpc/krpc-ktor/krpc-ktor-core/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
 
                 implementation(libs.kotlin.test)
                 implementation(libs.ktor.server.netty)
-                implementation(libs.ktor.client.cio)
+                implementation(libs.ktor.server.test.host)
             }
         }
     }

--- a/krpc/krpc-ktor/krpc-ktor-core/src/commonMain/kotlin/kotlinx/rpc/transport/ktor/KtorTransport.kt
+++ b/krpc/krpc-ktor/krpc-ktor-core/src/commonMain/kotlin/kotlinx/rpc/transport/ktor/KtorTransport.kt
@@ -5,29 +5,15 @@
 package kotlinx.rpc.transport.ktor
 
 import io.ktor.websocket.*
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.rpc.RPCTransport
 import kotlinx.rpc.RPCTransportMessage
 import kotlinx.rpc.internal.InternalRPCApi
-import kotlin.coroutines.CoroutineContext
 
 @InternalRPCApi
-@OptIn(InternalCoroutinesApi::class, DelicateCoroutinesApi::class)
-public class KtorTransport(private val webSocketSession: WebSocketSession): RPCTransport {
-    // Transport job should always be cancelled and never closed
-    private val transportJob = Job()
-
-    override val coroutineContext: CoroutineContext = webSocketSession.coroutineContext + transportJob
-
-    init {
-        // Close the socket when the transport job is cancelled manually
-        transportJob.invokeOnCompletion(onCancelling = true) {
-            if (!webSocketSession.coroutineContext.isActive) return@invokeOnCompletion
-            GlobalScope.launch {
-                webSocketSession.close()
-            }
-        }
-    }
+public class KtorTransport(
+    private val webSocketSession: WebSocketSession,
+) : RPCTransport, CoroutineScope by webSocketSession {
 
     /**
      * Sends a single encoded RPC message over network (or any other medium) to a peer endpoint.

--- a/krpc/krpc-ktor/krpc-ktor-core/src/jvmTest/kotlin/kotlinx/rpc/transport/ktor/KtorTransportTest.kt
+++ b/krpc/krpc-ktor/krpc-ktor-core/src/jvmTest/kotlin/kotlinx/rpc/transport/ktor/KtorTransportTest.kt
@@ -56,7 +56,7 @@ class KtorTransportTest {
         }
 
         val clientWithGlobalConfig = createClient {
-            install(kotlinx.rpc.transport.ktor.client.RPC) {
+            installRPC {
                 serialization {
                     json()
                 }

--- a/krpc/krpc-test/build.gradle.kts
+++ b/krpc/krpc-test/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                 implementation(libs.logback.classic)
 
                 implementation(libs.coroutines.test)
+                implementation(libs.coroutines.debug)
                 implementation(libs.kotlin.reflect)
             }
         }

--- a/krpc/krpc-test/src/jvmTest/kotlin/kotlinx/rpc/test/cancellation/CancellationService.kt
+++ b/krpc/krpc-test/src/jvmTest/kotlin/kotlinx/rpc/test/cancellation/CancellationService.kt
@@ -14,6 +14,8 @@ import kotlin.properties.Delegates
 import kotlin.test.assertIs
 
 interface CancellationService : RPC {
+    suspend fun longRequest()
+
     suspend fun serverDelay(millis: Long)
 
     suspend fun callException()
@@ -45,6 +47,11 @@ class CancellationServiceImpl(override val coroutineContext: CoroutineContext) :
     val firstIncomingConsumed = CompletableDeferred<Int>()
     val consumedAll = CompletableDeferred<Unit>()
     val fence = CompletableDeferred<Unit>()
+
+    override suspend fun longRequest() {
+        firstIncomingConsumed.complete(0)
+        fence.await()
+    }
 
     override suspend fun serverDelay(millis: Long) {
         delay(millis)


### PR DESCRIPTION
**Subsystem**
kRPC protocol

**Problem Description**
- Requests do not cancel on service/client cancellation
- Transport cancels abruptly in Ktor resulting in error messages in log

**Solution**
- Handle service/client cancellation case
- Return null in `RPCTransport` receive when messages ended

