### PR TITLE
Fixed @Rpc annotation diagnostic

### DIFF
--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/FirRpcPredicates.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/FirRpcPredicates.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc.codegen
@@ -10,6 +10,10 @@ import org.jetbrains.kotlin.fir.extensions.predicate.DeclarationPredicate
 object FirRpcPredicates {
     internal val rpc = DeclarationPredicate.create {
         annotated(RpcClassId.rpcAnnotation.asSingleFqName()) // @Rpc
+    }
+
+    internal val rpcMeta = DeclarationPredicate.create {
+        metaAnnotated(RpcClassId.rpcAnnotation.asSingleFqName(), includeItself = true)
     }
 
     internal val checkedAnnotationMeta = DeclarationPredicate.create {

--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc.codegen.checkers.diagnostics
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.KtAnnotationEntry
 object FirRpcDiagnostics {
     val MISSING_RPC_ANNOTATION by error0<KtAnnotationEntry>()
     val MISSING_SERIALIZATION_MODULE by warning0<KtAnnotationEntry>()
-    val WRONG_RPC_ANNOTATION_TARGET by error0<KtAnnotationEntry>()
+    val WRONG_RPC_ANNOTATION_TARGET by error1<KtAnnotationEntry, ConeKotlinType>()
     val CHECKED_ANNOTATION_VIOLATION by error1<KtAnnotationEntry, ConeKotlinType>()
     val NON_SUSPENDING_REQUEST_WITHOUT_STREAMING_RETURN_TYPE by error0<PsiElement>()
     val AD_HOC_POLYMORPHISM_IN_RPC_SERVICE by error2<PsiElement, Int, Name>()

--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc.codegen.checkers.diagnostics
@@ -29,7 +29,8 @@ object RpcDiagnosticRendererFactory : BaseDiagnosticRendererFactory() {
 
         put(
             factory = FirRpcDiagnostics.WRONG_RPC_ANNOTATION_TARGET,
-            message = "@Rpc annotation is only applicable to interfaces.",
+            message = "@{0} annotation is only applicable to interfaces and annotation classes.",
+            rendererA = FirDiagnosticRenderers.RENDER_TYPE,
         )
 
         put(

--- a/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
+++ b/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
 import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -20,7 +21,7 @@ import java.util.regex.Pattern;
 @SuppressWarnings("all")
 @TestMetadata("src/testData/box")
 @TestDataPath("$PROJECT_ROOT")
-@Ignore
+@Disabled("KRPC-137")
 public class BoxTestGenerated extends AbstractBoxTest {
   @Test
   public void testAllFilesPresentInBox() {

--- a/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/DiagnosticTestGenerated.java
+++ b/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/DiagnosticTestGenerated.java
@@ -9,9 +9,8 @@ package kotlinx.rpc.codegen.test.runners;
 import com.intellij.testFramework.TestDataPath;
 import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TestMetadata;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
 import java.io.File;
 import java.util.regex.Pattern;
 
@@ -19,7 +18,7 @@ import java.util.regex.Pattern;
 @SuppressWarnings("all")
 @TestMetadata("src/testData/diagnostics")
 @TestDataPath("$PROJECT_ROOT")
-@Ignore
+@Disabled("KRPC-137")
 public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
   @Test
   public void testAllFilesPresentInDiagnostics() {

--- a/tests/compiler-plugin-tests/src/testData/diagnostics/rpcChecked.kt
+++ b/tests/compiler-plugin-tests/src/testData/diagnostics/rpcChecked.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 @file:OptIn(ExperimentalRpcApi::class)
@@ -61,3 +61,15 @@ inline suspend fun <reified T : Any> fail(client: RpcClient, server: RpcServer, 
     serviceDescriptorOf<<!CHECKED_ANNOTATION_VIOLATION!>NotAService<!>>()
     serviceDescriptorOf<<!CHECKED_ANNOTATION_VIOLATION!>T<!>>()
 }
+
+@Rpc
+annotation class Grpc
+
+@Grpc
+interface MyGrpcService
+
+@Grpc
+class WrongGrpcTarget
+
+@Rpc
+class WrongRpcTarget


### PR DESCRIPTION
**Subsystem**
Compiler Plugin

**Problem Description**
Checked Type Annotation support transitive annotations, but diagnostic failed for `@Rpc` annottaion.

**Solution**
Fix that diagnostic
