### PR TITLE
Added test for non-serializable params

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,10 +15,10 @@ jobs:
   check-labels:
     name: Check labels
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'release') && !contains(github.event.pull_request.labels.*.name, 'feature') && !contains(github.event.pull_request.labels.*.name, 'bug') && !contains(github.event.pull_request.labels.*.name, 'breaking') && !contains(github.event.pull_request.labels.*.name, 'infra') && !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'deprecation') && !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    if: ${{ github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'release') && !contains(github.event.pull_request.labels.*.name, 'feature') && !contains(github.event.pull_request.labels.*.name, 'bug') && !contains(github.event.pull_request.labels.*.name, 'breaking') && !contains(github.event.pull_request.labels.*.name, 'infra') && !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'deprecation') && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'housekeeping') }}
     steps:
       - name: Fail build after no labels present
         run: |
           echo "Pull request does not contain any required labels"
-          echo "Please use at least one of 'feature', 'bug', 'breaking', 'infra', 'docs', 'deprecation', 'release' or 'dependencies' labels"
+          echo "Please use at least one of 'feature', 'bug', 'breaking', 'infra', 'docs', 'deprecation', 'release', 'housekeeping' or 'dependencies' labels"
           exit 1

--- a/krpc/krpc-test/src/jvmMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
+++ b/krpc/krpc-test/src/jvmMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
@@ -9,6 +9,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.rpc.RemoteService
 import kotlinx.rpc.annotations.Rpc
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Suppress("detekt.TooManyFunctions")
 @Rpc
@@ -27,6 +31,11 @@ interface KrpcTestService : RemoteService {
     suspend fun customType(arg1: TestClass): TestClass
     suspend fun nullable(arg1: String?): TestClass?
     suspend fun variance(arg2: TestList<in TestClass>, arg3: TestList2<*>): TestList<out TestClass>?
+
+    suspend fun nonSerializableClass(localDate: @Contextual LocalDate): LocalDate
+    suspend fun nonSerializableClassWithSerializer(
+        localDateTime: @Serializable(LocalDateTimeSerializer::class) LocalDateTime,
+    ): @Serializable(LocalDateTimeSerializer::class) LocalDateTime
 
     suspend fun incomingStreamSyncCollect(arg1: Flow<String>): Int
     suspend fun incomingStreamAsyncCollect(arg1: Flow<String>): Int

--- a/krpc/krpc-test/src/jvmMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
+++ b/krpc/krpc-test/src/jvmMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
@@ -7,6 +7,9 @@ package kotlinx.rpc.krpc.test
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.Serializable
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resumeWithException
 import kotlin.test.assertEquals
@@ -77,6 +80,14 @@ class KrpcTestServiceBackend(override val coroutineContext: CoroutineContext) : 
     ): TestList<out TestClass> {
         println("variance: $arg2 $arg3")
         return TestList(3)
+    }
+
+    override suspend fun nonSerializableClass(localDate: LocalDate): LocalDate {
+        return localDate.plusDays(1)
+    }
+
+    override suspend fun nonSerializableClassWithSerializer(localDateTime: LocalDateTime): String {
+        return localDateTime.plusDays(1).format(DateTimeFormatter.ISO_DATE_TIME)
     }
 
     override suspend fun incomingStreamSyncCollect(arg1: Flow<String>): Int {

--- a/krpc/krpc-test/src/jvmTest/kotlin/kotlinx/rpc/krpc/test/LocalTransportTest.kt
+++ b/krpc/krpc-test/src/jvmTest/kotlin/kotlinx/rpc/krpc/test/LocalTransportTest.kt
@@ -23,14 +23,18 @@ abstract class LocalTransportTest : KrpcTransportTestBase() {
 
 class JsonLocalTransportTest : LocalTransportTest() {
     override val serializationConfig: KrpcSerialFormatConfiguration.() -> Unit = {
-        json()
+        json {
+            serializersModule = this@JsonLocalTransportTest.serializersModule
+        }
     }
 }
 
 class CborLocalTransportTest : LocalTransportTest() {
     @OptIn(ExperimentalSerializationApi::class)
     override val serializationConfig: KrpcSerialFormatConfiguration.() -> Unit = {
-        cbor()
+        cbor {
+            serializersModule = this@CborLocalTransportTest.serializersModule
+        }
     }
 }
 
@@ -38,7 +42,9 @@ class CborLocalTransportTest : LocalTransportTest() {
 class ProtoBufLocalTransportTest : LocalTransportTest() {
     @OptIn(ExperimentalSerializationApi::class)
     override val serializationConfig: KrpcSerialFormatConfiguration.() -> Unit = {
-        protobuf()
+        protobuf {
+            serializersModule = this@ProtoBufLocalTransportTest.serializersModule
+        }
     }
 
     // 'null' is not supported in ProtoBuf


### PR DESCRIPTION
**Subsystem**
Core

**Problem Description**
No problem

**Solution**
Add a test for a `@Contextual` use-case, #89

