### PR TITLE
Change strict mode to level ERROR by default

### DIFF
--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/StrictMode.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/StrictMode.kt
@@ -49,13 +49,13 @@ object StrictModeConfigurationKeys {
 
 fun CompilerConfiguration.strictModeAggregator(): StrictModeAggregator {
     return StrictModeAggregator(
-        stateFlow = get(StrictModeConfigurationKeys.STATE_FLOW, StrictMode.WARNING),
-        sharedFlow = get(StrictModeConfigurationKeys.SHARED_FLOW, StrictMode.WARNING),
-        nestedFlow = get(StrictModeConfigurationKeys.NESTED_FLOW, StrictMode.WARNING),
-        streamScopedFunctions = get(StrictModeConfigurationKeys.STREAM_SCOPED_FUNCTIONS, StrictMode.WARNING),
-        suspendingServerStreaming = get(StrictModeConfigurationKeys.SUSPENDING_SERVER_STREAMING, StrictMode.WARNING),
-        notTopLevelServerFlow = get(StrictModeConfigurationKeys.NOT_TOP_LEVEL_SERVER_FLOW, StrictMode.WARNING),
-        fields = get(StrictModeConfigurationKeys.FIELDS, StrictMode.WARNING),
+        stateFlow = get(StrictModeConfigurationKeys.STATE_FLOW, StrictMode.ERROR),
+        sharedFlow = get(StrictModeConfigurationKeys.SHARED_FLOW, StrictMode.ERROR),
+        nestedFlow = get(StrictModeConfigurationKeys.NESTED_FLOW, StrictMode.ERROR),
+        streamScopedFunctions = get(StrictModeConfigurationKeys.STREAM_SCOPED_FUNCTIONS, StrictMode.ERROR),
+        suspendingServerStreaming = get(StrictModeConfigurationKeys.SUSPENDING_SERVER_STREAMING, StrictMode.ERROR),
+        notTopLevelServerFlow = get(StrictModeConfigurationKeys.NOT_TOP_LEVEL_SERVER_FLOW, StrictMode.ERROR),
+        fields = get(StrictModeConfigurationKeys.FIELDS, StrictMode.ERROR),
     )
 }
 

--- a/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/core/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
@@ -140,6 +140,7 @@ class RpcStrictModeDiagnosticRendererFactory(
             StrictMode.ERROR -> "prohibited"
         }
 
-        return "$entityName is $actionWord in @Rpc services in strict mode."
+        return "$entityName is $actionWord in @Rpc services in strict mode. " +
+                "Support will be removed completely in the 0.8.0 release."
     }
 }

--- a/docs/pages/kotlinx-rpc/topics/strict-mode.topic
+++ b/docs/pages/kotlinx-rpc/topics/strict-mode.topic
@@ -13,8 +13,11 @@
         Starting with version <code>0.5.0</code>, the library introduces major changes to the service APIs.
         The following declarations will be gradually restricted:
     </p>
+    <warning>
+        String mode will be enforced in the <code>0.8.0</code> release.
+    </warning>
     <chapter title="StateFlow and SharedFlow" id="stateflow-and-sharedflow">
