### PR TITLE
Release 0.2.3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ env:
   ALGOLIA_INDEX_NAME: 'prod_kotlin_rpc'
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'
   CONFIG_JSON_PRODUCT: 'kotlinx-rpc'
-  CONFIG_JSON_VERSION: '0.2.2'
+  CONFIG_JSON_VERSION: '0.2.3'
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.2.3
+> Published 19 August 2024
+
+### Features
+* KRPC-18 Add K2 and IR code generation plugins, preserve KSP for K1 by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/105
+* Added 1.9.25 and 2.0.10 Kotlin Versions by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/168
+
+### Bug fixes
+* KRPC-101 Check if the entire stream is not already closed. by @pikinier20 in https://github.com/Kotlin/kotlinx-rpc/pull/158
+* KRPC-119 Exception Deserialization by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/170
+
+### Infra
+* Add issue templates by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/167
+
+## New Contributors
+* @pikinier20 made their first contribution in https://github.com/Kotlin/kotlinx-rpc/pull/158
+
+**Full Changelog**: https://github.com/Kotlin/kotlinx-rpc/compare/0.2.2...0.2.3
+
 # 0.2.2
 > Published 5 August 2024
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Example of plugins setup in a project's `build.gradle.kts`:
 plugins {
     kotlin("jvm") version "2.0.10"
     kotlin("plugin.serialization") version "2.0.10"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.2"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
 }
 ```
 
@@ -106,7 +106,7 @@ plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.serialization") version "1.9.25"
     id("com.google.devtools.ksp") version "1.9.25-1.0.20"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.2"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
 }
 ```
 ### Runtime dependencies
@@ -166,11 +166,11 @@ based on the project's Kotlin version:
 ```kotlin
 plugins {
     kotlin("jvm") version "2.0.10"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.2"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
 }
 
 dependencies {
-    // version 0.2.2 is set by the Gradle plugin
+    // version 0.2.3 is set by the Gradle plugin
     implementation("org.jetbrains.kotlinx:kotlinx-rpc-core") 
 }
 ```

--- a/docs/pages/kotlinx-rpc/.idea/.gitignore
+++ b/docs/pages/kotlinx-rpc/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/docs/pages/kotlinx-rpc/.idea/vcs.xml
+++ b/docs/pages/kotlinx-rpc/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>

--- a/docs/pages/kotlinx-rpc/help-versions.json
+++ b/docs/pages/kotlinx-rpc/help-versions.json
@@ -1,3 +1,3 @@
 [
-  {"version":"0.2.2","url":"/kotlinx-rpc/0.2.2/","isCurrent":true}
+  {"version":"0.2.3","url":"/kotlinx-rpc/0.2.3/","isCurrent":true}
 ]

--- a/docs/pages/kotlinx-rpc/rpc.tree
+++ b/docs/pages/kotlinx-rpc/rpc.tree
@@ -26,6 +26,7 @@
     </toc-element>
     <toc-element topic="versions.topic"/>
     <toc-element toc-title="Migration guides">
+        <toc-element topic="0-2-3.topic"/>
         <toc-element topic="0-2-1.topic"/>
     </toc-element>
 </instance-profile>

--- a/docs/pages/kotlinx-rpc/topics/0-2-3.topic
+++ b/docs/pages/kotlinx-rpc/topics/0-2-3.topic
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+        SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Migration to 0.2.3" id="0-2-3">
+
+    <p>
+        Version <code>0.2.3</code> does introduce any breaking changes.
+        However, it includes some updates that may require additional modifications in user projects.
+    </p>
+    <chapter title="Removal of KSP plugin for Kotlin 2.0" id="removal-of-ksp-plugin-for-kotlin-2-0">
+        If your project uses Kotlin 2.0,
+        you are no longer required to add KSP Gradle plugin to your build files:
+        <code-block lang="kotlin">
+            plugins {
+                kotlin("jvm") version "2.0.10"
+                kotlin("plugin.serialization") version "2.0.10"
+                id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
+
+                // KSP can be removed
+                // id("com.google.devtools.ksp") version "2.0.10-1.0.24"
+            }
+        </code-block>
+        This change brings one more benefit:
+        without KSP, projects that use <code>kotlinx.rpc</code>
+        can now use <a href="https://docs.gradle.org/current/userguide/configuration_cache.html">Gradle configuration
+        caches</a>.
+    </chapter>
+    <chapter title="Moving of client APIs" id="moving-of-client-apis">
+        Some client APIs were moved from <code>kotlinx-rpc-krpc-client</code> artifact (and package)
+        into <code>kotlinx-rpc-core</code> module (and package). These APIs are not kRPC specific hence the move.
+        <p>List of API changes:</p>
+        <table>
+            <tr>
+                <td><code>0.2.2</code></td>
+                <td><code>0.2.3</code></td>
+            </tr>
+            <tr>
+                <td><code>kotlinx.rpc.client.withService</code></td>
+                <td><code>kotlinx.rpc.withService</code></td>
+            </tr>
+            <tr>
+                <td><code>kotlinx.rpc.client.awaitFieldInitialization</code></td>
+                <td><code>kotlinx.rpc.awaitFieldInitialization</code></td>
+            </tr>
+            <tr>
+                <td><code>kotlinx.rpc.client.UninitializedRPCFieldException</code></td>
+                <td><code>kotlinx.rpc.UninitializedRPCFieldException</code></td>
+            </tr>
+        </table>
+        Old declaration and marked with <code>@Deprecated(WARNING)</code>
+        and will be removed in 2 minor releases.
+    </chapter>
+</topic>

--- a/docs/pages/kotlinx-rpc/v.list
+++ b/docs/pages/kotlinx-rpc/v.list
@@ -14,7 +14,7 @@
     <var name="host" value="https://kotlin.github.io"/>
 
     <!--  Library versions  -->
-    <var name="kotlinx-rpc-version" value="0.2.2"/>
+    <var name="kotlinx-rpc-version" value="0.2.3"/>
     <var name="kotlin-version" value="2.0.10"/>
     <var name="ksp-version" value="1.9.25-1.0.20"/>
 </vars>

--- a/docs/pages/kotlinx-rpc/writerside.cfg
+++ b/docs/pages/kotlinx-rpc/writerside.cfg
@@ -12,5 +12,5 @@
     <images dir="images" web-path="images/"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="rpc.tree" version="0.2.2" web-path="/kotlinx-rpc/"/>
+    <instance src="rpc.tree" version="0.2.3" web-path="/kotlinx-rpc/"/>
 </ihp>

--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # core library version
-kotlinx-rpc = "0.2.2"
+kotlinx-rpc = "0.2.3"
 
 # kotlin
 kotlin-lang = "2.0.10"


### PR DESCRIPTION
Release of the 0.2.3 version:
- Update to K2 (2.0.0, 2.0.10)
- Support of 1.9.25
- APIs movements

This PR:
- Migration guide
- bump version
- update CHANGELOG.md