### PR TITLE
Release 0.2.4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ env:
   ALGOLIA_INDEX_NAME: 'prod_kotlin_rpc'
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'
   CONFIG_JSON_PRODUCT: 'kotlinx-rpc'
-  CONFIG_JSON_VERSION: '0.2.2'
+  CONFIG_JSON_VERSION: '0.2.3'
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ env:
   ALGOLIA_INDEX_NAME: 'prod_kotlin_rpc'
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'
   CONFIG_JSON_PRODUCT: 'kotlinx-rpc'
-  CONFIG_JSON_VERSION: '0.2.3'
+  CONFIG_JSON_VERSION: '0.2.4'
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.2.3
+> Published 19 August 2024
+
+### Features
+* KRPC-18 Add K2 and IR code generation plugins, preserve KSP for K1 by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/105
+* Added 1.9.25 and 2.0.10 Kotlin Versions by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/168
+
+### Bug fixes
+* KRPC-101 Check if the entire stream is not already closed. by @pikinier20 in https://github.com/Kotlin/kotlinx-rpc/pull/158
+* KRPC-119 Exception Deserialization by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/170
+
+### Infra
+* Add issue templates by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/167
+
+## New Contributors
+* @pikinier20 made their first contribution in https://github.com/Kotlin/kotlinx-rpc/pull/158
+
+**Full Changelog**: https://github.com/Kotlin/kotlinx-rpc/compare/0.2.2...0.2.3
+
 # 0.2.2
 > Published 5 August 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 0.2.3
-> Published 19 August 2024
+# 0.2.4
+> Published 20 August 2024
 
 ### Features
 * KRPC-18 Add K2 and IR code generation plugins, preserve KSP for K1 by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/105
@@ -8,6 +8,7 @@
 ### Bug fixes
 * KRPC-101 Check if the entire stream is not already closed. by @pikinier20 in https://github.com/Kotlin/kotlinx-rpc/pull/158
 * KRPC-119 Exception Deserialization by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/170
+* Fix compilation on Kotlin/Native by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/172
 
 ### Infra
 * Add issue templates by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/167
@@ -15,7 +16,7 @@
 ## New Contributors
 * @pikinier20 made their first contribution in https://github.com/Kotlin/kotlinx-rpc/pull/158
 
-**Full Changelog**: https://github.com/Kotlin/kotlinx-rpc/compare/0.2.2...0.2.3
+**Full Changelog**: https://github.com/Kotlin/kotlinx-rpc/compare/0.2.2...0.2.4
 
 # 0.2.2
 > Published 5 August 2024

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Example of plugins setup in a project's `build.gradle.kts`:
 plugins {
     kotlin("jvm") version "2.0.10"
     kotlin("plugin.serialization") version "2.0.10"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.4"
 }
 ```
 
@@ -106,7 +106,7 @@ plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.serialization") version "1.9.25"
     id("com.google.devtools.ksp") version "1.9.25-1.0.20"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.4"
 }
 ```
 ### Runtime dependencies
@@ -166,11 +166,11 @@ based on the project's Kotlin version:
 ```kotlin
 plugins {
     kotlin("jvm") version "2.0.10"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.4"
 }
 
 dependencies {
-    // version 0.2.3 is set by the Gradle plugin
+    // version 0.2.4 is set by the Gradle plugin
     implementation("org.jetbrains.kotlinx:kotlinx-rpc-core") 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Example of plugins setup in a project's `build.gradle.kts`:
 plugins {
     kotlin("jvm") version "2.0.10"
     kotlin("plugin.serialization") version "2.0.10"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.2"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
 }
 ```
 