-        <p>Deprecation level: <code>WARNING</code></p>
+        <p>Deprecation level: <code>ERROR</code></p>
         <code-block lang="kotlin">
             @Rpc
             interface Service : RemoteService {
@@ -26,7 +29,7 @@
     </chapter>
 
     <chapter title="Fields" id="fields">
-        <p>Deprecation level: <code>WARNING</code></p>
+        <p>Deprecation level: <code>ERROR</code></p>
         <code-block lang="kotlin">
             @Rpc
             interface Service : RemoteService {
@@ -37,7 +40,7 @@
         </code-block>
     </chapter>
     <chapter title="Nested Flows" id="nested-flows">
-        <p>Deprecation level: <code>WARNING</code></p>
+        <p>Deprecation level: <code>ERROR</code></p>
         <code-block lang="kotlin">
             @Rpc
             interface Service : RemoteService {
@@ -48,7 +51,7 @@
         </code-block>
     </chapter>
     <chapter title="Not top-level server flows" id="not-top-level-server-flows">
-        <p>Deprecation level: <code>WARNING</code></p>
+        <p>Deprecation level: <code>ERROR</code></p>
 
         <code-block lang="kotlin">
             data class SpotifyWrapped(val myMusicFlow: Flow&lt;Rap&gt;, val extra: Data)
@@ -64,7 +67,7 @@
         </code-block>
     </chapter>
     <chapter title="Non-suspending server flows" id="non-suspending-server-flows">
-        <p>Deprecation level: <code>WARNING</code></p>
+        <p>Deprecation level: <code>ERROR</code></p>
 
         <code-block lang="kotlin">
             data class SpotifyWrapped(val extra: Data)
@@ -78,7 +81,7 @@
         </code-block>
     </chapter>
     <chapter title="Stream scopes management" id="stream-scopes-management">
-        <p>Deprecation level: <code>WARNING</code></p>
+        <p>Deprecation level: <code>ERROR</code></p>
 
         <p>
             The next stream scope management structures are deprecated due to the introduction of
@@ -158,18 +161,18 @@
 
         rpc {
             strict {
-                stateFlow = RpcStrictMode.WARNING
-                sharedFlow = RpcStrictMode.WARNING
-                nestedFlow = RpcStrictMode.WARNING
-                notTopLevelServerFlow = RpcStrictMode.WARNING
-                fields = RpcStrictMode.WARNING
-                suspendingServerStreaming = RpcStrictMode.WARNING
-                streamScopedFunctions = RpcStrictMode.WARNING
+                stateFlow = RpcStrictMode.ERROR
+                sharedFlow = RpcStrictMode.ERROR
+                nestedFlow = RpcStrictMode.ERROR
+                notTopLevelServerFlow = RpcStrictMode.ERROR
+                fields = RpcStrictMode.ERROR
+                suspendingServerStreaming = RpcStrictMode.ERROR
+                streamScopedFunctions = RpcStrictMode.ERROR
             }
         }
     </code-block>
         <p>
-            Modes <code>RpcStrictMode.NONE</code> and <code>RpcStrictMode.ERROR</code> are available.
+            Modes <code>RpcStrictMode.NONE</code> and <code>RpcStrictMode.WARNING</code> are available.
         </p>
 
         <warning>

--- a/gradle-plugin/src/main/kotlin/kotlinx/rpc/Extensions.kt
+++ b/gradle-plugin/src/main/kotlin/kotlinx/rpc/Extensions.kt
@@ -91,7 +91,7 @@ open class RpcStrictModeExtension @Inject constructor(objects: ObjectFactory) {
     val fields: Property<RpcStrictMode> = objects.strictModeProperty()
 
     private fun ObjectFactory.strictModeProperty(
-        default: RpcStrictMode = RpcStrictMode.WARNING,
+        default: RpcStrictMode = RpcStrictMode.ERROR,
     ): Property<RpcStrictMode> {
         return property(RpcStrictMode::class.java).convention(default)
     }

--- a/krpc/krpc-client/build.gradle.kts
+++ b/krpc/krpc-client/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import kotlinx.rpc.RpcStrictMode
 import util.applyAtomicfuPlugin
 
 plugins {
@@ -24,5 +25,17 @@ kotlin {
                 implementation(projects.krpc.krpcLogging)
             }
         }
+    }
+}
+
+rpc {
+    strict {
+        stateFlow = RpcStrictMode.NONE
+        sharedFlow = RpcStrictMode.NONE
+        nestedFlow = RpcStrictMode.NONE
+        streamScopedFunctions = RpcStrictMode.NONE
+        suspendingServerStreaming = RpcStrictMode.NONE
+        notTopLevelServerFlow = RpcStrictMode.NONE
+        fields = RpcStrictMode.NONE
     }
 }

--- a/krpc/krpc-core/build.gradle.kts
+++ b/krpc/krpc-core/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import kotlinx.rpc.RpcStrictMode
 import util.applyAtomicfuPlugin
 
 plugins {
@@ -25,5 +26,17 @@ kotlin {
                 implementation(libs.kotlin.reflect)
             }
         }
+    }
+}
+
+rpc {
+    strict {
+        stateFlow = RpcStrictMode.NONE
+        sharedFlow = RpcStrictMode.NONE
+        nestedFlow = RpcStrictMode.NONE
+        streamScopedFunctions = RpcStrictMode.NONE
+        suspendingServerStreaming = RpcStrictMode.NONE
+        notTopLevelServerFlow = RpcStrictMode.NONE
+        fields = RpcStrictMode.NONE
     }
 }

--- a/krpc/krpc-test/build.gradle.kts
+++ b/krpc/krpc-test/build.gradle.kts
@@ -2,6 +2,7 @@
  * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
+import kotlinx.rpc.RpcStrictMode
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
@@ -98,5 +99,17 @@ tasks.register("moveToGold") {
                 it.delete()
             }
         }
+    }
+}
+
+rpc {
+    strict {
+        stateFlow = RpcStrictMode.NONE
+        sharedFlow = RpcStrictMode.NONE
+        nestedFlow = RpcStrictMode.NONE
+        streamScopedFunctions = RpcStrictMode.NONE
+        suspendingServerStreaming = RpcStrictMode.NONE
+        notTopLevelServerFlow = RpcStrictMode.NONE
+        fields = RpcStrictMode.NONE
     }
 }

--- a/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/services/ExtensionRegistrarConfigurator.kt
+++ b/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/services/ExtensionRegistrarConfigurator.kt
@@ -27,7 +27,7 @@ class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentCo
     ) {
         val strictMode = module.directives[RpcDirectives.RPC_STRICT_MODE]
         if (strictMode.isNotEmpty()) {
-            val mode = StrictMode.fromCli(strictMode.single()) ?: StrictMode.WARNING
+            val mode = StrictMode.fromCli(strictMode.single()) ?: StrictMode.ERROR
             configuration.put(StrictModeConfigurationKeys.STATE_FLOW, mode)
             configuration.put(StrictModeConfigurationKeys.SHARED_FLOW, mode)
             configuration.put(StrictModeConfigurationKeys.NESTED_FLOW, mode)


### PR DESCRIPTION
**Subsystem**
Gradle Plugin, Compiler Plugin

**Problem Description**
Strict mode was introduced in `0.5.0` with `warning` level.

**Solution**
Change default reporting level to `error`, as in `0.8.0` the mode will be enforced irreversibly. 

