### PR TITLE
Fix build config for for-ide builds

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-backend/build.gradle.kts
@@ -1,8 +1,10 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import util.otherwise
+import util.whenForIde
 
 plugins {
     alias(libs.plugins.conventions.jvm)
@@ -18,6 +20,11 @@ kotlin {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.compiler.embeddable)
+    whenForIde {
+        compileOnly(libs.kotlin.compiler)
+    } otherwise {
+        compileOnly(libs.kotlin.compiler.embeddable)
+    }
+
     implementation(projects.compilerPluginCommon)
 }

--- a/compiler-plugin/compiler-plugin-cli/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-cli/build.gradle.kts
@@ -1,8 +1,10 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import util.otherwise
+import util.whenForIde
 
 plugins {
     alias(libs.plugins.conventions.jvm)
@@ -14,7 +16,12 @@ kotlin {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.compiler.embeddable)
+    whenForIde {
+        compileOnly(libs.kotlin.compiler)
+    } otherwise {
+        compileOnly(libs.kotlin.compiler.embeddable)
+    }
+
     implementation(projects.compilerPluginK2)
     implementation(projects.compilerPluginCommon)
     implementation(projects.compilerPluginBackend)

--- a/compiler-plugin/compiler-plugin-common/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-common/build.gradle.kts
@@ -1,8 +1,10 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import util.otherwise
+import util.whenForIde
 
 plugins {
     alias(libs.plugins.conventions.jvm)
@@ -14,5 +16,9 @@ kotlin {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.compiler.embeddable)
+    whenForIde {
+        compileOnly(libs.kotlin.compiler)
+    } otherwise {
+        compileOnly(libs.kotlin.compiler.embeddable)
+    }
 }

--- a/compiler-plugin/compiler-plugin-k2/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-k2/build.gradle.kts
@@ -72,13 +72,13 @@ kotlin {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.reflect)
-    compileOnly(libs.kotlin.compiler.embeddable)
     whenForIde {
+        compileOnly(libs.kotlin.compiler)
         compileOnly(libs.serialization.plugin.forIde) {
             isTransitive = false
         }
     } otherwise {
+        compileOnly(libs.kotlin.compiler.embeddable)
         compileOnly(libs.serialization.plugin)
     }
     implementation(projects.compilerPluginCommon)

--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/FirRpcServiceGenerator.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/FirRpcServiceGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc.codegen
@@ -11,6 +11,7 @@ import kotlinx.rpc.codegen.common.rpcMethodName
 import kotlinx.rpc.codegen.serialization.addAnnotation
 import kotlinx.rpc.codegen.serialization.generateCompanionDeclaration
 import kotlinx.rpc.codegen.serialization.generateSerializerImplClass
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality

--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/FirVersionSpecificApi.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/FirVersionSpecificApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc.codegen
@@ -25,13 +25,6 @@ interface FirVersionSpecificApi {
     var FirResolvedTypeRefBuilder.coneTypeVS: ConeKotlinType
 }
 
-val vsApiClass by lazy {
-    runCatching {
-        Class.forName("kotlinx.rpc.codegen.FirVersionSpecificApiImpl")
-    }.getOrNull()
-}
-
 inline fun <T> vsApi(body: FirVersionSpecificApi.() -> T): T {
-    val kClass = vsApiClass?.kotlin ?: error("FirVersionSpecificApi is not present")
-    return (kClass.objectInstance as FirVersionSpecificApi).body()
+    return FirVersionSpecificApiImpl.body()
 }

--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
@@ -2,10 +2,11 @@
  * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+@file:Suppress("StructuralWrap")
+
 package kotlinx.rpc.codegen.checkers.diagnostics
 
 import kotlinx.rpc.codegen.StrictModeAggregator
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
 import org.jetbrains.kotlin.diagnostics.error0
 import org.jetbrains.kotlin.diagnostics.error1
@@ -14,16 +15,23 @@ import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtElement
+
+// ###########################################################################
+// ###                     BIG WARNING, LISTEN CLOSELY!                    ###
+// # Do NOT use `PsiElement` for `error0` or any other function              #
+// # Instead use KtElement, otherwise problems in IDE and in tests may arise #
+// ###########################################################################
 
 object FirRpcDiagnostics {
     val MISSING_RPC_ANNOTATION by error0<KtAnnotated>()
     val MISSING_SERIALIZATION_MODULE by error0<KtAnnotated>()
     val WRONG_RPC_ANNOTATION_TARGET by error1<KtAnnotated, ConeKotlinType>()
     val CHECKED_ANNOTATION_VIOLATION by error1<KtAnnotated, ConeKotlinType>()
-    val NON_SUSPENDING_REQUEST_WITHOUT_STREAMING_RETURN_TYPE by error0<PsiElement>()
-    val AD_HOC_POLYMORPHISM_IN_RPC_SERVICE by error2<PsiElement, Int, Name>()
-    val TYPE_PARAMETERS_IN_RPC_FUNCTION by error0<PsiElement>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
-    val TYPE_PARAMETERS_IN_RPC_INTERFACE by error0<PsiElement>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
+    val NON_SUSPENDING_REQUEST_WITHOUT_STREAMING_RETURN_TYPE by error0<KtElement>()
+    val AD_HOC_POLYMORPHISM_IN_RPC_SERVICE by error2<KtElement, Int, Name>()
+    val TYPE_PARAMETERS_IN_RPC_FUNCTION by error0<KtElement>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
+    val TYPE_PARAMETERS_IN_RPC_INTERFACE by error0<KtElement>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
 
     init {
         RootDiagnosticRendererFactory.registerFactory(RpcDiagnosticRendererFactory)
@@ -32,13 +40,13 @@ object FirRpcDiagnostics {
 
 @Suppress("PropertyName", "detekt.VariableNaming")
 class FirRpcStrictModeDiagnostics(val modes: StrictModeAggregator) {
-    val STATE_FLOW_IN_RPC_SERVICE by modded0<PsiElement>(modes.stateFlow)
-    val SHARED_FLOW_IN_RPC_SERVICE by modded0<PsiElement>(modes.sharedFlow)
-    val NESTED_STREAMING_IN_RPC_SERVICE by modded0<PsiElement>(modes.nestedFlow)
-    val STREAM_SCOPE_FUNCTION_IN_RPC by modded0<PsiElement>(modes.streamScopedFunctions)
-    val SUSPENDING_SERVER_STREAMING_IN_RPC_SERVICE by modded0<PsiElement>(modes.suspendingServerStreaming)
-    val NON_TOP_LEVEL_SERVER_STREAMING_IN_RPC_SERVICE by modded0<PsiElement>(modes.notTopLevelServerFlow)
-    val FIELD_IN_RPC_SERVICE by modded0<PsiElement>(modes.fields)
+    val STATE_FLOW_IN_RPC_SERVICE by modded0<KtElement>(modes.stateFlow)
+    val SHARED_FLOW_IN_RPC_SERVICE by modded0<KtElement>(modes.sharedFlow)
+    val NESTED_STREAMING_IN_RPC_SERVICE by modded0<KtElement>(modes.nestedFlow)
+    val STREAM_SCOPE_FUNCTION_IN_RPC by modded0<KtElement>(modes.streamScopedFunctions)
+    val SUSPENDING_SERVER_STREAMING_IN_RPC_SERVICE by modded0<KtElement>(modes.suspendingServerStreaming)
+    val NON_TOP_LEVEL_SERVER_STREAMING_IN_RPC_SERVICE by modded0<KtElement>(modes.notTopLevelServerFlow)
+    val FIELD_IN_RPC_SERVICE by modded0<KtElement>(modes.fields)
 
     init {
         RootDiagnosticRendererFactory.registerFactory(RpcStrictModeDiagnosticRendererFactory(this))

--- a/gradle-conventions-settings/build.gradle.kts
+++ b/gradle-conventions-settings/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 plugins {
@@ -8,7 +8,6 @@ plugins {
 
 configurations.configureEach {
     resolutionStrategy {
-        force(libs.kotlin.reflect)
         force(libs.kotlin.stdlib)
         force(libs.kotlin.stdlib.jdk7)
         force(libs.kotlin.stdlib.jdk8)

--- a/gradle-conventions-settings/develocity/build.gradle.kts
+++ b/gradle-conventions-settings/develocity/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 plugins {
@@ -8,7 +8,6 @@ plugins {
 
 configurations.configureEach {
     resolutionStrategy {
-        force(libs.kotlin.reflect)
         force(libs.kotlin.stdlib)
         force(libs.kotlin.stdlib.jdk7)
         force(libs.kotlin.stdlib.jdk8)

--- a/gradle-conventions-settings/settings.gradle.kts
+++ b/gradle-conventions-settings/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 rootProject.name = "gradle-conventions-settings"
@@ -7,7 +7,5 @@ rootProject.name = "gradle-conventions-settings"
 // Code below is a hack because a chicken-egg problem, I can't use myself as a settings-plugin
 apply(from = "src/main/kotlin/conventions-repositories.settings.gradle.kts")
 apply(from = "src/main/kotlin/conventions-version-resolution.settings.gradle.kts")
-
-val kotlinVersion: KotlinVersion by extra
 
 include(":develocity")

--- a/gradle-conventions-settings/src/main/kotlin/util/conventionsDefaults.kt
+++ b/gradle-conventions-settings/src/main/kotlin/util/conventionsDefaults.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package util
@@ -9,7 +9,6 @@ import org.gradle.api.Project
 fun Project.defaultConventionConfiguration() {
     configurations.configureEach {
         resolutionStrategy {
-            force(libs.kotlin.reflect)
             force(libs.kotlin.stdlib)
             force(libs.kotlin.stdlib.jdk7)
             force(libs.kotlin.stdlib.jdk8)

--- a/gradle-conventions/src/main/kotlin/compiler-specific-module.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/compiler-specific-module.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
@@ -8,7 +8,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.text.lowercase
 
-val kotlinVersion: KotlinVersion by extra
+val kotlinCompilerVersion: KotlinVersion by extra
 val preserveDefaultSourceDirectories by optionalProperty()
 
 fun NamedDomainObjectContainer<KotlinSourceSet>.applyCompilerSpecificSourceSets() {
@@ -31,11 +31,11 @@ fun NamedDomainObjectContainer<KotlinSourceSet>.applyCompilerSpecificSourceSets(
         val vsSets = filterSourceDirsForCSM(sourceSetPath)
 
         // choose 'latest' if there are no more specific ones
-        val mostSpecificApplicable = vsSets.mostSpecificVersionOrLatest(kotlinVersion)
+        val mostSpecificApplicable = vsSets.mostSpecificVersionOrLatest(kotlinCompilerVersion)
 
         logger.lifecycle(
             "${project.name}: included version specific source sets: " +
-                    "[${core.name}${mostSpecificApplicable?.let { ", $name" } ?: ""}]"
+                    "[${core.name}${mostSpecificApplicable?.let { ", ${it.name}" } ?: ""}]"
         )
 
         val newSourceDirectories = listOfNotNull(core, mostSpecificApplicable)
@@ -70,7 +70,7 @@ fun KotlinSourceSet.configureResources(sourceSetPath: Path) {
     }
 
     val mostSpecificApplicable = filterSourceDirsForCSM(resourcesDir)
-        .mostSpecificVersionOrLatest(kotlinVersion)
+        .mostSpecificVersionOrLatest(kotlinCompilerVersion)
 
     val versionNames = listOfNotNull(Dir.CORE_SOURCE_DIR, mostSpecificApplicable?.name)
 

--- a/tests/compiler-plugin-tests/build.gradle.kts
+++ b/tests/compiler-plugin-tests/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
@@ -80,10 +80,10 @@ dependencies {
         testImplementation(libs.serialization.plugin)
     }
 
-    testImplementation(libs.compiler.plugin.cli) {
-        exclude(group = "org.jetbrains.kotlinx", module = "compiler-plugin-k2")
-    }
-    testImplementation(files("$globalRootDir/compiler-plugin/compiler-plugin-k2/build/libs/plugin-k2-for-tests.jar"))
+    testImplementation(libs.compiler.plugin.common)
+    testImplementation(libs.compiler.plugin.backend)
+    testImplementation(libs.compiler.plugin.k2)
+    testImplementation(libs.compiler.plugin.cli)
 
     testImplementation(libs.kotlin.reflect)
     testImplementation(libs.kotlin.compiler)
@@ -136,7 +136,7 @@ tasks.withType<KotlinCompile>().configureEach {
     }
 }
 
-val generateTests by tasks.creating(JavaExec::class) {
+val generateTests = tasks.register<JavaExec>("generateTests") {
     classpath = sourceSets.test.get().runtimeClasspath
     mainClass.set("kotlinx.rpc.codegen.test.GenerateTestsKt")
 }

--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -39,6 +39,9 @@ kover = "0.9.1"
 # kotlinx.rpc – references to the included builds
 # as they're local to the project, kotlinx-rpc- prefix is omitted
 compiler-plugin-cli = { module = "org.jetbrains.kotlinx:compiler-plugin-cli" }
+compiler-plugin-k2 = { module = "org.jetbrains.kotlinx:compiler-plugin-k2" }
+compiler-plugin-backend = { module = "org.jetbrains.kotlinx:compiler-plugin-backend" }
+compiler-plugin-common = { module = "org.jetbrains.kotlinx:compiler-plugin-common" }
 
 # kotlin
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-lang" }


### PR DESCRIPTION
**Subsystem**
Gradle

**Problem Description**
`for-ide` artifacts were built against wrong version of the compiler, which led to incompatibilities

**Solution**
Fix configs to build against proper compiler version, respecting `kotlin-compiler` param in `libs.versions.toml`
