### PR TITLE
Fix flows that emit Units

### DIFF
--- a/krpc/krpc-server/src/commonMain/kotlin/kotlinx/rpc/krpc/server/internal/KrpcServerService.kt
+++ b/krpc/krpc-server/src/commonMain/kotlin/kotlinx/rpc/krpc/server/internal/KrpcServerService.kt
@@ -163,7 +163,7 @@ internal class KrpcServerService<@Rpc T : Any>(
                 if (callable.isNonSuspendFunction && !markedNonSuspending) {
                     @Suppress("detekt.MaxLineLength")
                     error(
-                        "Server flow returned from non-suspend function but marked so by a client: ${descriptor.fqName}::$callableName." +
+                        "Server flow returned from non-suspend function but marked so by a client: ${descriptor.fqName}::$callableName. " +
                                 "Probable cause is outdated client version, that does not support non-suspending flows, " +
                                 "but calls the function with the same name. Change the function name or update the client."
                     )
@@ -181,7 +181,7 @@ internal class KrpcServerService<@Rpc T : Any>(
                     }
                 }.let { interceptedValue ->
                     // KRPC-173
-                    if (callable.returnType.kType == typeOf<Unit>()) {
+                    if (!callable.isNonSuspendFunction && callable.returnType.kType == typeOf<Unit>()) {
                         Unit
                     } else {
                         interceptedValue
@@ -194,8 +194,9 @@ internal class KrpcServerService<@Rpc T : Any>(
                 if (callable.isNonSuspendFunction) {
                     if (value !is Flow<*>) {
                         error(
-                            "Return value of non-suspend function must be a non nullable flow, " +
-                                "but was: ${value?.let { it::class.simpleName }}"
+                            "Return value of non-suspend function '${callable.name}' " +
+                                    "with callId '$callId' must be a non nullable flow, " +
+                                    "but was: ${value?.let { it::class.simpleName }}"
                         )
                     }
 

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
@@ -113,6 +113,8 @@ interface KrpcTestService : RemoteService {
 
     suspend fun krpc173()
 
+    fun unitFlow(): Flow<Unit>
+
     val plainFlowOfInts : Flow<Int>
 
     val plainFlowOfFlowsOfInts : Flow<Flow<Int>>

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
@@ -282,6 +282,12 @@ class KrpcTestServiceBackend(override val coroutineContext: CoroutineContext) : 
         doWork()
     }
 
+    override fun unitFlow(): Flow<Unit> {
+        return flow {
+            emit(Unit)
+        }
+    }
+
     override val plainFlowOfInts: Flow<Int> = plainFlow { it }
 
     override val plainFlowOfFlowsOfInts: Flow<Flow<Int>> = plainFlow { plainFlow { i -> i } }

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
@@ -570,6 +570,11 @@ abstract class KrpcTransportTestBase {
     }
 
     @Test
+    fun testUnitFlow() = runTest {
+        assertEquals(Unit, client.unitFlow().toList().single())
+    }
+
+    @Test
     fun testPlainFlowOfInts() = runTest {
         val flow = client.plainFlowOfInts.toList()
         assertEquals(List(5) { it }, flow)


### PR DESCRIPTION
**Subsystem**
kRPC Server

**Problem Description**
Function like 

```kotlin
@Rpc
interface Service {
   fun request(): Flow<Unit>
}
```

Would through an error

**Solution**
Fix condition that checks it.

