### PR TITLE
KRPC-101 Check if the entire stream is not already closed.

### DIFF
--- a/core/src/commonMain/kotlin/kotlinx/rpc/internal/RPCStreamContext.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/internal/RPCStreamContext.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.selects.select
 import kotlinx.rpc.RPCConfig
 import kotlinx.rpc.StreamScope
 import kotlinx.rpc.internal.map.ConcurrentHashMap
@@ -243,7 +244,7 @@ public class RPCStreamContext(
     }
 
     public suspend fun send(message: RPCCallMessage.StreamMessage, serialFormat: SerialFormat) {
-        val info = select<RPCStreamCall?> {
+        val info: RPCStreamCall? = select {
             incomingStreams.getDeferred(message.streamId).onAwait { it }
             closedStreams.getDeferred(message.streamId).onAwait { null }
             closed.onAwait { null }


### PR DESCRIPTION
In such case, the incomingChannels get cleared and closedStreams don't contain the streamId which leads to deadlock


