### PR TITLE
Fix for KT-41082

### DIFF
--- a/core/src/commonMain/kotlin/kotlinx/rpc/annotations/Rpc.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/annotations/Rpc.kt
@@ -39,5 +39,5 @@ import kotlinx.rpc.RemoteService
  * @see [RemoteService]
  */
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
+//@Retention(AnnotationRetention.RUNTIME) // Runtime is the default retention, also see KT-41082
 public annotation class Rpc


### PR DESCRIPTION
**Subsystem**
Core

**Problem Description**
Annoying warning for `@Rpc` in Kotlin/JS

**Solution**
Fix as in `kotlinx.serialization`

