### PR TITLE
KRPC-162 Internal vs Public Codegen separation in gRPC

### DIFF
--- a/protobuf-plugin/src/main/kotlin/kotlinx/rpc/protobuf/CodeGenerator.kt
+++ b/protobuf-plugin/src/main/kotlin/kotlinx/rpc/protobuf/CodeGenerator.kt
@@ -255,13 +255,14 @@ class FileGenerator(
     codeGenerationParameters: CodeGenerationParameters,
     var filename: String? = null,
     var packageName: String? = null,
+    var packagePath: String? = packageName,
     var fileOptIns: List<String> = emptyList(),
     logger: Logger = NOPLogger.NOP_LOGGER,
 ) : CodeGenerator(codeGenerationParameters, "", logger = logger) {
     private val imports = mutableListOf<String>()
 
     fun importPackage(name: String) {
-        if (name != packageName) {
+        if (name != packageName && name.isNotEmpty()) {
             imports.add("$name.*")
         }
     }
@@ -304,4 +305,5 @@ fun file(
     packageName: String? = null,
     logger: Logger = NOPLogger.NOP_LOGGER,
     block: FileGenerator.() -> Unit,
-): FileGenerator = FileGenerator(codeGenerationParameters, name, packageName, emptyList(), logger).apply(block)
+): FileGenerator = FileGenerator(codeGenerationParameters, name, packageName, packageName, emptyList(), logger)
+    .apply(block)

--- a/protobuf-plugin/src/main/kotlin/kotlinx/rpc/protobuf/CodeGenerator.kt
+++ b/protobuf-plugin/src/main/kotlin/kotlinx/rpc/protobuf/CodeGenerator.kt
@@ -262,7 +262,7 @@ class FileGenerator(
     private val imports = mutableListOf<String>()
 
     fun importPackage(name: String) {
-        if (name != packageName && name.isNotEmpty()) {
+        if (name != packageName && name.isNotBlank()) {
             imports.add("$name.*")
         }
     }

--- a/protobuf-plugin/src/main/kotlin/kotlinx/rpc/protobuf/RpcProtobufPlugin.kt
+++ b/protobuf-plugin/src/main/kotlin/kotlinx/rpc/protobuf/RpcProtobufPlugin.kt
@@ -14,6 +14,7 @@ import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.Feature
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.helpers.NOPLogger
+import java.io.File
 
 class RpcProtobufPlugin {
     companion object {
@@ -68,7 +69,9 @@ class RpcProtobufPlugin {
             .map { file ->
                 CodeGeneratorResponse.File.newBuilder()
                     .apply {
-                        val dir = file.packageName?.replace('.', '/')?.plus("/") ?: ""
+                        val dir = file.packagePath
+                            ?.replace('.', File.separatorChar)?.plus(File.separatorChar)
+                            ?: ""
 
                         // some filename already contain package (true for Google's default .proto files)
                         val filename = file.filename?.removePrefix(dir) ?: error("File name can not be null")


### PR DESCRIPTION
**Subsystem**
gRPC Protobuf plugin

**Problem Description**
Internal and public generated entities were placed into a single file, which complicates the comprehension of the content

**Solution**
Separate them into two files, placing internal declarations into the `_rpc_internal` subdirectory (but package is the same)