@@ -106,7 +106,7 @@ plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.serialization") version "1.9.25"
     id("com.google.devtools.ksp") version "1.9.25-1.0.20"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.2"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
 }
 ```
 ### Runtime dependencies
@@ -166,11 +166,11 @@ based on the project's Kotlin version:
 ```kotlin
 plugins {
     kotlin("jvm") version "2.0.10"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.2"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
 }
 
 dependencies {
-    // version 0.2.2 is set by the Gradle plugin
+    // version 0.2.3 is set by the Gradle plugin
     implementation("org.jetbrains.kotlinx:kotlinx-rpc-core") 
 }
 ```

--- a/docs/pages/kotlinx-rpc/.idea/.gitignore
+++ b/docs/pages/kotlinx-rpc/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/docs/pages/kotlinx-rpc/.idea/vcs.xml
+++ b/docs/pages/kotlinx-rpc/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
+  </component>
+</project>

--- a/docs/pages/kotlinx-rpc/help-versions.json
+++ b/docs/pages/kotlinx-rpc/help-versions.json
@@ -1,3 +1,3 @@
 [
-  {"version":"0.2.3","url":"/kotlinx-rpc/0.2.3/","isCurrent":true}
+  {"version":"0.2.4","url":"/kotlinx-rpc/0.2.4/","isCurrent":true}
 ]

--- a/docs/pages/kotlinx-rpc/help-versions.json
+++ b/docs/pages/kotlinx-rpc/help-versions.json
@@ -1,3 +1,3 @@
 [
-  {"version":"0.2.2","url":"/kotlinx-rpc/0.2.2/","isCurrent":true}
+  {"version":"0.2.3","url":"/kotlinx-rpc/0.2.3/","isCurrent":true}
 ]

--- a/docs/pages/kotlinx-rpc/rpc.tree
+++ b/docs/pages/kotlinx-rpc/rpc.tree
@@ -26,7 +26,7 @@
     </toc-element>
     <toc-element topic="versions.topic"/>
     <toc-element toc-title="Migration guides">
-        <toc-element topic="0-2-3.topic"/>
+        <toc-element topic="0-2-4.topic"/>
         <toc-element topic="0-2-1.topic"/>
     </toc-element>
 </instance-profile>

--- a/docs/pages/kotlinx-rpc/rpc.tree
+++ b/docs/pages/kotlinx-rpc/rpc.tree
@@ -26,6 +26,7 @@
     </toc-element>
     <toc-element topic="versions.topic"/>
     <toc-element toc-title="Migration guides">
+        <toc-element topic="0-2-3.topic"/>
         <toc-element topic="0-2-1.topic"/>
     </toc-element>
 </instance-profile>

--- a/docs/pages/kotlinx-rpc/topics/0-2-3.topic
+++ b/docs/pages/kotlinx-rpc/topics/0-2-3.topic
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic
+        SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Migration to 0.2.3" id="0-2-3">
+
+    <p>
+        Version <code>0.2.3</code> does introduce any breaking changes.
+        However, it includes some updates that may require additional modifications in user projects.
+    </p>
+    <chapter title="Removal of KSP plugin for Kotlin 2.0" id="removal-of-ksp-plugin-for-kotlin-2-0">
+        If your project uses Kotlin 2.0,
+        you are no longer required to add KSP Gradle plugin to your build files:
+        <code-block lang="kotlin">
+            plugins {
+                kotlin("jvm") version "2.0.10"
+                kotlin("plugin.serialization") version "2.0.10"
+                id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
+
+                // KSP can be removed
+                // id("com.google.devtools.ksp") version "2.0.10-1.0.24"
+            }
+        </code-block>
+        This change brings one more benefit:
+        without KSP, projects that use <code>kotlinx.rpc</code>
+        can now use <a href="https://docs.gradle.org/current/userguide/configuration_cache.html">Gradle configuration
+        caches</a>.
+    </chapter>
+    <chapter title="Moving of client APIs" id="moving-of-client-apis">
+        Some client APIs were moved from <code>kotlinx-rpc-krpc-client</code> artifact (and package)
+        into <code>kotlinx-rpc-core</code> module (and package). These APIs are not kRPC specific hence the move.
+        <p>List of API changes:</p>
+        <table>
+            <tr>
+                <td><code>0.2.2</code></td>
+                <td><code>0.2.3</code></td>
+            </tr>
+            <tr>
+                <td><code>kotlinx.rpc.client.withService</code></td>
+                <td><code>kotlinx.rpc.withService</code></td>
+            </tr>
+            <tr>
+                <td><code>kotlinx.rpc.client.awaitFieldInitialization</code></td>
+                <td><code>kotlinx.rpc.awaitFieldInitialization</code></td>
+            </tr>
+            <tr>
+                <td><code>kotlinx.rpc.client.UninitializedRPCFieldException</code></td>
+                <td><code>kotlinx.rpc.UninitializedRPCFieldException</code></td>
+            </tr>
+        </table>
+        Old declaration and marked with <code>@Deprecated(WARNING)</code>
+        and will be removed in 2 minor releases.
+    </chapter>
+</topic>

--- a/docs/pages/kotlinx-rpc/topics/0-2-4.topic
+++ b/docs/pages/kotlinx-rpc/topics/0-2-4.topic
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
 <!DOCTYPE topic
         SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
-       title="Migration to 0.2.3" id="0-2-3">
+       title="Migration to 0.2.4" id="0-2-4">
 
     <p>
-        Version <code>0.2.3</code> does introduce any breaking changes.
+        Version <code>0.2.4</code> does introduce any breaking changes.
         However, it includes some updates that may require additional modifications in user projects.
     </p>
     <chapter title="Removal of KSP plugin for Kotlin 2.0" id="removal-of-ksp-plugin-for-kotlin-2-0">
@@ -16,7 +20,7 @@
             plugins {
                 kotlin("jvm") version "2.0.10"
                 kotlin("plugin.serialization") version "2.0.10"
-                id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.3"
+                id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.4"
 
                 // KSP can be removed
                 // id("com.google.devtools.ksp") version "2.0.10-1.0.24"
@@ -34,7 +38,7 @@
         <table>
             <tr>
                 <td><code>0.2.2</code></td>
-                <td><code>0.2.3</code></td>
+                <td><code>0.2.4</code></td>
             </tr>
             <tr>
                 <td><code>kotlinx.rpc.client.withService</code></td>

--- a/docs/pages/kotlinx-rpc/v.list
+++ b/docs/pages/kotlinx-rpc/v.list
@@ -14,7 +14,7 @@
     <var name="host" value="https://kotlin.github.io"/>
 
     <!--  Library versions  -->
-    <var name="kotlinx-rpc-version" value="0.2.3"/>
+    <var name="kotlinx-rpc-version" value="0.2.4"/>
     <var name="kotlin-version" value="2.0.10"/>
     <var name="ksp-version" value="1.9.25-1.0.20"/>
 </vars>

--- a/docs/pages/kotlinx-rpc/v.list
+++ b/docs/pages/kotlinx-rpc/v.list
@@ -14,7 +14,7 @@
     <var name="host" value="https://kotlin.github.io"/>
 
     <!--  Library versions  -->
-    <var name="kotlinx-rpc-version" value="0.2.2"/>
+    <var name="kotlinx-rpc-version" value="0.2.3"/>
     <var name="kotlin-version" value="2.0.10"/>
     <var name="ksp-version" value="1.9.25-1.0.20"/>
 </vars>

--- a/docs/pages/kotlinx-rpc/writerside.cfg
+++ b/docs/pages/kotlinx-rpc/writerside.cfg
@@ -12,5 +12,5 @@
     <images dir="images" web-path="images/"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="rpc.tree" version="0.2.2" web-path="/kotlinx-rpc/"/>
+    <instance src="rpc.tree" version="0.2.3" web-path="/kotlinx-rpc/"/>
 </ihp>

--- a/docs/pages/kotlinx-rpc/writerside.cfg
+++ b/docs/pages/kotlinx-rpc/writerside.cfg
@@ -12,5 +12,5 @@
     <images dir="images" web-path="images/"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="rpc.tree" version="0.2.3" web-path="/kotlinx-rpc/"/>
+    <instance src="rpc.tree" version="0.2.4" web-path="/kotlinx-rpc/"/>
 </ihp>

--- a/samples/ktor-all-platforms-app/build.gradle.kts
+++ b/samples/ktor-all-platforms-app/build.gradle.kts
@@ -13,5 +13,5 @@ plugins {
     alias(libs.plugins.kotlinPluginSerialization) apply false
     alias(libs.plugins.kotlinx.rpc) apply false
     alias(libs.plugins.kotlinx.rpc.platform) apply false
-    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/samples/ktor-all-platforms-app/composeApp/build.gradle.kts
+++ b/samples/ktor-all-platforms-app/composeApp/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlinx.rpc.platform)
 }
 

--- a/samples/ktor-all-platforms-app/composeApp/src/commonMain/kotlin/App.kt
+++ b/samples/ktor-all-platforms-app/composeApp/src/commonMain/kotlin/App.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import io.ktor.client.*
 import io.ktor.http.*
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.serialization.json
 import kotlinx.rpc.streamScoped
 import kotlinx.rpc.transport.ktor.client.installRPC

--- a/samples/ktor-all-platforms-app/gradle/libs.versions.toml
+++ b/samples/ktor-all-platforms-app/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
-kotlin = "1.9.24"
-ksp = "1.9.24-1.0.20"
+kotlin = "2.0.10"
 
 agp = "8.2.0"
 android-compileSdk = "34"
@@ -20,7 +19,7 @@ ktor = "2.3.11"
 logback = "1.5.6"
 kotlinx-serialization-json = "1.6.3"
 kotlinx-coroutines-core = "1.8.1"
-kotlinx-rpc = "0.2.2"
+kotlinx-rpc = "0.2.4"
 
 [libraries]
 # kotlin
@@ -75,10 +74,10 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinPluginSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-rpc = { id = "org.jetbrains.kotlinx.rpc.plugin", version.ref = "kotlinx-rpc" }
 kotlinx-rpc-platform = { id = "org.jetbrains.kotlinx.rpc.platform", version.ref = "kotlinx-rpc" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/samples/ktor-all-platforms-app/server/src/test/kotlin/kotlinx/rpc/sample/ApplicationTest.kt
+++ b/samples/ktor-all-platforms-app/server/src/test/kotlin/kotlinx/rpc/sample/ApplicationTest.kt
@@ -8,7 +8,7 @@ import UserData
 import UserService
 import io.ktor.server.testing.*
 import kotlinx.coroutines.flow.toList
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.serialization.json
 import kotlinx.rpc.streamScoped
 import kotlinx.rpc.transport.ktor.client.installRPC

--- a/samples/ktor-all-platforms-app/shared/build.gradle.kts
+++ b/samples/ktor-all-platforms-app/shared/build.gradle.kts
@@ -5,7 +5,6 @@
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.rpc)
     alias(libs.plugins.kotlinPluginSerialization)
 }

--- a/samples/ktor-android-app/app/build.gradle.kts
+++ b/samples/ktor-android-app/app/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.kotlinPluginSerialization)
-    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.rpc.platform)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {

--- a/samples/ktor-android-app/app/src/main/kotlin/kotlinx/rpc/sample/ui/AppViewModel.kt
+++ b/samples/ktor-android-app/app/src/main/kotlin/kotlinx/rpc/sample/ui/AppViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.rpc.RPCClient
 import kotlinx.rpc.streamScoped
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.sample.MyService
 import kotlinx.rpc.sample.UserData
 

--- a/samples/ktor-android-app/build.gradle.kts
+++ b/samples/ktor-android-app/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.kotlinJvm) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/samples/ktor-android-app/common/build.gradle.kts
+++ b/samples/ktor-android-app/common/build.gradle.kts
@@ -5,7 +5,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinPluginSerialization)
-    alias(libs.plugins.ksp)
     alias(libs.plugins.ktor)
     alias(libs.plugins.kotlinx.rpc)
 }

--- a/samples/ktor-android-app/gradle/libs.versions.toml
+++ b/samples/ktor-android-app/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.1.3"
-kotlin = "1.9.24"
+kotlin = "2.0.10"
 androidx-activityCompose = "1.8.2"
 androidx-appcompat = "1.6.1"
 androidx-constraintlayout = "2.1.4"
@@ -14,8 +14,7 @@ ktor = "2.3.11"
 kotlinx-serialization-json = "1.6.1"
 kotlinx-coroutines-core = "1.8.1"
 logback = "1.5.6"
-kotlinx-rpc = "0.2.2"
-ksp = "1.9.24-1.0.20"
+kotlinx-rpc = "0.2.4"
 
 [libraries]
 # kotlin
@@ -77,7 +76,7 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinPluginSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-rpc = { id = "org.jetbrains.kotlinx.rpc.plugin", version.ref = "kotlinx-rpc" }
 kotlinx-rpc-platform = { id = "org.jetbrains.kotlinx.rpc.platform", version.ref = "kotlinx-rpc" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }

--- a/samples/ktor-android-app/server/build.gradle.kts
+++ b/samples/ktor-android-app/server/build.gradle.kts
@@ -5,7 +5,6 @@
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinPluginSerialization)
-    alias(libs.plugins.ksp)
     alias(libs.plugins.ktor)
     alias(libs.plugins.kotlinx.rpc.platform)
 

--- a/samples/ktor-android-app/server/src/test/kotlin/ApplicationTest.kt
+++ b/samples/ktor-android-app/server/src/test/kotlin/ApplicationTest.kt
@@ -10,7 +10,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.flow.toList
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.sample.MyService
 import kotlinx.rpc.sample.UserData
 import kotlinx.rpc.serialization.json

--- a/samples/ktor-web-app/common/build.gradle.kts
+++ b/samples/ktor-web-app/common/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.plugin.serialization)
     alias(libs.plugins.kotlinx.rpc)
-    alias(libs.plugins.ksp)
 }
 
 kotlin {

--- a/samples/ktor-web-app/frontend/src/jsMain/kotlin/App.kt
+++ b/samples/ktor-web-app/frontend/src/jsMain/kotlin/App.kt
@@ -4,7 +4,7 @@
 
 import kotlinx.coroutines.flow.flow
 import kotlinx.rpc.RPCClient
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.streamScoped
 import react.FC
 import react.Props

--- a/samples/ktor-web-app/gradle/libs.versions.toml
+++ b/samples/ktor-web-app/gradle/libs.versions.toml
@@ -1,12 +1,11 @@
 [versions]
-kotlin = "1.9.24"
+kotlin = "2.0.10"
 kotlin-wrappers-bom = "1.0.0-pre.747"
 ktor = "2.3.11"
 kotlinx-serialization-json = "1.6.1"
 kotlinx-coroutines-core = "1.8.1"
 logback = "1.5.6"
-kotlinx-rpc = "0.2.2"
-ksp = "1.9.24-1.0.20"
+kotlinx-rpc = "0.2.4"
 
 [libraries]
 # kotlin
@@ -55,4 +54,3 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-rpc = { id = "org.jetbrains.kotlinx.rpc.plugin", version.ref = "kotlinx-rpc" }
 kotlinx-rpc-platform = { id = "org.jetbrains.kotlinx.rpc.platform", version.ref = "kotlinx-rpc" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/samples/ktor-web-app/server/src/test/kotlin/ApplicationTest.kt
+++ b/samples/ktor-web-app/server/src/test/kotlin/ApplicationTest.kt
@@ -4,7 +4,7 @@
 
 import io.ktor.server.testing.*
 import kotlinx.coroutines.flow.toList
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.serialization.json
 import kotlinx.rpc.streamScoped
 import kotlinx.rpc.transport.ktor.client.installRPC

--- a/samples/simple-ktor-app/build.gradle.kts
+++ b/samples/simple-ktor-app/build.gradle.kts
@@ -3,11 +3,10 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.9.24"
-    kotlin("plugin.serialization") version "1.9.24"
+    kotlin("jvm") version "2.0.10"
+    kotlin("plugin.serialization") version "2.0.10"
     id("io.ktor.plugin") version "2.3.11"
-    id("com.google.devtools.ksp") version "1.9.24-1.0.20"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.2"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.2.4"
 }
 
 val kotlin_version: String by project

--- a/samples/simple-ktor-app/src/main/kotlin/Client.kt
+++ b/samples/simple-ktor-app/src/main/kotlin/Client.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.serialization.json
 import kotlinx.rpc.streamScoped
 import kotlinx.rpc.transport.ktor.client.rpc

--- a/samples/simple-ktor-app/src/test/kotlin/ApplicationTest.kt
+++ b/samples/simple-ktor-app/src/test/kotlin/ApplicationTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.rpc.client.awaitFieldInitialization
-import kotlinx.rpc.client.withService
+import kotlinx.rpc.withService
 import kotlinx.rpc.serialization.json
 import kotlinx.rpc.transport.ktor.client.installRPC
 import kotlinx.rpc.transport.ktor.client.rpc

--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # core library version
-kotlinx-rpc = "0.2.3"
+kotlinx-rpc = "0.2.4"
 
 # kotlin
 kotlin-lang = "2.0.10"

--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # core library version
-kotlinx-rpc = "0.2.2"
+kotlinx-rpc = "0.2.3"
 
 # kotlin
 kotlin-lang = "2.0.10"


### PR DESCRIPTION
Release of the 0.2.4 version:
- Update to K2 (2.0.0, 2.0.10)
- Support of 1.9.25
- APIs movements

This PR:
- Migration guide
- bump version
- update CHANGELOG.md

