### PR TITLE
Added missing aliases for migration

### DIFF
--- a/core/src/commonMain/kotlin/kotlinx/rpc/RpcCall.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/RpcCall.kt
@@ -1,10 +1,13 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc
 
 import kotlinx.rpc.descriptor.RpcServiceDescriptor
+
+@Deprecated("Use RpcCall instead", ReplaceWith("RpcCall"), level = DeprecationLevel.ERROR)
+public typealias RPCCall = RpcCall
 
 /**
  * Represents a method or field call of an RPC service.

--- a/core/src/commonMain/kotlin/kotlinx/rpc/RpcClient.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/RpcClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc
@@ -7,6 +7,9 @@ package kotlinx.rpc
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlin.coroutines.CoroutineContext
+
+@Deprecated("Use RpcClient instead", ReplaceWith("RpcClient"), level = DeprecationLevel.ERROR)
+public typealias RPCClient = RpcClient
 
 /**
  * [RpcClient] represents an abstraction of an RPC client, that can handle requests from several RPC services,


### PR DESCRIPTION
**Subsystem**
Core

**Problem Description**
When removing APIs, forgot to make deprecated typealiases

