### PR TITLE
Cold Ktor client

### DIFF
--- a/krpc/krpc-client/api/krpc-client.api
+++ b/krpc/krpc-client/api/krpc-client.api
@@ -1,6 +1,14 @@
-public abstract class kotlinx/rpc/krpc/client/KrpcClient : kotlinx/rpc/RpcClient, kotlinx/rpc/krpc/internal/KrpcEndpoint {
+public abstract class kotlinx/rpc/krpc/client/InitializedKrpcClient : kotlinx/rpc/krpc/client/KrpcClient {
 	public fun <init> (Lkotlinx/rpc/krpc/KrpcConfig$Client;Lkotlinx/rpc/krpc/KrpcTransport;)V
+	public final fun initializeConfig ()Lkotlinx/rpc/krpc/KrpcConfig$Client;
+	public final fun initializeTransport (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class kotlinx/rpc/krpc/client/KrpcClient : kotlinx/rpc/RpcClient, kotlinx/rpc/krpc/internal/KrpcEndpoint {
+	public fun <init> ()V
 	public final fun call (Lkotlinx/rpc/RpcCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun callServerStreaming (Lkotlinx/rpc/RpcCall;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun initializeConfig ()Lkotlinx/rpc/krpc/KrpcConfig$Client;
+	public abstract fun initializeTransport (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/krpc/krpc-ktor/krpc-ktor-client/api/krpc-ktor-client.api
+++ b/krpc/krpc-ktor/krpc-ktor-client/api/krpc-ktor-client.api
@@ -8,15 +8,15 @@ public final class kotlinx/rpc/krpc/ktor/client/KrpcKt {
 }
 
 public final class kotlinx/rpc/krpc/ktor/client/KtorClientDslKt {
-	public static final fun rpc (Lio/ktor/client/HttpClient;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun rpc (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun rpc$default (Lio/ktor/client/HttpClient;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun rpc$default (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun rpc (Lio/ktor/client/HttpClient;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/krpc/ktor/client/KtorRpcClient;
+	public static final fun rpc (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/krpc/ktor/client/KtorRpcClient;
+	public static synthetic fun rpc$default (Lio/ktor/client/HttpClient;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/krpc/ktor/client/KtorRpcClient;
+	public static synthetic fun rpc$default (Lio/ktor/client/HttpClient;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/krpc/ktor/client/KtorRpcClient;
 	public static final fun rpcConfig (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun rpcConfig$default (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
 public abstract interface class kotlinx/rpc/krpc/ktor/client/KtorRpcClient : kotlinx/rpc/RpcClient {
-	public abstract fun getWebSocketSession ()Lio/ktor/websocket/WebSocketSession;
+	public abstract fun getWebSocketSession ()Lkotlinx/coroutines/Deferred;
 }
 

--- a/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorRpcClient.kt
+++ b/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorRpcClient.kt
@@ -5,21 +5,46 @@
 package kotlinx.rpc.krpc.ktor.client
 
 import io.ktor.websocket.*
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import kotlinx.rpc.RpcClient
 import kotlinx.rpc.krpc.KrpcConfig
+import kotlinx.rpc.krpc.KrpcConfigBuilder
+import kotlinx.rpc.krpc.KrpcTransport
 import kotlinx.rpc.krpc.client.KrpcClient
 import kotlinx.rpc.krpc.ktor.KtorTransport
+import kotlinx.rpc.krpc.rpcClientConfig
 
 /**
  * [RpcClient] implementation for Ktor, containing [webSocketSession] object,
  * that is used to maintain connection.
  */
 public interface KtorRpcClient : RpcClient {
-    public val webSocketSession: WebSocketSession
+    public val webSocketSession: Deferred<WebSocketSession>
 }
 
 internal class KtorKrpcClientImpl(
-    override val webSocketSession: WebSocketSession,
-    config: KrpcConfig.Client,
-): KrpcClient(config, KtorTransport(webSocketSession)), KtorRpcClient
+    private val pluginConfigBuilder: KrpcConfigBuilder.Client?,
+    private val webSocketSessionFactory: suspend (
+        configSetter: (KrpcConfigBuilder.Client.() -> Unit) -> Unit,
+    ) -> WebSocketSession,
+): KrpcClient(), KtorRpcClient {
+    private var requestConfigBuilder: KrpcConfigBuilder.Client.() -> Unit = {}
 
+    private val _webSocketSession = CompletableDeferred<WebSocketSession>()
+    override val webSocketSession: Deferred<WebSocketSession> = _webSocketSession
+
+    override suspend fun initializeTransport(): KrpcTransport {
+        val session = webSocketSessionFactory {
+            requestConfigBuilder = it
+        }
+
+        _webSocketSession.complete(session)
+        return KtorTransport(session)
+    }
+
+    override fun initializeConfig(): KrpcConfig.Client {
+        return pluginConfigBuilder?.apply(requestConfigBuilder)?.build()
+            ?: rpcClientConfig(requestConfigBuilder)
+    }
+}

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestClient.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestClient.kt
@@ -6,6 +6,7 @@ package kotlinx.rpc.krpc.test
 
 import kotlinx.rpc.krpc.KrpcConfig
 import kotlinx.rpc.krpc.KrpcTransport
+import kotlinx.rpc.krpc.client.InitializedKrpcClient
 import kotlinx.rpc.krpc.client.KrpcClient
 
 /**
@@ -17,4 +18,4 @@ import kotlinx.rpc.krpc.client.KrpcClient
 class KrpcTestClient(
     config: KrpcConfig.Client,
     transport: KrpcTransport,
-) : KrpcClient(config, transport)
+) : InitializedKrpcClient(config, transport)

--- a/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/LocalTransportTest.kt
+++ b/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/LocalTransportTest.kt
@@ -12,6 +12,7 @@ import kotlinx.rpc.krpc.serialization.cbor.cbor
 import kotlinx.rpc.krpc.serialization.json.json
 import kotlinx.rpc.krpc.serialization.protobuf.protobuf
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlin.test.Test
 
 abstract class LocalTransportTest : KrpcTransportTestBase() {
     private val transport = LocalTransport()
@@ -50,11 +51,15 @@ class ProtoBufLocalTransportTest : LocalTransportTest() {
     }
 
     // 'null' is not supported in ProtoBuf
+    @Test
     override fun nullable(): TestResult = runTest { }
 
+    @Test
     override fun testByteArraySerialization(): TestResult = runTest { }
 
+    @Test
     override fun testNullables(): TestResult = runTest { }
 
+    @Test
     override fun testNullableLists(): TestResult = runTest { }
 }

--- a/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/ProtocolTestBase.kt
+++ b/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/ProtocolTestBase.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.rpc.annotations.Rpc
 import kotlinx.rpc.internal.utils.hex.rpcInternalHexToReadableBinary
 import kotlinx.rpc.krpc.KrpcConfig
-import kotlinx.rpc.krpc.client.KrpcClient
+import kotlinx.rpc.krpc.client.InitializedKrpcClient
 import kotlinx.rpc.krpc.internal.logging.RpcInternalCommonLogger
 import kotlinx.rpc.krpc.internal.logging.RpcInternalDumpLogger
 import kotlinx.rpc.krpc.internal.logging.RpcInternalDumpLoggerContainer
@@ -105,4 +105,4 @@ class ProtocolTestServer(
 class ProtocolTestClient(
     config: KrpcConfig.Client,
     transport: LocalTransport,
-) : KrpcClient(config, transport.client)
+) : InitializedKrpcClient(config, transport.client)

--- a/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/cancellation/CancellationToolkit.kt
+++ b/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/cancellation/CancellationToolkit.kt
@@ -25,7 +25,11 @@ import kotlin.time.Duration.Companion.seconds
 fun runCancellationTest(body: suspend CancellationToolkit.() -> Unit): TestResult {
     return runTest(timeout = 15.seconds) {
         debugCoroutines()
-        CancellationToolkit(this).apply { body() }
+        CancellationToolkit(this).apply {
+            client.initializeTransport()
+
+            body()
+        }
     }
 }
 

--- a/tests/compiler-plugin-tests/src/main/kotlin/kotlinx/rpc/codegen/test/TestRpcClient.kt
+++ b/tests/compiler-plugin-tests/src/main/kotlin/kotlinx/rpc/codegen/test/TestRpcClient.kt
@@ -4,17 +4,13 @@
 
 package kotlinx.rpc.codegen.test
 
-import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.rpc.RpcCall
 import kotlinx.rpc.RpcClient
-import kotlin.coroutines.CoroutineContext
 
 @Suppress("UNCHECKED_CAST", "unused")
 object TestRpcClient : RpcClient {
-    override val coroutineContext: CoroutineContext = Job()
-
     override suspend fun <T> call(call: RpcCall): T {
         return "call_42" as T
     }

--- a/tests/krpc-compatibility-tests/src/test/kotlin/kotlinx/rpc/krpc/compatibility/LocalTransport.kt
+++ b/tests/krpc-compatibility-tests/src/test/kotlin/kotlinx/rpc/krpc/compatibility/LocalTransport.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.job
 import kotlinx.rpc.krpc.KrpcConfig
 import kotlinx.rpc.krpc.KrpcTransport
 import kotlinx.rpc.krpc.KrpcTransportMessage
-import kotlinx.rpc.krpc.client.KrpcClient
+import kotlinx.rpc.krpc.client.InitializedKrpcClient
 import kotlinx.rpc.krpc.server.KrpcServer
 import kotlin.coroutines.CoroutineContext
 
@@ -24,7 +24,7 @@ class KrpcTestServer(
 class KrpcTestClient(
     config: KrpcConfig.Client,
     transport: KrpcTransport,
-) : KrpcClient(config, transport)
+) : InitializedKrpcClient(config, transport)
 
 class LocalTransport(parentScope: CoroutineScope? = null) : CoroutineScope {
     override val coroutineContext = parentScope?.run { SupervisorJob(coroutineContext.job) }


### PR DESCRIPTION
**Strict mode Migration**
A series of changes to simplify kRPC protocol
 - [x] Remove fields support
 - [x] Remove stream scopes
 - [x] Simplify lifetime management
 - [x] Cold RPC clients creation
 - [ ] Deprecated declarations cleanup
 - [ ] Documentation update for previous changes


**Subsystem**
Krpc Ktor

**Problem Description**
Ktor Krpc client requires invokavion of `.rpc` method which is suspending. In some cases that might be bad UX.

**Solution**
Allow for a cold client creation

