### PR TITLE
Fix regression of nested declarations in RPC interfaces

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/core/kotlinx/rpc/codegen/extension/RPCIrServiceProcessor.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/core/kotlinx/rpc/codegen/extension/RPCIrServiceProcessor.kt
@@ -25,7 +25,7 @@ internal class RPCIrServiceProcessor(
     }
 
     private fun processService(service: IrClass, context: RPCIrContext) {
-        val declaration = RPCDeclarationScanner.scanServiceDeclaration(service, context)
+        val declaration = RPCDeclarationScanner.scanServiceDeclaration(service, context, logger)
         RPCStubGenerator(declaration, context, logger).generate()
     }
 }


### PR DESCRIPTION
**Subsystem**
Compiler plugin

**Problem Description**
We introduced regression in patch release `0.2.4` that breaks compilation in case of nested declarations in RPC interfaces

**Solution**
Switch the error to a warning

