### PR TITLE
Update README.md to use non-suspend flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import kotlinx.rpc.annotations.Rpc
 
 @Rpc
 interface AwesomeService : RemoteService {
-    suspend fun getNews(city: String): Flow<String>
+    fun getNews(city: String): Flow<String>
     
     suspend fun daysUntilStableRelease(): Int
 }
@@ -35,7 +35,7 @@ class AwesomeServiceImpl(
     val parameters: AwesomeParameters,
     override val coroutineContext: CoroutineContext,
 ) : AwesomeService {
-    override suspend fun getNews(city: String): Flow<String> {
+    override fun getNews(city: String): Flow<String> {
         return flow { 
             emit("Today is 23 degrees!")
             emit("Harry Potter is in $city!")


### PR DESCRIPTION
**Subsystem**
Documentation

**Problem Description**
README was still using semantics that are obsolete since #299

**Solution**
Remove suspend keyword from RPC functions returning a flow in the documentation
