### PR TITLE
Documentation update for 0.8.0

### DIFF
--- a/core/src/commonMain/kotlin/kotlinx/rpc/RpcCall.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/RpcCall.kt
@@ -7,12 +7,12 @@ package kotlinx.rpc
 import kotlinx.rpc.descriptor.RpcServiceDescriptor
 
 /**
- * Represents a method or field call of an RPC service.
+ * Represents a method call from an RPC service.
  *
  * @property descriptor [RpcServiceDescriptor] of a service that made the call.
- * @property callableName The name of the callable. Can be the name of the method or field.
+ * @property callableName The name of the method being called.
  * @property data The data for the call.
- * @property serviceId id of the service, that made the call.
+ * @property serviceId The id of the service that made the call.
  */
 public data class RpcCall(
     val descriptor: RpcServiceDescriptor<*>,

--- a/core/src/commonMain/kotlin/kotlinx/rpc/RpcClient.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/RpcClient.kt
@@ -4,13 +4,11 @@
 
 package kotlinx.rpc
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 /**
  * [RpcClient] represents an abstraction of an RPC client, that can handle requests from several RPC services,
  * transform them, send to the server and handle responses and errors.
- * [CoroutineScope] defines the lifetime of the client.
  */
 public interface RpcClient {
     /**
@@ -19,7 +17,7 @@ public interface RpcClient {
      * @param T type of the result
      * @param call an object that contains all required information about the called method,
      * that is needed to route it properly to the server.
-     * @return actual result of the call, for example, data from the server.
+     * @return result of the call, for example, data from the server.
      */
     public suspend fun <T> call(call: RpcCall): T
 
@@ -30,7 +28,7 @@ public interface RpcClient {
      * @param T type of the result
      * @param call an object that contains all required information about the called method,
      * that is needed to route it properly to the server.
-     * @return the actual result of the call, for example, data from the server
+     * @return result of the call, for example, data from the server
      */
     public fun <T> callServerStreaming(call: RpcCall): Flow<T>
 }

--- a/core/src/commonMain/kotlin/kotlinx/rpc/RpcServer.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/RpcServer.kt
@@ -13,20 +13,32 @@ import kotlin.reflect.KClass
  */
 public interface RpcServer {
     /**
-     * Registers new service to the server. Server will route all designated messages to it.
+     * Registers new service. Server will route all designated messages to it.
      * Service of any type should be unique on the server, but RpcServer doesn't specify the actual retention policy.
      *
      * @param Service the exact type of the server to be registered.
-     * For example, for service with `MyService` interface and `MyServiceImpl` implementation,
-     * type `MyService` should be specified explicitly.
+     * For example, for a service with `MyService` interface and `MyServiceImpl` implementation
+     * the type `MyService` should be specified explicitly.
      * @param serviceKClass [KClass] of the [Service].
      * @param serviceFactory function that produces the actual implementation of the service that will handle the calls.
+     *
+     * @see kotlinx.rpc.annotations.CheckedTypeAnnotation
      */
     public fun <@Rpc Service : Any> registerService(
         serviceKClass: KClass<Service>,
         serviceFactory: () -> Service,
     )
 
+    /**
+     * Deregisters a service. Server will stop routing messages to it.
+     *
+     * @param Service the exact type of the server to be deregistered, the same one that was used for registration.
+     * For example, for a service with `MyService` interface and `MyServiceImpl` implementation
+     * the type `MyService` should be specified explicitly.
+     * @param serviceKClass [KClass] of the [Service].
+     *
+     * @see kotlinx.rpc.annotations.CheckedTypeAnnotation
+     */
     public fun <@Rpc Service : Any> deregisterService(
         serviceKClass: KClass<Service>,
     )
@@ -37,9 +49,11 @@ public interface RpcServer {
  * Service of any type should be unique on the server, but RpcServer doesn't specify the actual retention policy.
  *
  * @param Service the exact type of the server to be registered.
- * For example, for service with `MyService` interface and `MyServiceImpl` implementation,
- * type `MyService` should be specified explicitly.
+ * For example, for a service with `MyService` interface and `MyServiceImpl` implementation
+ * the type `MyService` should be specified explicitly.
  * @param serviceFactory function that produces the actual implementation of the service that will handle the calls.
+ *
+ * @see kotlinx.rpc.annotations.CheckedTypeAnnotation
  */
 public inline fun <@Rpc reified Service : Any> RpcServer.registerService(
     noinline serviceFactory: () -> Service,

--- a/core/src/commonMain/kotlin/kotlinx/rpc/annotations/CheckedTypeAnnotation.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/annotations/CheckedTypeAnnotation.kt
@@ -5,8 +5,11 @@
 package kotlinx.rpc.annotations
 
 /**
- * Marks an annotation as a one that marks
- * a type argument as a one that requires its resolved type to be annotated this annotation.
+ * Meta annotation.
+ * Used to perform [annotation type-safety](https://kotlin.github.io/kotlinx-rpc/annotation-type-safety.html) checks.
+ *
+ * When an annotation class (for example, `@X`) is marked with `@CheckedTypeAnnotation` -
+ * Any other type can be marked with `@X` to perform safety checks on type parameters that are also marked with `@X`.
  *
  * Example:
  * ```kotlin

--- a/core/src/commonMain/kotlin/kotlinx/rpc/annotations/Rpc.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/annotations/Rpc.kt
@@ -8,18 +8,24 @@ package kotlinx.rpc.annotations
  * Every [Rpc] annotated interface will have a code generation process run on it,
  * making the interface effectively usable for RPC calls.
  *
- * Example usage:
+ * Example usage.
+ *
+ * Define an interface and mark it with `@Rpc`.
+ * Compiler plugin will ensure that all declarations inside the interface are valid.
  * ```kotlin
- * // common code
  * @Rpc
  * interface MyService {
  *    suspend fun sayHello(firstName: String, lastName: String, age: Int): String
  * }
- * // client code
+ * ```
+ * On the client side use [kotlinx.rpc.RpcClient] to get a generated instance of the service, and use it to make calls:
+ * ```kotlin
  * val rpcClient: RpcClient
  * val myService = rpcClient.withService<MyService>()
  * val greetingFromServer = myService.sayHello("Alex", "Smith", 35)
- * // server code
+ * ```
+ * On the server side, define an implementation of this interface and register it on an [kotlinx.rpc.RpcServer]:
+ * ```kotlin
  * class MyServiceImpl : MyService {
  *     override suspend fun sayHello(firstName: String, lastName: String, age: Int): String {
  *         return "Hello, $firstName $lastName, of age $age. I am your server!"
@@ -28,6 +34,11 @@ package kotlinx.rpc.annotations
  * val server: RpcServer
  * server.registerService<MyService> { MyServiceImpl() }
  * ```
+ *
+ * @see kotlinx.rpc.RpcClient
+ * @see kotlinx.rpc.RpcServer
+ * @see CheckedTypeAnnotation
+ * @see kotlinx.rpc.withService
  */
 @CheckedTypeAnnotation
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.TYPE_PARAMETER)

--- a/core/src/commonMain/kotlin/kotlinx/rpc/withService.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/withService.kt
@@ -12,21 +12,25 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 /**
- * Creates instance of the generated service [T], that is able to communicate with server using [RpcClient].
+ * Creates an instance of the generated service [T], that is able to communicate with a server using this [RpcClient].
  *
  * @param T the exact type of the service to be created.
  * @return instance of the generated service.
+ *
+ * @see kotlinx.rpc.annotations.CheckedTypeAnnotation
  */
 public inline fun <@Rpc reified T : Any> RpcClient.withService(): T {
     return withService(T::class)
 }
 
 /**
- * Creates instance of the generated service [T], that is able to communicate with server using [RpcClient].
+ * Creates an instance of the generated service [T], that is able to communicate with a server using this [RpcClient].
  *
  * @param T the exact type of the service to be created.
  * @param serviceKType [KType] of the service to be created.
  * @return instance of the generated service.
+ *
+ * @see kotlinx.rpc.annotations.CheckedTypeAnnotation
  */
 public fun <@Rpc T : Any> RpcClient.withService(serviceKType: KType): T {
     return withService(serviceKType.rpcInternalKClass())
@@ -39,11 +43,13 @@ public fun <@Rpc T : Any> RpcClient.withService(serviceKType: KType): T {
 private val SERVICE_ID = atomic(0L)
 
 /**
- * Creates instance of the generated service [T], that is able to communicate with server using [RpcClient].
+ * Creates an instance of the generated service [T], that is able to communicate with a server using this [RpcClient].
  *
  * @param T the exact type of the service to be created.
  * @param serviceKClass [KClass] of the service to be created.
  * @return instance of the generated service.
+ *
+ * @see kotlinx.rpc.annotations.CheckedTypeAnnotation
  */
 public fun <@Rpc T : Any> RpcClient.withService(serviceKClass: KClass<T>): T {
     val descriptor = serviceDescriptorOf(serviceKClass)

--- a/docs/pages/kotlinx-rpc/rpc.tree
+++ b/docs/pages/kotlinx-rpc/rpc.tree
@@ -40,6 +40,7 @@
     <toc-element topic="strict-mode.topic"/>
     <toc-element topic="versions.topic"/>
     <toc-element toc-title="Migration guides">
+        <toc-element topic="0-8-0.topic"/>
         <toc-element topic="0-6-0.topic"/>
         <toc-element topic="0-5-0.topic"/>
         <toc-element topic="0-4-0.topic"/>

--- a/docs/pages/kotlinx-rpc/rpc.tree
+++ b/docs/pages/kotlinx-rpc/rpc.tree
@@ -24,7 +24,11 @@
         <toc-element toc-title="kRPC">
             <toc-element topic="configuration.topic"/>
             <toc-element topic="features.topic"/>
-            <toc-element topic="transport.topic"/>
+            <toc-element topic="krpc-client.topic"/>
+            <toc-element topic="krpc-server.topic"/>
+            <toc-element topic="transport.topic">
+                <toc-element topic="krpc-ktor.topic"/>
+            </toc-element>
         </toc-element>
         <toc-element toc-title="gRPC">
             <toc-element topic="grpc-configuration.topic"/>

--- a/docs/pages/kotlinx-rpc/topics/0-8-0.topic
+++ b/docs/pages/kotlinx-rpc/topics/0-8-0.topic
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
+<!DOCTYPE topic
+        SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Migration to 0.8.0" id="0-8-0">
+
+    <p>
+        Version <code>0.8.0</code> brings a lot of changes,
+        mainly targeted to remove inherently broken functionality and simplify kRPC protocol where possible.
+        This is reflected in the number of breaking changes and deprecations.
+    </p>
+    <p>
+        This page aims to cover all such changes and associated migration instructions.
+    </p>
+
+    <chapter title="Strict mode enforcement" id="strict-mode-enforcement">
+        <p>
+            Strict mode is now enforced and can't be disabled.
+            See <a href="strict-mode.topic"/> for detailed migrations.
+        </p>
+    </chapter>
+
+    <chapter title="kRPC protocol changes" id="krpc-protocol-changes">
+        <p>
+            The following changes are reflected in the kRPC protocol on the wire:
+        </p>
+        <list>
+            <li>
+                <code>KrpcServer</code> doesn't send CANCELLATION_ACK messages anymore.
+            </li>
+            <li>
+                <code>KrpcClient</code> sends REQUEST cancellation messages for every individually finished call,
+                canceled or finished successfully
+            </li>
+        </list>
+        <p>
+            Though changes should not affect most users,
+            for those who like to look at the wire it might be useful to know.
+        </p>
+    </chapter>
+
+    <chapter title="Behavioral changes" id="behavioral-changes">
+        <p>
+            Some changes in the behavior of kRPC clients and servers:
+        </p>
+        <list>
+            <li>
+                <p>
+                    Lifetime for client-side streams is changed.
+                </p>
+                <p>
+                    Previously, the stream scopes bounded client-side streams.
+                    However, stream scopes are completely removed now,
+                    so the client-side streams lifetime is now bound to the request's lifetime.
+                    This means that when the function returns, every client stream is closed.
+                </p>
+            </li>
+            <li>
+                <p>
+                    Serial format is now only constructed once per client.
+                </p>
+                <p>
+                    Previously, the serial format was constructed once per RPC call.
+                    The serial format can be passed using the <code>KrpcConfig</code>.
+                    And the builder code was executed once per every call.
+                </p>
+                <p>
+                    Now this behavior is removed.
+                    The serial format is constructed once per client.
+                </p>
+            </li>
+            <li>
+                <p>
+                    Services are now instantiated once per service type (Rpc FQ name)
+                    and not once per client-side instance.
+                </p>
+                <p>
+                    Services lost their CoroutineScopes (see <a href="0-8-0.topic#incompatible-api-changes"/>).
+                    That means that there are no individual lifetimes for each service instance now.
+                    Instead, now each service stub on a client is merely a proxy for function calls.
+                    And on the server side, the service implementation is instantiated once per service type.
+                    To control this behavior more granularly on the server, new <code>deregisterService</code>
+                    function is introduced.
+                </p>
+                <tip>
+                    For kRPC servers, the factory function for service instances is now executed once per service type:
+                    <code-block lang="kotlin">
+                        rpcServer.registerService&lt;MyService&gt; { MyServiceImpl() }
+                    </code-block>
+                </tip>
+            </li>
+            <li>
+                <p>
+                    Handshake is now cold.
+                </p>
+                <p>
+                    Previously, the handshake was executed on client creation.
+                    Now, the handshake is executed on the first RPC request.
+                </p>
+            </li>
+        </list>
+    </chapter>
+
+    <chapter title="Incompatible API changes" id="incompatible-api-changes">
+        <list>
+            <li>
+                <p>
+                    <code>RpcClient.callServerStreaming</code> lost its default implementation:
+                </p>
+
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        interface RpcClient {
+                            fun &lt;T&gt; callServerStreaming(call: RpcCall): Flow&lt;T&gt; {
+                                error("Not implemented")
+                            }
+                        }
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        interface RpcClient {
+                            fun &lt;T&gt; callServerStreaming(call: RpcCall): Flow&lt;T&gt;
+                        }
+                    </code-block>
+                </compare>
+            </li>
+            <li>
+                <p>
+                    <code>@Rpc</code> services lost their CoroutineScope:
+                </p>
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        val service = client.withService&lt;MyService&gt;()
+                        assert(service is CoroutineScope) // OK
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        val service = client.withService&lt;MyService&gt;()
+                        assert(service is CoroutineScope) // fail
+                    </code-block>
+                </compare>
+            </li>
+            <li>
+                <p>
+                    <code>RpcClient</code> lost its <code>CoroutineScope</code>:
+                </p>
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        interface RpcClient : CoroutineScope
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        interface RpcClient
+                    </code-block>
+                </compare>
+            </li>
+            <li>
+                <p>
+                    <code>RpcServer</code> lost its <code>CoroutineScope</code>:
+                </p>
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        interface RpcServer : CoroutineScope
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        interface RpcServer
+                    </code-block>
+                </compare>
+            </li>
+            <li>
+                <p>
+                    <code>RpcServer.registerService</code> <code>factory</code> parameter changes type
+                    from <code>(CoroutineContext) -> Service</code> to <code>() -> Service</code>:
+                </p>
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        interface RpcServer {
+                            fun &lt;@Rpc Service : Any&gt; registerService(
+                                serviceKClass: KClass&lt;Service&gt;,
+                                serviceFactory: (CoroutineContext) -&gt; Service,
+                            )
+                        }
+
+                        inline fun &lt;@Rpc reified Service : Any&gt; RpcServer.registerService(
+                            noinline serviceFactory: (CoroutineContext) -&gt; Service,
+                        ) {
+                            registerService(Service::class, serviceFactory)
+                        }
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        interface RpcServer {
+                            fun &lt;@Rpc Service : Any&gt; registerService(
+                                serviceKClass: KClass&lt;Service&gt;,
+                                serviceFactory: () -&gt; Service,
+                            )
+                        }
+
+                        inline fun &lt;@Rpc reified Service : Any&gt; RpcServer.registerService(
+                            noinline serviceFactory: () -&gt; Service,
+                        ) {
+                            registerService(Service::class, serviceFactory)
+                        }
+                    </code-block>
+                </compare>
+            </li>
+            <li>
+                <p>
+                    <code>RpcServer.registerService</code> lost its <code>CoroutineContext</code> parameter:
+                </p>
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        interface RpcServer
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        interface RpcServer {
+                            fun &lt;@Rpc Service : Any&gt; deregisterService(
+                                serviceKClass: KClass&lt;Service&gt;,
+                            )
+                        }
+                    </code-block>
+                </compare>
+            </li>
+            <li>
+                <p>
+                    For Ktor, <code>HttpClient.rpc</code> extension function is now non-suspendable.
+                </p>
+            </li>
+            <li>
+                <code>KtorRpcClient.webSocketSession</code> is now wrapped in Deferred:
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        interface KtorRpcClient : RpcClient {
+                            val webSocketSession: WebSocketSession
+                        }
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        interface KtorRpcClient : RpcClient {
+                            val webSocketSession: Deferred&lt;WebSocketSession&gt;
+                        }
+                    </code-block>
+                </compare>
+            </li>
+            <li>
+                <p>
+                    <code>KrpcClient</code> abstract class has two new abstract methods:
+                    <code>initializeConfig</code> and <code>initializeTransport</code>.
+                    They can be used to delay transport initialization until the first RPC call.
+                </p>
+                <p>
+                    To mimic old behavior, <code>InitializedKrpcClient</code> can be used:
+                </p>
+                <compare type="top-bottom">
+                    <code-block lang="Kotlin">
+                        class MyClient(
+                            config: KrpcConfig,
+                            transport: KrpcTransport,
+                        ) : KrpcClient(config, transport)
+                    </code-block>
+                    <code-block lang="Kotlin">
+                        class MyClient(
+                            config: KrpcConfig,
+                            transport: KrpcTransport,
+                        ) : InitializedKrpcClient(transport, config)
+                    </code-block>
+                </compare>
+                <note>
+                    Notice that the parameter order is reversed in new <code>InitializedKrpcClient</code>.
+                </note>
+            </li>
+        </list>
+    </chapter>
+
+    <chapter title="API removals" id="api-removals">
+        <p>
+            The following APIs are removed:
+        </p>
+        <list>
+            <li><code>kotlinx.rpc.RpcClient.callAsync</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.RpcClient.provideStubContext</code></li>
+
+            <li><code>kotlinx.rpc.registerPlainFlowField</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.registerSharedFlowField</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.registerStateFlowField</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.awaitFieldInitialization</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.UninitializedRpcFieldException</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.UninitializedRPCFieldException</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.RpcEagerField</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.RPCCall</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.RPCClient</code> - previously deprecated alias</li>
+
+            <li><code>kotlinx.rpc.descriptor.RpcInvokator.Field</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.descriptor.RpcServiceDescriptor.getFields</code> - previously deprecated</li>
+
+            <li><code>kotlinx.rpc.krpc.StreamScope</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.krpc.streamScoped</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.krpc.withStreamScope</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.krpc.invokeOnStreamScopeCompletion</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.krpc.KrpcConfigBuilder.SharedFlowParametersBuilder</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.krpc.KrpcConfigBuilder.sharedFlowParameters</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.krpc.KrpcConfig.sharedFlowBuilder</code> - previously deprecated</li>
+            <li><code>kotlinx.rpc.krpc.RPCTransport</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.RPCTransportMessage</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.RPCConfigBuilder</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.client.KRPCClient</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.server.RPCServer</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.server.KRPCServer</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.serialization.RPCSerialFormat</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.serialization.RPCSerialFormatBuilder</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.serialization.RPCSerialFormatConfiguration</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.ktor.client.RPC</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.ktor.client.installRPC</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.ktor.server.RPC</code> - previously deprecated alias</li>
+            <li><code>kotlinx.rpc.krpc.ktor.server.RPCRoute</code> - previously deprecated alias</li>
+        </list>
+    </chapter>
+
+    <chapter title="Deprecations" id="deprecations">
+        <list>
+            <li>
+                <p>
+                    Gradle's <code>rpc.strict</code> extension is deprecated with an error.
+                    Strict mode is now enforced and can't be disabled.
+                    See <a href="strict-mode.topic"/> for detailed migrations.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <code>RemoteService</code> is deprecated with error;
+                    services are no longer having this interface added during the compilation.
+                    See <a href="0-8-0.topic#behavioral-changes"/> for services' lifetime information.
+                </p>
+            </li>
+        </list>
+    </chapter>
+
+    <chapter title="Other changes" id="other-changes">
+        <list>
+            <li>
+                <p>
+                    <code>MISSING_RPC_ANNOTATION</code> compiler inspection is removed.
+                </p>
+            </li>
+            <li>
+                <p>
+                    ABI incompatible change: <code>KrpcTransport.receiveCatching</code> is now an extension function.
+                </p>
+            </li>
+            <li>
+                <p>
+                    The following compiler plugin options are removed:
+                </p>
+                <list>
+                    <li><code>strict-stateFlow</code></li>
+                    <li><code>strict-sharedFlow</code></li>
+                    <li><code>strict-nested-flow</code></li>
+                    <li><code>strict-stream-scope</code></li>
+                    <li><code>strict-suspending-server-streaming</code></li>
+                    <li><code>strict-not-top-level-server-flow</code></li>
+                    <li><code>strict-fields</code></li>
+                </list>
+            </li>
+        </list>
+    </chapter>
+</topic>

--- a/docs/pages/kotlinx-rpc/topics/annotation-type-safety.topic
+++ b/docs/pages/kotlinx-rpc/topics/annotation-type-safety.topic
@@ -29,7 +29,7 @@
     </p>
     <code-block lang="Kotlin">
         @Rpc
-        interface MyService : RemoteService
+        interface MyService
 
         class MyServiceImpl : MyService
 
@@ -50,12 +50,31 @@
 
             // T is resolved to MyService,
             // but 'body' returns MyServiceImpl
-            registerService&lt;MyService&gt; { ctx -> MyServiceImpl(ctx) }
+            registerService&lt;MyService&gt; { MyServiceImpl() }
 
             // Error: T is resolved to MyServiceImpl
-            registerService { ctx -> MyServiceImpl(ctx) }
+            registerService { MyServiceImpl() }
         </code-block>
     </note>
+    <p>
+        Annotation type-safety can be enforced recursively:
+    </p>
+    <code-block lang="Kotlin">
+        @Rpc
+        annotation class Grpc
+
+        @Grpc
+        interface MyGrpcService
+
+        fun &lt;@Rpc T&gt; acceptAnyRpcType()
+        fun &lt;@Grpc T&gt; acceptOnlyGrpcType()
+
+        acceptAnyRpcType&lt;MyService&gt;() // OK
+        acceptAnyRpcType&lt;MyGrpcService&gt;() // OK
+
+        acceptOnlyGrpcType&lt;MyService&gt;() // Compiler time error
+        acceptOnlyGrpcType&lt;MyGrpcService&gt;() // OK
+    </code-block>
 
     <warning>
         This feature is highly experimental and may lead to unexpected behaviour. If you encounter any issues,

--- a/docs/pages/kotlinx-rpc/topics/configuration.topic
+++ b/docs/pages/kotlinx-rpc/topics/configuration.topic
@@ -8,97 +8,78 @@
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        title="Configuration" id="configuration">
-     <p><code>KrpcConfig</code> is a class used to configure <code>KrpcClient</code> and <code>KrpcServer</code>
-            (not to be confused with <code>KrpcClient</code> and <code>KrpcServer</code>).
-            It has two children: <code>KrpcConfig.Client</code> and <code>KrpcConfig.Server</code>.
-            <code>Client</code> and <code>Server</code> may have shared properties as well as distinct ones.
-            To create instances of these configurations, DSL builders are provided
-            (<code>KrpcConfigBuilder.Client</code> class with <code>rpcClientConfig</code> function
-            and <code>KrpcConfigBuilder.Server</code> class with <code>rpcServerConfig</code> function respectively):
+    <p>
+        <code>KrpcConfig</code> is a class used to configure <code>KrpcClient</code> and <code>KrpcServer</code>
+        (not to be confused with <code>RpcClient</code> and <code>RpcServer</code>).
+    </p>
+    <p>
+        It has two children: <code>KrpcConfig.Client</code> and <code>KrpcConfig.Server</code>.
+        <code>Client</code> and <code>Server</code> may have shared properties as well as distinct ones.
+        To create instances of these configurations, DSL builders are provided:
+    </p>
+    <list>
+        <li>
+            <code>rpcClientConfig</code>
+        </li>
+        <li>
+            <code>rpcServerConfig</code>
+        </li>
+    </list>
+
+    <code-block lang="kotlin">
+        val config: KrpcConfig.Client = rpcClientConfig { // same for KrpcConfig.Server with rpcServerConfig
+            waitForServices = true // default parameter
+        }
+    </code-block>
+    <p>
+        The following configuration options are available:
+    </p>
+    <chapter id="serialization-dsl">
+        <title>
+            <code>serialization</code> DSL
+        </title>
+        <p>
+            This parameter defines how serialization should work in RPC services
+            and is present in both client and server configurations.
+        </p>
+        <p>
+            The serialization process is used to encode and decode data in RPC requests,
+            so that the data can be transferred through the network.
+        </p>
+        <p>
+            Currently only <code>StringFormat</code> and <code>BinaryFormat</code> from
+            <a href="https://github.com/Kotlin/kotlinx.serialization">kotlinx.serialization</a> are supported,
+            and by default you can choose from Json, Protobuf or Cbor formats:
         </p>
 
         <code-block lang="kotlin">
-            val config: KrpcConfig.Client = rpcClientConfig { // same for KrpcConfig.Server with rpcServerConfig
-                waitForServices = true // default parameter
+            rpcClientConfig {
+                serialization {
+                    json { /* this: JsonBuilder from kotlinx.serialization */ }
+                    cbor { /* this: CborBuilder from kotlinx.serialization */ }
+                    protobuf { /* this: ProtobufBuilder from kotlinx.serialization */ }
+                }
             }
         </code-block>
-        <p>The following configuration options are available:</p>
-        <chapter id="serialization-dsl">
-            <title>
-                <code>serialization</code> DSL
-            </title>
-            <p>This parameter defines how serialization should work in RPC services
-                and is present in both client and server configurations.</p>
-            <p>The serialization process is used to encode and decode data in RPC requests,
-                so that the data can be transferred through the network.</p>
-            <p>Currently only <code>StringFormat</code> and <code>BinaryFormat</code> from
-                <a href="https://github.com/Kotlin/kotlinx.serialization">kotlinx.serialization</a> are supported,
-                and by default you can choose from Json, Protobuf or Cbor formats:</p>
-
-            <code-block lang="kotlin">
-                rpcClientConfig {
-                    serialization {
-                        json { /* this: JsonBuilder from kotlinx.serialization */ }
-                        cbor { /* this: CborBuilder from kotlinx.serialization */ }
-                        protobuf { /* this: ProtobufBuilder from kotlinx.serialization */ }
-                    }
-                }
-            </code-block>
-            <p>Only last defined format will be used to serialize requests.
-                If no format is specified, the error will be thrown.
-                You can also define a custom format.</p>
-        </chapter>
-        <chapter id="sharedflowparameters-dsl">
-            <title>
-                <code>sharedFlowParameters</code> DSL
-            </title>
-
-            <warning>
-                These parameters are deprecated since <code>0.5.0</code>. For more information,
-                see the <a href="0-5-0.topic">migration guide</a>.
-            </warning>
-
-            <code-block lang="kotlin">
-                rpcClientConfig {
-                    sharedFlowParameters {
-                        replay = 1 // default parameter
-                        extraBufferCapacity = 10 // default parameter
-                        onBufferOverflow = BufferOverflow.SUSPEND // default parameter
-                    }
-                }
-            </code-block>
-            <p>This parameter is needed to decode <code>SharedFlow</code> parameters received from a peer.
-                <code>MutableSharedFlow</code>, the default function to create a <code>SharedFlow</code> instance,
-                has the following signature:</p>
-
-            <code-block lang="kotlin">
-                fun &lt;T&gt; MutableSharedFlow(
-                    replay: Int = 0,
-                    extraBufferCapacity: Int = 0,
-                    onBufferOverflow: BufferOverflow = BufferOverflow.SUSPEND
-                ): MutableSharedFlow&lt;T&gt; { /* ... */
-                }
-            </code-block>
-            <p>It creates a <code>SharedFlowImpl</code> class that contains these parameters as properties,
-                but this class in internal in <code>kotlinx.coroutines</code> and neither <code>SharedFlow</code>,
-                nor <code>MutableShatedFlow</code> interfaces define these properties,
-                which makes it impossible (at least for now) to send these properties from one endpoint to another.
-                But instances of these flows when deserialized should be created somehow,
-                so to overcome this - configuration parameter is created.
-                Configuration builder allows defining these parameters
-                and produces a builder function that is then placed into the <code>KrpcConfig</code>.</p>
-        </chapter>
-        <chapter id="waitforservices-dsl">
-            <title>
-                <code>waitForServices</code> DSL
-            </title>
-            <p><code>waitForServices</code> parameter is available for both client and server.
-                It specifies the behavior for an endpoint in situations
-                when the message for a service is received,
-                but the service is not present in <code>KrpcClient</code> or <code>KrpcServer</code>.
-                If set to <code>true</code>, the message will be stored in memory,
-                otherwise, the error will be sent to a peer endpoint,
-                saying that the message was not handled.
-                Default value is <code>true</code>.</p>
-        </chapter>
+        <p>
+            Only last defined format will be used to serialize requests.
+            If no format is specified, a runtime error will be thrown.
+            You can also define a custom format.
+        </p>
+    </chapter>
+    <chapter id="waitforservices-dsl">
+        <title>
+            <code>waitForServices</code> DSL
+        </title>
+        <p>
+            <code>waitForServices</code> parameter is available for both client and server.
+            It specifies the behavior for an endpoint in situations
+            when the message for a service is received,
+            but the service is not present in <code>KrpcClient</code> or <code>KrpcServer</code>.
+            If set to <code>true</code>, the message will be stored in memory,
+            otherwise, the error will be sent to a peer endpoint,
+            saying that the message was not handled.
+            Default value is <code>true</code>.
+        </p>
+    </chapter>
 </topic>

--- a/docs/pages/kotlinx-rpc/topics/features.topic
+++ b/docs/pages/kotlinx-rpc/topics/features.topic
@@ -24,7 +24,7 @@
             )
 
             @Rpc
-            interface MyService : RemoteService {
+            interface MyService {
                 fun sendStream(stream: Flow&lt;Int&gt;): Flow&lt;String&gt;
 
                 suspend fun streamRequest(request: StreamRequest)
@@ -44,7 +44,7 @@
             )
 
             @Rpc
-            interface MyService : RemoteService {
+            interface MyService {
                 fun serverStream(): Flow&lt;String&gt; // ok
                 suspend fun serverStream(): Flow&lt;String&gt; // not ok
                 suspend fun serverStream(): StreamResult // not ok
@@ -52,7 +52,7 @@
         </code-block>
 
         <note>
-            Note that flows that are declared in classes (like in <code>StreamResult</code>) require a
+            Note that flows that are declared in classes (like in <code>StreamRequest</code>) require a
             <a href="https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#contextual-serialization">Contextual</a>
             annotation.
         </note>

--- a/docs/pages/kotlinx-rpc/topics/krpc-client.topic
+++ b/docs/pages/kotlinx-rpc/topics/krpc-client.topic
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
+<!DOCTYPE topic
+        SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Client" id="krpc-client">
+
+    <chapter title="KrpcClient" id="krpc-client">
+        <p>
+            <code>KrpcClient</code> is an abstract class that implements <code>RpcClient</code> and kRPC protocol
+            logic.
+        </p>
+        <chapter title="Initialization" id="initialization">
+            <p>
+                The client comes in two forms:
+            </p>
+            <list>
+                <li>
+                    <code>KrpcClient</code>
+                </li>
+                <li>
+                    <code>InitializedKrpcClient</code>
+                </li>
+            </list>
+            <p>
+                The only difference between them is that <code>KrpcClient</code> allows to delay the initialization
+                of the transport until the first RPC request is sent.
+                <code>InitializedKrpcClient</code> is initialized right away with a ready <code>KrpcTransport</code>
+                instance.
+            </p>
+        </chapter>
+        <chapter title="Transport" id="transport">
+            <p>
+                The only thing required to be implemented is the transporting of the raw data.
+                Abstract transport is represented by <code>KrpcTransport</code> interface.
+            </p>
+            <p>
+                To implement your own <code>KrpcTransport</code>
+                you need to be able to transfer strings and/or raw bytes (Kotlin's <code>ByteArray</code>).
+                Additionally, the library will provide you with <a href="transport.topic">integrations with different
+                libraries</a> that are used to work with the network.
+            </p>
+
+            <p>
+                See below an example usage of kRPC with a custom transport:
+            </p>
+
+            <code-block lang="kotlin">
+                class MySimpleRpcTransport : KrpcTransport {
+                    val outChannel = Channel&lt;KrpcTransportMessage&gt;()
+                    val inChannel = Channel&lt;KrpcTransportMessage&gt;()
+
+                    override val coroutineContext: CoroutineContext = Job()
+
+                    override suspend fun send(message: KrpcTransportMessage) {
+                        outChannel.send(message)
+                    }
+
+                    override suspend fun receive(): KrpcTransportMessage {
+                        return inChannel.receive()
+                    }
+                }
+
+                class MySimpleRpcClient : KrpcClient(rpcClientConfig(), MySimpleRpcTransport())
+
+                val client = MySimpleRpcClient()
+                val service: MyService = client.withService&lt;MyService&gt;()
+            </code-block>
+        </chapter>
+    </chapter>
+</topic>

--- a/docs/pages/kotlinx-rpc/topics/krpc-ktor.topic
+++ b/docs/pages/kotlinx-rpc/topics/krpc-ktor.topic
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
+<!DOCTYPE topic
+        SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Ktor" id="krpc-ktor">
+
+    <p>
+        The <code>kotlinx.rpc</code> library provides integration with the <a href="https://ktor.io">Ktor
+        framework</a>.
+        This includes both server and client APIs.
+        Under the hood, the library uses <a href="https://ktor.io/docs/websocket.html">WebSocket</a> plugin
+        to create a <code>KrpcTransport</code> and send and receive messages through it.
+    </p>
+    <chapter title="Client" id="client">
+        <p>
+            <code>kotlinx.rpc</code> provides a way to plug-in into existing Ktor clients with your RPC services.
+            To do that, the following DSL can be used:
+        </p>
+
+        <code-block lang="kotlin">
+            val ktorClient = HttpClient {
+                installKrpc {
+                    waitForServices = true
+                }
+            }
+
+            val rpcClient: KtorKrpcClient =
+                ktorClient.rpc(&quot;ws://localhost:4242/services&quot;) {
+                    rpcConfig {
+                        waitForServices = false
+                    }
+                }
+
+            // get an RPC service
+            val myService: MyService = rpcClient.withService&lt;MyService&gt;()
+        </code-block>
+        <note>
+            Note that in this example, only the latter defined <code>KrpcConfig</code> will be used.
+        </note>
+    </chapter>
+    <chapter title="Server" id="server">
+        <p>
+            <code>kotlinx.rpc</code> provides a way to plug-in into existing server routing with your RPC
+            services.
+            To do that, the following DSL can be used:
+        </p>
+
+        <code-block lang="kotlin">
+            fun Application.module() {
+                install(Krpc) {
+                    waitForServices = true
+                }
+
+                routing {
+                    rpc(&quot;/services&quot;) {
+                        rpcConfig {
+                            waitForServices = false
+                        }
+
+                        registerService&lt;MyService&gt; { MyServiceImpl() }
+                        registerService&lt;MyOtherService&gt; { MyOtherServiceImpl() }
+                        // more services if needed
+                    }
+                }
+            }
+        </code-block>
+    </chapter>
+    <chapter title="Ktor application example" id="ktor-application-example">
+        <p>
+            An example code for a Ktor web application may look like this:
+        </p>
+
+        <p>
+            In common code, shared classes and services are defined:
+        </p>
+        <code-block lang="kotlin">
+            @Serializable
+            data class ProcessedImage(
+                val url: String,
+                val numberOfCats: Int,
+                val numberOfDogs: Int
+            )
+
+            @Rpc
+            interface ImageService : RemoteService {
+                suspend fun processImage(url: String): ProcessedImage
+            }
+        </code-block>
+        <p>
+            In client code, create an HTTP client and access the service on a the desired route:
+        </p>
+        <code-block lang="kotlin">
+            val client = HttpClient {
+                installKrpc {
+                    serialization {
+                        json()
+                    }
+                }
+            }
+
+            val service = client
+                .rpc(&quot;/image-recognizer&quot;)
+                .withService&lt;ImageService&gt;()
+
+            service.processImage(url = &quot;https://catsanddogs.com/cats/1&quot;)
+        </code-block>
+        <p>
+            In server code, provide an implementation of the <code>ImageService</code> and register it on a route:
+        </p>
+        <code-block lang="kotlin">
+            class ImageServiceImpl : ImageService {
+                // some user defined classes
+                private val downloader = Downloader()
+                private val recognizer = AnimalRecognizer()
+
+                override suspend fun processImage(url: Srting): ProcessedImage {
+                    val image = downloader.loadImage(url)
+                    return ProcessedImage(
+                        url,
+                        recognizer.getNumberOfCatsOnImage(image),
+                        recognizer.getNumberOfDogsOnImage(image)
+                    )
+                }
+            }
+
+            fun main() {
+                embeddedServer(Netty, port = 8080) {
+                    install(Krpc) {
+                        serialization {
+                            json()
+                        }
+                    }
+
+                    routing {
+                        rpc(&quot;/image-recognizer&quot;) {
+                            registerService&lt;ImageService&gt; { ImageServiceImpl() }
+                        }
+                    }
+                }.start(wait = true)
+            }
+        </code-block>
+        <p>
+            For more details and complete examples, see the <a href="%repo-tree-path%/samples">code samples</a>.
+        </p>
+    </chapter>
+</topic>

--- a/docs/pages/kotlinx-rpc/topics/krpc-server.topic
+++ b/docs/pages/kotlinx-rpc/topics/krpc-server.topic
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
+<!DOCTYPE topic
+        SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Server" id="krpc-server">
+
+    <chapter title="KrpcServer" id="krpc-server">
+        <p>
+            <code>KrpcServer</code> abstract class implements <code>RpcServer</code>
+            and all the logic for processing RPC messages
+            and again leaves <code>KrpcTransport</code> methods for the specific implementations
+            (see <a href="transport.topic">transports</a>).
+        </p>
+
+        <p>
+            Example usage with custom transport:
+        </p>
+
+        <code-block lang="kotlin">
+            // same MySimpleRpcTransport as in the client example above
+            class MySimpleRpcServer : KrpcServer(rpcServerConfig(), MySimpleRpcTransport())
+
+            val server = MySimpleRpcServer()
+            server.registerService&lt;MyService&gt; { MyServiceImpl() }
+        </code-block>
+        <note>
+            <p>
+                Note that here we pass explicit <code>MyService</code> type parameter to the <code>registerService</code>
+                method.
+                You must explicitly specify the type of the service interface here,
+                otherwise the server service will not be found.
+            </p>
+            <p>
+                See <a href="annotation-type-safety.topic"/> for more details.
+            </p>
+        </note>
+    </chapter>
+</topic>

--- a/docs/pages/kotlinx-rpc/topics/plugins.topic
+++ b/docs/pages/kotlinx-rpc/topics/plugins.topic
@@ -9,22 +9,32 @@
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        title="Gradle plugin" id="plugins">
     <p>
-        The <code>kotlinx.rpc</code> library offers a <a href="https://docs.gradle.org/current/userguide/plugins.html">Gradle plugin</a>
-        that simplifies project configuration by automating repetitive tasks: `org.jetbrains.kotlinx.rpc.plugin`
+        The <code>kotlinx.rpc</code> library offers a <a href="https://docs.gradle.org/current/userguide/plugins.html">Gradle
+        plugin</a>
+        that simplifies project configuration by automating repetitive tasks and configuring code generation.
     </p>
 
-    <chapter title="org.jetbrains.kotlinx.rpc.plugin" id="rpc-plugin">
-        <p>
-            The <code>org.jetbrains.kotlinx.rpc.plugin</code> plugin sets up code generation configurations.
-        </p>
-        <code-block lang="kotlin">
-            plugins {
-                kotlin("jvm") version "%kotlin-version%"
-                id("org.jetbrains.kotlinx.rpc.plugin") version "%kotlinx-rpc-version%"
-            }
-        </code-block>
-        <p>
-            For multi-project setups you must add the plugin to all modules where services are declared or used.
-        </p>
-    </chapter>
+    <code-block lang="kotlin">
+        plugins {
+            kotlin("jvm") version "%kotlin-version%"
+            id("org.jetbrains.kotlinx.rpc.plugin") version "%kotlinx-rpc-version%"
+        }
+    </code-block>
+    <note>
+        For multi-project setups you must add the plugin to all modules where services are declared or used.
+    </note>
+
+    Plugin provides an <code>rpc</code> extension:
+    <code-block lang="kotlin">
+        rpc {
+            annotationTypeSafetyEnabled = true
+        }
+    </code-block>
+    <p>Options:</p>
+    <list>
+        <li>
+            <code>annotationTypeSafetyEnabled</code> - whether to enable type safety checks for annotations.
+            See <a href="annotation-type-safety.topic"/>.
+        </li>
+    </list>
 </topic>

--- a/docs/pages/kotlinx-rpc/topics/rpc-clients.topic
+++ b/docs/pages/kotlinx-rpc/topics/rpc-clients.topic
@@ -8,22 +8,22 @@
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        title="RPC Clients" id="rpc-clients">
-     <p>
-         For each declared service, <code>kotlinx.rpc</code> will generate an actual client implementation
-         that can be used to send requests to a server. You must not use generated code directly. Instead,
-         you should use the APIs that will provide you with the instance of your interface. This generated instance is
-         commonly called a stub in RPC.
-     </p>
+    <p>
+        For each declared service, <code>kotlinx.rpc</code> will generate an actual client implementation
+        that can be used to send requests to a server. This generated instance is
+        commonly called a stub in RPC.
+    </p>
     <tip>
-        Note that we talk about generated stubs (service implementations on the client side)
-            that must not be called directly.
-            There might be a case when the generated code is not a stub, but a service declaration itself
-            (for example, the services generated from
-            <a href="https://grpc.io/docs/what-is-grpc/core-concepts/#service-definition">.proto files</a>).
-            In this case, you can use the generated code.
+        Note that we talk about generated stubs (service interface implementations on the client side)
+        that must not be called directly.
+        There might be a case when the generated code is not a stub, but a service declaration itself
+        (for example, the services generated from
+        <a href="https://grpc.io/docs/what-is-grpc/core-concepts/#service-definition">.proto files</a>).
+        In this case, you can use the generated code.
+        See <a href="grpc-services.topic"/>.
     </tip>
     <p>
-        To be able to obtain an instance of your service, you need to have an <code>RpcClient</code>.
+        To be able to get an instance of your service, you need to have an <code>RpcClient</code>.
         You can call the <code>withService()</code> method on your client:
     </p>
     <code-block lang="kotlin">
@@ -31,6 +31,9 @@
 
         val myService: MyService = rpcClient.withService&lt;MyService&gt;()
     </code-block>
+    <tip>
+        Note that the type parameter of <code>withService</code> must be annotated with <code>@Rpc</code> annotation.
+    </tip>
     <p>
         Now you have your client instance that is able to send RPC requests to your server.
         <code>RpcClient</code> can have multiple services that communicate through it.
@@ -42,42 +45,7 @@
     <p>
         You can provide your own implementations of the <code>RpcClient</code>.
         But <code>kotlinx.rpc</code> already provides one out-of-the-box solution that uses
-        in-house RPC protocol (called kRPC), and we are working on supporting more protocols
-        (with priority on gRPC).
+        in-house RPC protocol (called <a href="krpc-client.topic">kRPC</a>), and we are working on supporting more
+        protocols (see <a href="grpc-configuration.topic"/>).
     </p>
-
-    <chapter title="KrpcClient — RpcClient for kRPC Protocol" id="krpcclient-rpcclient-for-krpc-protocol">
-        <p><code>KrpcClient</code> is an abstract class that implements <code>RpcClient</code> and kRPC protocol
-            logic.
-            The only thing required to be implemented is the transporting of the raw data.
-            Abstract transport is represented by <code>KrpcTransport</code> interface.</p>
-        <p>To implement your own <code>KrpcTransport</code>
-            you need to be able to transfer strings and/or raw bytes (Kotlin's <code>ByteArray</code>).
-            Additionally, the library will provide you with <a href="transport.topic">integrations with different
-            libraries</a> that are used to work with the network.
-        </p>
-        <p>See below an example usage of kRPC with a custom transport:</p>
-
-        <code-block lang="kotlin">
-            class MySimpleRpcTransport : KrpcTransport {
-                val outChannel = Channel&lt;KrpcTransportMessage&gt;()
-                val inChannel = Channel&lt;KrpcTransportMessage&gt;()
-
-                override val coroutineContext: CoroutineContext = Job()
-
-                override suspend fun send(message: KrpcTransportMessage) {
-                    outChannel.send(message)
-                }
-
-                override suspend fun receive(): KrpcTransportMessage {
-                    return inChannel.receive()
-                }
-            }
-
-            class MySimpleRpcClient : KrpcClient(rpcClientConfig(), MySimpleRpcTransport())
-
-            val client = MySimpleRpcClient()
-            val service: MyService = client.withService&lt;MyService&gt;()
-        </code-block>
-    </chapter>
 </topic>

--- a/docs/pages/kotlinx-rpc/topics/rpc-servers.topic
+++ b/docs/pages/kotlinx-rpc/topics/rpc-servers.topic
@@ -8,51 +8,39 @@
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        title="RPC Servers" id="rpc-servers">
-        <p><code>RpcServer</code> interface represents an RPC server,
-            that accepts RPC messages and may contain multiple services to route to.
-            <code>RpcServer</code> uses data from incoming RPC messages
-            and routes it to the designated service and sends service's response back to the corresponding client.
-        </p>
-        <p>You can provide your own <code>RpcServer</code> implementation
-            or use the one provided out of the box.
-            Note that client and server must use the same RPC protocol to communicate.</p>
-        <p>Use <code>registerService</code> function to add your own factory for implemented RPC services.
-            This factory function should accept <code>CoroutineContext</code> argument and pass it to the service,
-            which should use it to override <code>coroutineContext</code> property of parent interface.
-            This ensures proper application lifetime for your services.</p>
-        <p>Example usage:</p>
+    <p>
+        <code>RpcServer</code> interface represents an RPC server,
+        that accepts RPC messages and may contain multiple services to route to.
+        <code>RpcServer</code> uses data from incoming RPC messages
+        and routes it to the designated service and sends service's response back to the corresponding client.
+    </p>
+    <p>
+        You can provide your own <code>RpcServer</code> implementation
+        or use the one provided out of the box.
+        Note that client and server must use the same RPC protocol to communicate.
+    </p>
+    <p>
+        Use <code>registerService</code> function to add your own factory for implemented RPC services:
+    </p>
 
-        <code-block lang="kotlin">
-            val server: RpcServer
+    <code-block lang="kotlin">
+        val server: RpcServer
 
-            server.registerService&lt;MyService&gt; { ctx: CoroutineContext -&gt; MyServiceImpl(ctx) }
-        </code-block>
-        <p>The <code>registerService</code> function requires the explicit type of the declared RPC service.
+        server.registerService&lt;MyService&gt; { MyServiceImpl() }
+    </code-block>
+    <note>
+        <p>
+            The <code>registerService</code> function requires the explicit type of the declared RPC service.
             That means that the code will not work if you provide it with the type of the service implementation:
         </p>
 
         <code-block lang="kotlin">
             // Wrong! Should be `MyService` as type argument
-            server.registerService&lt;MyServiceImpl&gt; { ctx: CoroutineContext -&gt; MyServiceImpl(ctx) }
+            server.registerService&lt;MyServiceImpl&gt; { MyServiceImpl() }
         </code-block>
 
-    <chapter title="KrpcServer — RpcServer for kRPC Protocol" id="krpcserver-rpcserver-for-krpc-protocol">
-        <p><code>KrpcServer</code> abstract class implements <code>RpcServer</code>
-            and all the logic for processing RPC messages
-            and again leaves <code>RpcTransport</code> methods for the specific implementations
-            (see <a href="transport.topic">transports</a>).</p>
-        <p>Example usage with custom transport:</p>
-
-        <code-block lang="kotlin">
-            // same MySimpleRpcTransport as in the client example above
-            class MySimpleRpcServer : KrpcServer(rpcServerConfig(), MySimpleRpcTransport())
-
-            val server = MySimpleRpcServer()
-            server.registerService&lt;MyService&gt; { ctx -&gt; MyServiceImpl(ctx) }
-        </code-block>
-        <p>Note that here we pass explicit <code>MyService</code> type parameter to the <code>registerService</code>
-            method.
-            You must explicitly specify the type of the service interface here,
-            otherwise the server service will not be found.</p>
-    </chapter>
+        <p>
+            See <a href="annotation-type-safety.topic"/> for more details.
+        </p>
+    </note>
 </topic>

--- a/docs/pages/kotlinx-rpc/topics/services.topic
+++ b/docs/pages/kotlinx-rpc/topics/services.topic
@@ -9,45 +9,87 @@
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        title="Services" id="services">
     <p>Services are the centerpieces of the library.
-                A service is an interface annotated with the <code>@Rpc</code> annotation,
-                and contains a set of methods and fields
-                that can be executed or accessed remotely.
-                Additionally, a service always has a type of <code>RemoteService</code>,
-                which can be specified explicitly, or assumed implicitly by the compiler.
+        A service is an interface annotated with the <code>@Rpc</code> annotation,
+        and contains a set of methods that can be executed remotely.
     </p>
-    <note>
-        Note that implicit typing is currently not supported in IDEs, but is a work in progress.
-    </note>
     <p>A simple service can be declared as follows:</p>
 
-            <code-block lang="kotlin">
-                @Rpc
-                interface MyService : RemoteService {
-                    suspend fun hello(name: String): String
-                }
-            </code-block>
-            <p>Here we declare the method <code>hello</code>, that accepts one argument and returns a string.
-                The method is marked with a <code>suspend</code> modifier, which means that we use
-                <a href="https://kotlinlang.org/docs/coroutines-guide.html">coroutines</a>
-                to send RPC requests.
-                Note that for now, only <code>suspend</code> methods are supported in service interfaces.</p>
-            <tip>
-                <p>Depending on the type of the protocol you use, services may support different features and
-                    declarations.</p>
-            </tip>
-            <p>To be able to use a service both in client and server code,
-                the interface should be placed in the common module
-                — kudos to Kotlin Multiplatform.</p>
-            <p>Now we can implement the service, so server knows how to process incoming requests.</p>
-
-            <code-block lang="kotlin">
-                class MyServiceImpl(
-                    override val coroutineContext: CoroutineContext,
-                ) : MyService {
-                    override suspend fun hello(name: String): String {
-                        return &quot;Hello, $name! I'm server!&quot;
-                    }
-                }
-            </code-block>
-            <p>The server will use that implementation to answer the client requests.</p>
+    <code-block lang="kotlin">
+        @Rpc
+        interface MyService {
+            suspend fun hello(name: String): String
+        }
+    </code-block>
+    <p>
+        Here we declare the method <code>hello</code>, that accepts one argument and returns a string.
+        The method is marked with a <code>suspend</code> modifier, which means that we use
+        <a href="https://kotlinlang.org/docs/coroutines-guide.html">coroutines</a>
+        to send RPC requests.
+    </p>
+    <tip>
+        <p>
+            Depending on the type of the protocol you use, services may support different features and
+            declarations.
+        </p>
+    </tip>
+    <p>
+        To be able to use a service both in client and server code,
+        the interface should be placed in the common module
+        — kudos to Kotlin Multiplatform.
+    </p>
+    <p>
+        Now we can implement the service, so the server knows how to process incoming requests.
+    </p>
+    <code-block lang="kotlin">
+        class MyServiceImpl : MyService {
+            override suspend fun hello(name: String): String {
+                return &quot;Hello, $name! I'm server!&quot;
+            }
+        }
+    </code-block>
+    <p>
+        The server will use that implementation to answer the client requests.
+    </p>
+    <chapter title="Streaming" id="streaming">
+        <p>
+            The library supports streaming of data.
+            To declare a streaming method, you need to use the <code>Flow</code> type.
+            For example, to declare a method that returns a stream of integers:
+        </p>
+        <code-block lang="kotlin">
+            @Rpc
+            interface MyService {
+                fun stream(): Flow&lt;Int&gt;
+            }
+        </code-block>
+        <p>
+            Note that the method is not marked with the <code>suspend</code> modifier.
+        </p>
+        <p>
+            You can also pass a <code>Flow</code> as a parameter to the method.
+            For example, to declare a method that accepts a stream of integers:
+        </p>
+        <code-block lang="kotlin">
+            @Rpc
+            interface MyService {
+                suspend fun sendStream(stream: Flow&lt;Int&gt;)
+            }
+        </code-block>
+        <p>
+            Or make streams bidirectional:
+        </p>
+        <code-block lang="kotlin">
+            @Rpc
+            interface MyService {
+                fun bidi(stream: Flow&lt;Int&gt;): Flow&lt;Int&gt;
+            }
+        </code-block>
+        <tip>
+            <p>
+                Note that the function is not <code>suspend</code>
+                only when the return type is a <code>Flow</code>.
+                <code>Flow</code> in parameter list does not affect the function's signature.
+            </p>
+        </tip>
+    </chapter>
 </topic>

--- a/docs/pages/kotlinx-rpc/topics/strict-mode.topic
+++ b/docs/pages/kotlinx-rpc/topics/strict-mode.topic
@@ -10,11 +10,11 @@
        title="Strict mode" id="strict-mode">
 
     <p>
-        Starting with version <code>0.5.0</code>, the library introduces major changes to the service APIs.
-        The following declarations will be gradually restricted:
+        Starting with version <code>0.5.0</code>, the library introduced major changes to the service APIs.
+        The following declarations are now restricted:
     </p>
     <warning>
-        String mode will be enforced in the <code>0.8.0</code> release.
+        Strict mode is enforced irreversibly since <code>0.8.0</code>.
     </warning>
     <chapter title="StateFlow and SharedFlow" id="stateflow-and-sharedflow">
         <p>Deprecation level: <code>ERROR</code></p>
@@ -147,38 +147,5 @@
                 }
             }
         </code-block>
-    </chapter>
-
-    <chapter title="Gradle settings" id="gradle-settings">
-        <p>
-            Deprecation levels are controlled by the Gradle <code>rpc</code> extension:
-        </p>
-        <code-block lang="Kotlin">
-        // build.gradle.kts
-        plugins {
-            id("org.jetbrains.kotlinx.rpc.plugin")
-        }
-
-        rpc {
-            strict {
-                stateFlow = RpcStrictMode.ERROR
-                sharedFlow = RpcStrictMode.ERROR
-                nestedFlow = RpcStrictMode.ERROR
-                notTopLevelServerFlow = RpcStrictMode.ERROR
-                fields = RpcStrictMode.ERROR
-                suspendingServerStreaming = RpcStrictMode.ERROR
-                streamScopedFunctions = RpcStrictMode.ERROR
-            }
-        }
-    </code-block>
-        <p>
-            Modes <code>RpcStrictMode.NONE</code> and <code>RpcStrictMode.WARNING</code> are available.
-        </p>
-
-        <warning>
-            Note that setting <code>RpcStrictMode.NONE</code> should not be done permanently.
-            All deprecated APIs will become errors in the future without an option to suppress them.
-            Consider your migration path in advance.
-        </warning>
     </chapter>
 </topic>

--- a/docs/pages/kotlinx-rpc/topics/transport.topic
+++ b/docs/pages/kotlinx-rpc/topics/transport.topic
@@ -9,143 +9,21 @@
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        title="Transport" id="transport">
 
-        <p>Transport layer exists to abstract from the RPC requests logic and focus on delivering and receiving
-            encoded RPC messages in kRPC Protocol.
-            This layer is represented by <code>KrpcTransport</code> interface.
-            It supports two message formats — string and binary,
-            and depending on which <a href="configuration.topic" anchor="serialization-dsl">serialization</a> format you choose,
-            one or the other will be used.</p>
+    <p>
+        Transport layer exists to abstract from the RPC requests logic and focus on delivering and receiving
+        encoded RPC messages in kRPC Protocol.
+        This layer is represented by the <code>KrpcTransport</code> interface.
+        It supports two message formats — string and binary,
+        and depends on which <a href="configuration.topic" anchor="serialization-dsl">serialization</a> format you
+        choose.
+    </p>
 
-    <chapter title="Ktor transport" id="ktor-transport">
-        <p>The <code>kotlinx.rpc</code> library provides integration with the <a href="https://ktor.io">Ktor
-            framework</a> with the in-house RPC
-            protocol.
-            This includes both server and client APIs.
-            Under the hood, the library uses <a href="https://ktor.io/docs/websocket.html">WebSocket</a> plugin
-            to create a <code>KrpcTransport</code> and send and receive messages through it.</p>
-        <chapter title="Client" id="client">
-            <p><code>kotlinx.rpc</code> provides a way to plug-in into existing Ktor clients with your RPC services.
-                To do that, the following DSL can be used:</p>
-
-            <code-block lang="kotlin">
-                val ktorClient = HttpClient {
-                    installKrpc { // this: KrpcConfigBuilder.Client
-                        waitForServices = true
-                    }
-                }
-
-                val rpcClient: KtorKrpcClient =
-                    ktorClient.rpc(&quot;ws://localhost:4242/services&quot;) { // this: HttpRequestBuilder
-                        rpcConfig { // this: KrpcConfigBuilder.Client
-                            waitForServices = false
-                        }
-                    }
-
-                // access WebSocketSession that created the connection
-                rpcClient.webSocketSession
-
-                // create RPC service
-                val myService: MyService = rpcClient.withService&lt;MyService&gt;()
-            </code-block>
-            <p>Note that in this example, only the latter defined <code>KrpcConfig</code> will be used.</p>
-        </chapter>
-        <chapter title="Server" id="server">
-            <p><code>kotlinx.rpc</code> provides a way to plug-in into existing server routing with your RPC
-                services.
-                To do that, the following DSL can be used:</p>
-
-            <code-block lang="kotlin">
-                fun Application.module() {
-                    install(Krpc) { // this: KrpcConfigBuilder.Server
-                        waitForServices = true
-                    }
-
-                    routing {
-                        rpc(&quot;/services&quot;) { // this KrpcRoute, inherits WebSocketSession
-                            rpcConfig { // this: KrpcConfigBuilder.Server
-                                waitForServices = false
-                            }
-
-                            registerService&lt;MyService&gt; { ctx -&gt; MyServiceImpl(ctx) }
-                            registerService&lt;MyOtherService&gt; { ctx - MyOtherServiceImpl(ctx) }
-                            // etc
-                        }
-                    }
-                }
-            </code-block>
-        </chapter>
-        <chapter title="Ktor application example" id="ktor-application-example">
-            <p>An example code for a Ktor web application may look like this:</p>
-
-            <code-block lang="kotlin">
-                // ### COMMON CODE ###
-                @Serializable
-                data class ProcessedImage(
-                    val url: String,
-                    val numberOfCats: Int,
-                    val numberOfDogs: Int
-                )
-
-                @Rpc
-                interface ImageService : RemoteService {
-                    suspend fun processImage(url: String): ProcessedImage
-                }
-
-                // ### CLIENT CODE ###
-
-                val client = HttpClient {
-                    installKrpc {
-                        serialization {
-                            json()
-                        }
-                    }
-                }
-
-                val service = client.rpc(&quot;/image-recognizer&quot;).withService&lt;ImageService&gt;()
-
-                service.processImage(url = &quot;https://catsanddogs.com/cats/1&quot;)
-
-                // ### SERVER CODE ###
-
-                class ImageServiceImpl(override val coroutineContext: CoroutineContext) : ImageService {
-                    // user defined classes
-                    private val downloader = Downloader()
-                    private val recognizer = AnimalRecognizer()
-
-                    override suspend fun processImage(url: Srting): ProcessedImage {
-                        val image = downloader.loadImage(url)
-                        return ProcessedImage(
-                            url,
-                            recognizer.getNumberOfCatsOnImage(image),
-                            recognizer.getNumberOfDogsOnImage(image)
-                        )
-                    }
-                }
-
-                fun main() {
-                    embeddedServer(Netty, port = 8080) {
-                        install(Krpc) {
-                            serialization {
-                                json()
-                            }
-                        }
-
-                        routing {
-                            rpc(&quot;/image-recognizer&quot;) {
-                                registerService&lt;ImageService&gt; { ctx -&gt; ImageServiceImpl(ctx) }
-                            }
-                        }
-                    }.start(wait = true)
-                }
-            </code-block>
-            <p>For more details and complete examples, see the <a href="%repo-tree-path%/samples">code samples</a>.
-            </p>
-        </chapter>
-    </chapter>
-    <chapter title="Other transports" id="other-transports">
-        <p>Generally, there are no specific guidelines on how RPC should be set up for different transports,
+    <chapter title="Generic transports" id="generic-transports">
+        <p>
+            Generally, there are no specific guidelines on how RPC should be set up for different transports,
             but structures and APIs used to develop integration with Ktor should outline the common approach.
             You can provide your own transport and even your own fully implemented protocols,
-            while the library will take care of code generation.</p>
+            while the library will take care of code generation.
+        </p>
     </chapter>
 </topic>

--- a/docs/pages/kotlinx-rpc/topics/versions.topic
+++ b/docs/pages/kotlinx-rpc/topics/versions.topic
@@ -8,42 +8,47 @@
 <topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
        title="Versions" id="versions">
-        <p>As <code>kotlinx.rpc</code> uses Kotlin compiler plugin,
-            we rely on internal functionality that may change over time with any new Kotlin version.
-            To prevent the library from breaking with an incompatible Kotlin version,
-            we use version prefix for artifacts with code generating functionality.
-        </p>
-        <p>
-            We provide core version updates for all stable versions of
-            <control>the last three</control>
-            major Kotlin releases.
-            So if the last stable Kotlin version is <code>%kotlin-version%</code>, as at the time of writing this guide,
-            the following versions of Kotlin are supported:
-        </p>
-        <list>
-            <li>2.0.0, 2.0.10, 2.0.20, 2.0.21</li>
-            <li>2.1.0, 2.1.10, 2.1.20, 2.1.21</li>
-        </list>
-        <p>
-            Our code generation will support these versions (See more on <a anchor="code-generation-artifacts">code generation artifacts</a>).
-            Runtime artifacts are configured with
-            <a href="https://kotlinlang.org/docs/compatibility-modes.html">
-                <code>language-version</code> and <code>api-version</code> parameters
-            </a>
-            for the oldest supported minor version of Kotlin.
-        </p>
-        <warning>
-            The <code>kotlinx-rpc</code> library is currently <b>not stable</b>.
-            As a result, we cannot guarantee compatibility with all Kotlin versions for our runtime dependencies at this time.
-            However, we are committed to maintaining compatibility as much as possible.
-            It is in our plans to ensure that all runtime dependencies are compatible with all supported Kotlin versions by the time of the stable release.
-        </warning>
-    <chapter title="Project configuration" id="project-configuration">
     <p>
-        To simplify project configuration, both our <a href="plugins.topic">Gradle plugins</a>
-        are able to set proper runtime dependencies versions automatically based
-        on the project's Kotlin version and the Gradle plugin version
-        which is used as a core library version.</p>
+        As <code>kotlinx.rpc</code> uses Kotlin compiler plugin,
+        we rely on internal functionality that may change over time with any new Kotlin version.
+        To prevent the library from breaking with an incompatible Kotlin version,
+        we use version prefix for artifacts with code generating functionality.
+    </p>
+    <p>
+        We provide core version updates for all stable versions of
+        <control>the last three</control>
+        major Kotlin releases.
+        So if the last stable Kotlin version is <code>%kotlin-version%</code>, as at the time of writing this guide,
+        the following versions of Kotlin are supported:
+    </p>
+    <list>
+        <li>2.0.0, 2.0.10, 2.0.20, 2.0.21</li>
+        <li>2.1.0, 2.1.10, 2.1.20, 2.1.21</li>
+    </list>
+    <p>
+        Our code generation will support these versions (See more on <a anchor="code-generation-artifacts">code
+        generation artifacts</a>).
+        Runtime artifacts are configured with
+        <a href="https://kotlinlang.org/docs/compatibility-modes.html">
+            <code>language-version</code> and <code>api-version</code> parameters
+        </a>
+        for the oldest supported minor version of Kotlin.
+    </p>
+    <warning>
+        The <code>kotlinx-rpc</code> library is currently <b>not stable</b>.
+        As a result, we cannot guarantee compatibility with all Kotlin versions for our runtime dependencies at this
+        time.
+        However, we are committed to maintaining compatibility as much as possible.
+        It is in our plans to ensure that all runtime dependencies are compatible with all supported Kotlin versions by
+        the time of the stable release.
+    </warning>
+    <chapter title="Project configuration" id="project-configuration">
+        <p>
+            To simplify project configuration, our <a href="plugins.topic"/>
+            is able to set proper runtime dependencies versions automatically based
+            on the project's Kotlin version and the Gradle plugin version
+            which is used as a core library version.
+        </p>
         <code-block lang="kotlin">
             plugins {
                 // project's Kotlin plugin
@@ -77,6 +82,6 @@
             org.jetbrains.kotlinx:kotlinx-rpc-compiler-plugin-k2:%kotlin-version%-%kotlinx-rpc-version%
             org.jetbrains.kotlinx:kotlinx-rpc-compiler-plugin-backend:%kotlin-version%-%kotlinx-rpc-version%
         </code-block>
-        Such dependencies are managed automatically, and should not be used explicitly.
+        These dependencies are managed automatically, and should not be used explicitly.
     </chapter>
 </topic>

--- a/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorClientDsl.kt
+++ b/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorClientDsl.kt
@@ -28,12 +28,15 @@ public fun HttpRequestBuilder.rpcConfig(configBuilder: KrpcConfigBuilder.Client.
 }
 
 /**
- * Configures [RpcClient] for the following path. Provides means for additional configuration via [block].
+ * Configures [KtorRpcClient] for the following path. Provides means for additional configuration via [block].
  * Note that the [WebSockets] plugin is required for these calls.
  *
  * @param urlString The URL to use for the request.
- * @param block Optional configuration for the
- * @return An instance of [RpcClient] that is configured to send messages to the server.
+ * @param block Optional configuration for the [HttpRequestBuilder].
+ * @return An instance of [KtorRpcClient] that is configured to send messages to the server.
+ * The instance is cold and will establish WebSocket connection on the first request.
+ *
+ * @See [KtorRpcClient]
  */
 public fun HttpClient.rpc(
     urlString: String,
@@ -46,11 +49,14 @@ public fun HttpClient.rpc(
 }
 
 /**
- * Configures [RpcClient] for the following path. Provides means for additional configuration via [block].
+ * Configures [KtorRpcClient] for the following path. Provides means for additional configuration via [block].
  * Note that the [WebSockets] plugin is required for these calls.
  *
- * @param block Optional configuration for the
- * @return An instance of [RpcClient] that is configured to send messages to the server.
+ * @param block Optional configuration for the [HttpRequestBuilder].
+ * @return An instance of [KtorRpcClient] that is configured to send messages to the server.
+ * The instance is cold and will establish WebSocket connection on the first request.
+ *
+ * @See [KtorRpcClient]
  */
 public fun HttpClient.rpc(
     block: HttpRequestBuilder.() -> Unit = {},

--- a/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorRpcClient.kt
+++ b/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorRpcClient.kt
@@ -18,8 +18,14 @@ import kotlinx.rpc.krpc.rpcClientConfig
 /**
  * [RpcClient] implementation for Ktor, containing [webSocketSession] object,
  * that is used to maintain connection.
+ *
+ * Client is cold, meaning the connection will be established on the first request.
+ * [webSocketSession] will be completed when the connection is established.
  */
 public interface KtorRpcClient : RpcClient {
+    /**
+     * Cold [WebSocketSession] object. Instantiated when the connection is established on the first request.
+     */
     public val webSocketSession: Deferred<WebSocketSession>
 }
 

--- a/krpc/krpc-ktor/krpc-ktor-core/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/KtorTransport.kt
+++ b/krpc/krpc-ktor/krpc-ktor-core/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/KtorTransport.kt
@@ -16,7 +16,7 @@ public class KtorTransport(
 ) : KrpcTransport, CoroutineScope by webSocketSession {
 
     /**
-     * Sends a single encoded RPC message over network (or any other medium) to a peer endpoint.
+     * Sends a single encoded RPC message over a network (or any other medium) to a peer endpoint.
      *
      * @param message a message to send. Either of string or binary type.
      */
@@ -33,9 +33,9 @@ public class KtorTransport(
     }
 
     /**
-     * Suspends until next RPC message from a peer endpoint is received and then returns it.
+     * Suspends until the next RPC message from a peer endpoint is received and then returns it.
      *
-     * @return received RPC message.
+     * @return the received RPC message.
      */
     override suspend fun receive(): KrpcTransportMessage {
         return when (val message = webSocketSession.incoming.receive()) {

--- a/krpc/krpc-ktor/krpc-ktor-server/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/server/KrpcRoute.kt
+++ b/krpc/krpc-ktor/krpc-ktor-server/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/server/KrpcRoute.kt
@@ -11,8 +11,8 @@ import kotlinx.rpc.krpc.KrpcConfigBuilder
 import kotlin.reflect.KClass
 
 /**
- * RpcRoute class represents an RPC server that is mounted in Ktor routing.
- * This class provides API to register services and optionally setup configuration.
+ * [KrpcRoute] class represents an RPC server mounted in Ktor routing.
+ * This class provides an API to register services and optionally setup configuration.
  */
 public class KrpcRoute(
     webSocketSession: DefaultWebSocketServerSession
@@ -36,7 +36,7 @@ public class KrpcRoute(
      * Service of any type should be unique on the server, but RpcServer does not specify the actual retention policy.
      *
      * @param Service the exact type of the server to be registered.
-     * For example for service with `MyService` interface and `MyServiceImpl` implementation,
+     * For example, for service with `MyService` interface and `MyServiceImpl` implementation,
      * type `MyService` should be specified explicitly.
      * @param serviceKClass [KClass] of the [Service].
      * @param serviceFactory function that produces the actual implementation of the service that will handle the calls.
@@ -55,7 +55,7 @@ public class KrpcRoute(
      * Service of any type should be unique on the server, but RpcServer does not specify the actual retention policy.
      *
      * @param Service the exact type of the server to be registered.
-     * For example for service with `MyService` interface and `MyServiceImpl` implementation,
+     * For example, for service with `MyService` interface and `MyServiceImpl` implementation,
      * type `MyService` should be specified explicitly.
      * @param serviceFactory function that produces the actual implementation of the service that will handle the calls.
      */

--- a/krpc/krpc-server/src/commonMain/kotlin/kotlinx/rpc/krpc/server/KrpcServer.kt
+++ b/krpc/krpc-server/src/commonMain/kotlin/kotlinx/rpc/krpc/server/KrpcServer.kt
@@ -21,18 +21,11 @@ import kotlin.concurrent.Volatile
 import kotlin.reflect.KClass
 
 /**
- * Default implementation of [RpcServer].
+ * kRPC implementation of the [RpcServer].
  * Takes care of tracking requests and responses,
  * serializing data, tracking streams, processing exceptions, and other protocol responsibilities.
  * Routes resulting messages to the proper registered services.
- * Leaves out the delivery of encoded messages to the specific implementations.
- *
- * A simple example of how this server may be implemented:
- * ```kotlin
- * class MyTransport : KrpcTransport { /*...*/ }
- *
- * class MyServer(config: KrpcConfig.Server): KrpcServer(config, MyTransport())
- * ```
+ * Leaves out the delivery of encoded messages to the specific implementations with [KrpcTransport].
  *
  * @param config configuration provided for that specific server. Applied to all services that use this server.
  * @param transport [KrpcTransport] instance that will be used to send and receive RPC messages.
@@ -43,6 +36,15 @@ public abstract class KrpcServer(
     private val config: KrpcConfig.Server,
     transport: KrpcTransport,
 ) : RpcServer, KrpcEndpoint {
+
+    /*
+     * #####################################################################
+     * #                                                                   #
+     * #                         INTERNALS AHEAD                           #
+     * #                                                                   #
+     * #####################################################################
+     */
+
     @InternalRpcApi
     public val internalScope: CoroutineScope = CoroutineScope(SupervisorJob(transport.coroutineContext.job))
 


### PR DESCRIPTION
**Strict mode Migration**
A series of changes to simplify kRPC protocol
 - [x] Remove fields support
 - [x] Remove stream scopes
 - [x] Simplify lifetime management
 - [x] Cold RPC clients creation
 - [x] Deprecated declarations cleanup
 - [x] Documentation update for previous changes

**Subsystem**
Kdocs, documentation

**Problem Description**
A lot of changes in 0.8.0 make most of the docs outdated.

**Solution**
Update API docs, examples, documentation website, and provide a migration guide.

