### PR TITLE
Fix bidirectional flows in non-suspend streams

### DIFF
--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
@@ -49,6 +49,9 @@ interface KrpcTestService : RemoteService {
     fun nonSuspendFlow(): Flow<Int>
     fun nonSuspendFlowErrorOnEmit(): Flow<Int>
     fun nonSuspendFlowErrorOnReturn(): Flow<Int>
+    fun nonSuspendBidirectional(flow: Flow<Int>): Flow<Int>
+    fun nonSuspendBidirectionalPayload(payloadWithStream: PayloadWithStream): Flow<Int>
+
     suspend fun empty()
     suspend fun returnType(): String
     suspend fun simpleWithParams(name: String): String

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
@@ -37,6 +37,14 @@ class KrpcTestServiceBackend(override val coroutineContext: CoroutineContext) : 
         error("nonSuspendFlowErrorOnReturn")
     }
 
+    override fun nonSuspendBidirectional(flow: Flow<Int>): Flow<Int> {
+        return flow.map { it * 2 }
+    }
+
+    override fun nonSuspendBidirectionalPayload(payloadWithStream: PayloadWithStream): Flow<Int> {
+        return payloadWithStream.stream.map { it.length }
+    }
+
     @Suppress("detekt.EmptyFunctionBlock")
     override suspend fun empty() {}
 

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
@@ -136,6 +136,22 @@ abstract class KrpcTransportTestBase {
         }
     }
 
+    @Test
+    fun nonSuspendBidirectional() = runTest {
+        assertEquals(
+            expected = List(10) { it * 2 },
+            actual = client.nonSuspendBidirectional(List(10) { it }.asFlow()).toList(),
+        )
+        print(1)
+    }
+
+    @Test
+    fun nonSuspendBidirectionalPayload() = runTest {
+        assertEquals(
+            expected = List(3) { 2 },
+            actual = client.nonSuspendBidirectionalPayload(payload(0)).toList(),
+        )
+    }
 
     @Test
     fun empty() {


### PR DESCRIPTION
**Subsystem**
kRPC Client

**Problem Description**
Bidirectional streams fail in `0.6.0` in non-suspend flows

**Solution**
Fix serialization context

