### PR TITLE
Remove unused and inactive annotation

### DIFF
--- a/samples/ktor-all-platforms-app/composeApp/src/commonMain/kotlin/App.kt
+++ b/samples/ktor-all-platforms-app/composeApp/src/commonMain/kotlin/App.kt
@@ -22,7 +22,6 @@ import kotlinx.rpc.transport.ktor.client.rpc
 import kotlinx.rpc.transport.ktor.client.rpcConfig
 import ktor_all_platforms_app.composeapp.generated.resources.Res
 import ktor_all_platforms_app.composeapp.generated.resources.compose_multiplatform
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 
 expect val DEV_SERVER_HOST: String
@@ -33,7 +32,6 @@ val client by lazy {
     }
 }
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 fun App() {
     var serviceOrNull: UserService? by remember { mutableStateOf(null) }
@@ -61,7 +59,10 @@ fun App() {
         val news = remember { mutableStateListOf<String>() }
 
         LaunchedEffect(service) {
-            greeting = service.hello("User from ${getPlatform().name} platform", UserData("Berlin", "Smith"))
+            greeting = service.hello(
+                "User from ${getPlatform().name} platform",
+                UserData("Berlin", "Smith")
+            )
         }
 
         LaunchedEffect(service) {
@@ -91,7 +92,10 @@ fun App() {
                 }
 
                 AnimatedVisibility(showIcon) {
-                    Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                    Column(
+                        Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
                         Image(painterResource(Res.drawable.compose_multiplatform), null)
                     }
                 }


### PR DESCRIPTION
**Subsystem**
sample module

**Problem Description**
This PR addresses the removal of unused and inactive annotations in the sample module, specifically `@ExperimentalResourceApi`. The related import import `org.jetbrains.compose.resources.ExperimentalResourceApi` was also removed because it was no longer needed. This cleanup helps maintain code quality by removing unnecessary experimental annotations that are not being used in the current implementation.

**Solution**
Removed the `@ExperimentalResourceApi` annotation and its corresponding import `(import org.jetbrains.compose.resources.ExperimentalResourceApi)` from the sample module where it was inactive and not in use.



