### PR TITLE
Update build for custom KC versions

### DIFF
--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -2,7 +2,6 @@
  * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import util.otherwise
 import util.whenForIde
 
 plugins {
@@ -16,10 +15,11 @@ val kotlinLangVersion = libs.versions.kotlin.lang.get()
 
 allprojects {
     group = "org.jetbrains.kotlinx"
-    whenForIde {
-        version = "$kotlinCompilerVersion-$rpcVersion"
-    } otherwise {
-        version = "$kotlinLangVersion-$rpcVersion"
+
+    version = if (kotlinCompilerVersion != kotlinLangVersion) {
+        "$kotlinCompilerVersion-$rpcVersion"
+    } else {
+        "$kotlinLangVersion-$rpcVersion"
     }
 }
 

--- a/compiler-plugin/compiler-plugin-backend/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-backend/build.gradle.kts
@@ -3,8 +3,6 @@
  */
 
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
-import util.otherwise
-import util.whenForIde
 
 plugins {
     alias(libs.plugins.conventions.jvm)
@@ -20,11 +18,7 @@ kotlin {
 }
 
 dependencies {
-    whenForIde {
-        compileOnly(libs.kotlin.compiler)
-    } otherwise {
-        compileOnly(libs.kotlin.compiler.embeddable)
-    }
+    compileOnly(libs.kotlin.compiler)
 
     implementation(projects.compilerPluginCommon)
 }

--- a/compiler-plugin/compiler-plugin-cli/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-cli/build.gradle.kts
@@ -3,8 +3,6 @@
  */
 
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
-import util.otherwise
-import util.whenForIde
 
 plugins {
     alias(libs.plugins.conventions.jvm)
@@ -16,11 +14,7 @@ kotlin {
 }
 
 dependencies {
-    whenForIde {
-        compileOnly(libs.kotlin.compiler)
-    } otherwise {
-        compileOnly(libs.kotlin.compiler.embeddable)
-    }
+    compileOnly(libs.kotlin.compiler)
 
     implementation(projects.compilerPluginK2)
     implementation(projects.compilerPluginCommon)

--- a/compiler-plugin/compiler-plugin-common/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-common/build.gradle.kts
@@ -3,8 +3,6 @@
  */
 
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
-import util.otherwise
-import util.whenForIde
 
 plugins {
     alias(libs.plugins.conventions.jvm)
@@ -16,9 +14,5 @@ kotlin {
 }
 
 dependencies {
-    whenForIde {
-        compileOnly(libs.kotlin.compiler)
-    } otherwise {
-        compileOnly(libs.kotlin.compiler.embeddable)
-    }
+    compileOnly(libs.kotlin.compiler)
 }

--- a/compiler-plugin/compiler-plugin-k2/build.gradle.kts
+++ b/compiler-plugin/compiler-plugin-k2/build.gradle.kts
@@ -72,14 +72,15 @@ kotlin {
 }
 
 dependencies {
+    compileOnly(libs.kotlin.compiler)
+
     whenForIde {
-        compileOnly(libs.kotlin.compiler)
         compileOnly(libs.serialization.plugin.forIde) {
             isTransitive = false
         }
     } otherwise {
-        compileOnly(libs.kotlin.compiler.embeddable)
         compileOnly(libs.serialization.plugin)
     }
+
     implementation(projects.compilerPluginCommon)
 }

--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -55,7 +55,6 @@ kotlin-annotations-jvm = { module = "org.jetbrains.kotlin:kotlin-annotations-jvm
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-lang" }
 
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin-compiler" }
-kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable" }
 kotlin-compiler-test-framework = { module = "org.jetbrains.kotlin:kotlin-compiler-internal-test-framework", version.ref = "kotlin-lang" }
 serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version.ref = "kotlin-compiler" }
 serialization-plugin-forIde = { module = "org.jetbrains.kotlin:kotlinx-serialization-compiler-plugin-for-ide", version.ref = "kotlin-compiler" }


### PR DESCRIPTION
**Subsystem**
Gradle

**Problem Description**
Custom Kotlin versions build (like 2.1.20-RC) that are NOT for IDE were misconfigured

**Solution**
Get rid of `embeddable` dependency which fixes the proper compiler version in builds

