### PR TITLE
Fix compilation on Kotlin/Native

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/core/kotlinx/rpc/codegen/extension/RPCStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/core/kotlinx/rpc/codegen/extension/RPCStubGenerator.kt
@@ -696,7 +696,7 @@ internal class RPCStubGenerator(
             emptyList()
         }
 
-        methodClass.superTypes = listOf(ctx.rpcMethodClassArguments.defaultType)
+        methodClass.superTypes += ctx.rpcMethodClassArguments.defaultType
 
         methodClass.addFunction {
             name = ctx.functions.asArray.name


### PR DESCRIPTION
**Subsystem**
Compiler plugin

**Problem Description**
Compilation on Kotlin/Native targets produces wrong IR, leading to 
```
kotlinx.serialization.SerializationException: Serializer for class 'rpcMethod' is not found.
Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
To get enum serializer on Kotlin/Native, it should be annotated with @Serializable annotation.
To get interface serializer on Kotlin/Native, use PolymorphicSerializer() constructor function.
```

**Solution**
Remove supertype overriding for `rpcMethod` classes, fixing the issue

