### PR TITLE
Experimental support for: KRPC-125 Manual stream scope management

### DIFF
--- a/krpc/krpc-core/api/krpc-core.api
+++ b/krpc/krpc-core/api/krpc-core.api
@@ -77,9 +77,15 @@ public final class kotlinx/rpc/krpc/RPCTransportMessage$StringMessage : kotlinx/
 	public final fun getValue ()Ljava/lang/String;
 }
 
+public final class kotlinx/rpc/krpc/StreamScope : kotlinx/rpc/internal/utils/AutoCloseable {
+	public fun close ()V
+}
+
 public final class kotlinx/rpc/krpc/StreamScopeKt {
+	public static final fun StreamScope (Lkotlin/coroutines/CoroutineContext;)Lkotlinx/rpc/krpc/StreamScope;
 	public static final fun invokeOnStreamScopeCompletion (ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun invokeOnStreamScopeCompletion$default (ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun streamScoped (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withStreamScope (Lkotlinx/rpc/krpc/StreamScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 


### PR DESCRIPTION
**Subsystem**
kRPC

**Problem Description**
`streamScoped` function is not always usable, due to its strict lifetime limits

**Solution**
Provide `StreamScope` resource that is manageable via manual `close` calls.
