### PR TITLE
Ci updates

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,30 @@
+name: Verify Docs Changelog
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-platforms-table:
+    name: Run Verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Check Platforms Table
+        run: ./gradlew updateDocsChangelog --info --stacktrace
+
+      - name: Check if changelog is up-to-date
+        run: |
+          if [[ -n "$(git status --porcelain | grep docs/pages/kotlinx-rpc/topics/changelog.md)" ]]; then
+            echo "Changelog is not up to date. Please run './gradlew updateDocsChangelog' and commit changes"
+            exit 1
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
       - 'docs/pages/**'
       - '.github/workflows/**'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of library that is being documented'
+        required: true
 
 permissions:
   id-token: write
@@ -21,6 +25,9 @@ env:
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'
   CONFIG_JSON_PRODUCT: 'kotlinx-rpc'
   CONFIG_JSON_VERSION: '0.8.0'
+  DOKKA_ARTIFACT: 'dokka.zip'
+  ASSEMBLE_DIR: '__docs_assembled'
+  ASSEMBLE_ARTIFACT: 'assembled.zip'
 
 jobs:
   build:
@@ -67,11 +74,8 @@ jobs:
         with:
           instance: ${{ env.INSTANCE }}
 
-  deploy:
+  assemble:
     if: github.event_name == 'workflow_dispatch'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     needs: [ build, test ]
     runs-on: ubuntu-latest
     steps:
@@ -80,34 +84,52 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Run Dokka
-        run: ./gradlew dokkaGenerate
-
-      - name: Move API docs to the publication directory
-        run:
-          mkdir __docs_publication_dir
-          cp -r docs/pages/api __docs_publication_dir/api
-
-      - name: Download artifacts
+      - name: Download Writerside artifacts
         uses: actions/download-artifact@v4
         with:
           name: kotlinx-rpc
 
-      - name: Unzip artifact
-        run: unzip -O UTF-8 -qq '${{ env.ARTIFACT }}' -d __docs_publication_dir
+      - name: Unzip Writerside artifacts
+        run: unzip -O UTF-8 -qq '${{ env.ARTIFACT }}' -d ${{ env.ASSEMBLE_DIR }}
+
+      - name: Download Dokka
+        uses: actions/download-artifact@v4
+        with:
+          name: dokka-${{ inputs.version }}
+          path: ${{ env.DOKKA_ARTIFACT }}
+
+      - name: Unzip Dokka
+        run: unzip -O UTF-8 -qq '${{ env.DOKKA_ARTIFACT }}' -d ${{ env.ASSEMBLE_DIR }}/api
+        
+      - name: Move changelog.md to the docs root
+        run: mv ${{ env.ASSEMBLE_DIR }}/api/changelog.md ${{ env.ASSEMBLE_DIR }}/changelog.md      
 
       - name: Update sitemap.xml
-        run: chmod +x updateSitemap.sh && ./updateSitemap.sh __docs_publication_dir/sitemap.xml __docs_publication_dir/api
+        run: chmod +x updateSitemap.sh && ./updateSitemap.sh ${{ env.ASSEMBLE_DIR }}/sitemap.xml ${{ env.ASSEMBLE_DIR }}/api
 
-      - name: Run Changelog Generator
-        run: ./gradlew updateDocsChangelog
+      - name: Save assembled artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kotlinx-rpc-assembled
+          path: |
+            ${{ env.ASSEMBLE_DIR }}
+          retention-days: 7
 
-      - name: Move Changelog.md to the publication directory
-        run:
-          mv docs/pages/kotlinx-rpc/topics/changelog.md __docs_publication_dir/changelog.md
+  deploy:
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: [ build, test, assemble ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: kotlinx-rpc-assembled
+
+      - name: Unzip artifact
+        run: unzip -O UTF-8 -qq '${{ env.ASSEMBLE_ARTIFACT }}' -d ${{ env.ASSEMBLE_DIR }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -115,15 +137,15 @@ jobs:
       - name: Package and upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: __docs_publication_dir
+          path: ${{ env.ASSEMBLE_DIR }}
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
 
   publish-indexes:
-    if: github.event_name == 'workflow_dispatch'
-    needs: [ build, test, deploy ]
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: [ build, test, assemble, deploy ]
     runs-on: ubuntu-latest
     container:
       image: registry.jetbrains.team/p/writerside/builder/algolia-publisher:2.0.32-3
@@ -131,7 +153,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: kotlinx-rpc
+          name: kotlinx-rpc-assembled
       - name: Unzip artifact
         run: |
           unzip -O UTF-8 -qq '${{ env.ALGOLIA_ARTIFACT }}' -d algolia-indexes

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,9 +38,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create stub changelog.md file
-        run: echo "# Changelog" > docs/pages/kotlinx-rpc/topics/changelog.md
-
       - name: Build docs using Writerside Docker builder
         uses: JetBrains/writerside-github-action@v4
         with:
@@ -100,9 +97,6 @@ jobs:
 
       - name: Unzip Dokka
         run: unzip -O UTF-8 -qq '${{ env.DOKKA_ARTIFACT }}' -d ${{ env.ASSEMBLE_DIR }}/api
-        
-      - name: Move changelog.md to the docs root
-        run: mv ${{ env.ASSEMBLE_DIR }}/api/changelog.md ${{ env.ASSEMBLE_DIR }}/changelog.md      
 
       - name: Update sitemap.xml
         run: chmod +x updateSitemap.sh && ./updateSitemap.sh ${{ env.ASSEMBLE_DIR }}/sitemap.xml ${{ env.ASSEMBLE_DIR }}/api

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -1,0 +1,34 @@
+name: Store Dokka Artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of library that is being documented'
+        required: true
+        type: string
+      buildId:
+        description: 'TeamCity build id'
+        required: true
+        type: string
+      artifactName:
+        description: 'Name of artifact to download'
+        required: true
+        type: string
+
+jobs:
+  store-dokka-artifact:
+    name: Store Dokka Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Dokka artifact
+        run: |
+          curl -v -s -f -L \
+            -H "Authorization: Bearer ${{ secrets.TEAMCITY_TOKEN }}" \
+            https://krpc.teamcity.com/app/rest/builds/id:${{ inputs.buildId }}/artifacts/content/${{ inputs.artifactName }} -o dokka.zip
+      - name: Save artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dokka-${{ inputs.version }}
+          path: dokka.zip
+          retention-days: 21

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Check Platforms Table
-        run: ./gradlew verifyPlatformTable --no-configuration-cache
+        run: ./gradlew verifyPlatformTable --no-configuration-cache --info --stacktrace

--- a/.idea/kotlinx-rpc.iml
+++ b/.idea/kotlinx-rpc.iml
@@ -9,12 +9,6 @@
       <excludeFolder url="file://$MODULE_DIR$/docs/pages/api" />
       <excludeFolder url="file://$MODULE_DIR$/kotlin-js-store" />
       <excludeFolder url="file://$MODULE_DIR$/detekt/reports" />
-      <excludeFolder url="file://$MODULE_DIR$/gradle-conventions/build/generated-sources/kotlin-dsl-external-plugin-spec-builders/kotlin" />
-      <excludeFolder url="file://$MODULE_DIR$/gradle-conventions/build/generated-sources/kotlin-dsl-plugins/kotlin" />
-      <excludeFolder url="file://$MODULE_DIR$/gradle-conventions/build/generated-sources/kotlin-dsl-accessors/kotlin" />
-      <excludeFolder url="file://$MODULE_DIR$/gradle-conventions-settings/build/generated-sources/kotlin-dsl-external-plugin-spec-builders/kotlin" />
-      <excludeFolder url="file://$MODULE_DIR$/gradle-conventions-settings/build/generated-sources/kotlin-dsl-plugins/kotlin" />
-      <excludeFolder url="file://$MODULE_DIR$/gradle-conventions-settings/build/generated-sources/kotlin-dsl-accessors/kotlin" />
     </content>
   </component>
 </module>

--- a/compiler-plugin/gradle.properties
+++ b/compiler-plugin/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.parallel=true
 org.gradle.workers.max=8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configureondemand=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/compiler-plugin/gradle.properties
+++ b/compiler-plugin/gradle.properties
@@ -6,10 +6,10 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=8

--- a/docs/pages/.gitignore
+++ b/docs/pages/.gitignore
@@ -1,2 +1,1 @@
 api/**
-kotlinx-rpc/topics/changelog.md

--- a/docs/pages/kotlinx-rpc/topics/changelog.md
+++ b/docs/pages/kotlinx-rpc/topics/changelog.md
@@ -1,0 +1,335 @@
+# Changelog
+
+This page contains all changes throughout releases of the library.
+
+## 0.8.0
+> Published 30 June 2025
+
+**Full Changelog**: [0.7.0...0.8.0](https://github.com/Kotlin/kotlinx-rpc/compare/0.7.0...0.8.0)
+
+### Overview {id=Overview_0_8_0}
+This release brings a lot of changes, including breaking changes:
+- Kotlin 2.2.0 Update
+- Decoupling of `kotlinx.serialization` from the core functionality
+- Simplifying lifetime schema (services lost their `CoroutineScope`)
+- Irreversible enforcement of the [strict mode](https://kotlin.github.io/kotlinx-rpc/strict-mode.html)
+
+These changes significantly reduce the number of footguns and improve the overall usability of the library.
+
+Additionally, the internal structure of kRPC protocol and our compiler plugin reduced its complexity. 
+That allows us to provide better quality in future releases
+(and this also applies to gRPC, even though in this particular release it was not a priority).
+
+For the full list of changes that require migration,
+see the [Migration Guide](https://kotlin.github.io/kotlinx-rpc/0-8-0.html).
+
+### Docs update {id=Docs_update_0_8_0}
+
+We added three new documentation sections:
+- [API Reference](https://kotlin.github.io/kotlinx-rpc/api/index.html) 
+- [Platform compatibility overview](https://kotlin.github.io/kotlinx-rpc/platforms.html) 
+- [Changelog](https://kotlin.github.io/kotlinx-rpc/changelog.html) in the web
+
+#### Features 🎉 {id=Features_0_8_0}
+* Serialization decoupling by [@Mr3zee](https://github.com/Mr3zee) in [#354](https://github.com/Kotlin/kotlinx-rpc/pull/354)
+* Update Kotlin to 2.2.0 by [@Mr3zee](https://github.com/Mr3zee) in [#359](https://github.com/Kotlin/kotlinx-rpc/pull/359)
+
+#### Breaking Changes 🔴 {id=Breaking_Changes_0_8_0}
+* [Meta] Strict mode, deprecations, lifetime by [@Mr3zee](https://github.com/Mr3zee) in [#353](https://github.com/Kotlin/kotlinx-rpc/pull/353)
+
+#### Bug fixes 🐛 {id=Bug_fixes_0_8_0}
+* Fix compilation for standalone k2 module by [@Mr3zee](https://github.com/Mr3zee) in [#350](https://github.com/Kotlin/kotlinx-rpc/pull/350)
+* Fix Pupperteer Version by [@Mr3zee](https://github.com/Mr3zee) in [#355](https://github.com/Kotlin/kotlinx-rpc/pull/355)
+
+#### Documentation 📗 {id=Documentation_0_8_0}
+* Platforms Table and docs by [@Mr3zee](https://github.com/Mr3zee) in [#356](https://github.com/Kotlin/kotlinx-rpc/pull/356)
+* Dokka  by [@Mr3zee](https://github.com/Mr3zee) in [#357](https://github.com/Kotlin/kotlinx-rpc/pull/357)
+* Add Changelog.md to Docs by [@Mr3zee](https://github.com/Mr3zee) in [#358](https://github.com/Kotlin/kotlinx-rpc/pull/358)
+* Onboarding by [@Mr3zee](https://github.com/Mr3zee) in [#363](https://github.com/Kotlin/kotlinx-rpc/pull/363)
+
+#### Other Changes 🧹 {id=Other_Changes_0_8_0}
+* Advance version to 0.8.0-SNAPSHOT by [@Mr3zee](https://github.com/Mr3zee) in [#340](https://github.com/Kotlin/kotlinx-rpc/pull/340)
+* Update README.md to use non-suspend flows by [@brokenhappy](https://github.com/brokenhappy) in [#342](https://github.com/Kotlin/kotlinx-rpc/pull/342)
+* Fix kotlin master builds by [@Mr3zee](https://github.com/Mr3zee) in [#345](https://github.com/Kotlin/kotlinx-rpc/pull/345)
+* Simplify Gradle Configs by [@Mr3zee](https://github.com/Mr3zee) in [#360](https://github.com/Kotlin/kotlinx-rpc/pull/360)
+
+### New Contributors {id=New_Contributors_0_8_0}
+* [@brokenhappy](https://github.com/brokenhappy) made their first contribution in [#342](https://github.com/Kotlin/kotlinx-rpc/pull/342)
+
+
+## 0.7.0
+> Published 13 May 2025
+
+**Full Changelog**: [0.6.2...0.7.0](https://github.com/Kotlin/kotlinx-rpc/compare/0.6.2...0.7.0)
+
+### Announcement {id=Announcement_0_7_0}
+This release enforces ERROR as a default reporting level for APIs that are forbidden by the strict mode.
+You can still change the level manually, but in `0.8.0` strict mode will be enforced irreversibly.
+
+#### Breaking Changes 🔴 {id=Breaking_Changes_0_7_0}
+* Change strict mode to level ERROR by default by [@Mr3zee](https://github.com/Mr3zee) in [#338](https://github.com/Kotlin/kotlinx-rpc/pull/338)
+
+#### Other Changes 🧹 {id=Other_Changes_0_7_0}
+* Update Kotlin to 2.1.21 by [@Mr3zee](https://github.com/Mr3zee) in [#337](https://github.com/Kotlin/kotlinx-rpc/pull/337)
+* Version 0.7.0-SNAPSHOT by [@Mr3zee](https://github.com/Mr3zee) in [#325](https://github.com/Kotlin/kotlinx-rpc/pull/325)
+* Samples: version 0.6.2 by [@Mr3zee](https://github.com/Mr3zee) in [#326](https://github.com/Kotlin/kotlinx-rpc/pull/326)
+* 2.2.0 compiler migration by [@Mr3zee](https://github.com/Mr3zee) in [#335](https://github.com/Kotlin/kotlinx-rpc/pull/335)
+
+
+## 0.6.2
+> Published 17 April 2025
+
+**Full Changelog**: [0.6.1...0.6.2](https://github.com/Kotlin/kotlinx-rpc/compare/0.6.1...0.6.2)
+
+#### Bug fixes 🐛 {id=Bug_fixes_0_6_2}
+* Fix flows that emit Units by [@Mr3zee](https://github.com/Mr3zee) in [#323](https://github.com/Kotlin/kotlinx-rpc/pull/323)
+
+
+## 0.6.1
+> Published 11 April 2025
+
+**Full Changelog**: [0.6.0...0.6.1](https://github.com/Kotlin/kotlinx-rpc/compare/0.6.0...0.6.1)
+
+#### Bug fixes 🐛 {id=Bug_fixes_0_6_1}
+* Fix bidirectional flows in non-suspend streams by [@Mr3zee](https://github.com/Mr3zee) in [#316](https://github.com/Kotlin/kotlinx-rpc/pull/316)
+* Fix KRPC-173 (#315) by [@Mr3zee](https://github.com/Mr3zee) in [#317](https://github.com/Kotlin/kotlinx-rpc/pull/317)
+
+
+## 0.6.0
+> Published 4 April 2025
+
+**Full Changelog**: [0.5.1...0.6.0](https://github.com/Kotlin/kotlinx-rpc/compare/0.5.1...0.6.0)
+
+#### Features 🎉 {id=Features_0_6_0}
+* 2.1.20 by [@Mr3zee](https://github.com/Mr3zee) in [#309](https://github.com/Kotlin/kotlinx-rpc/pull/309)
+* Non suspend flow by [@Mr3zee](https://github.com/Mr3zee) in [#299](https://github.com/Kotlin/kotlinx-rpc/pull/299)
+
+#### Documentation 📗 {id=Documentation_0_6_0}
+* Update gRPC Docs and Sample by [@Mr3zee](https://github.com/Mr3zee) in [#284](https://github.com/Kotlin/kotlinx-rpc/pull/284)
+
+#### Infra 🚧 {id=Infra_0_6_0}
+* Update monitior by [@Mr3zee](https://github.com/Mr3zee) in [#282](https://github.com/Kotlin/kotlinx-rpc/pull/282)
+* Fix build config for for-ide builds by [@Mr3zee](https://github.com/Mr3zee) in [#287](https://github.com/Kotlin/kotlinx-rpc/pull/287)
+* Update build for custom KC versions by [@Mr3zee](https://github.com/Mr3zee) in [#293](https://github.com/Kotlin/kotlinx-rpc/pull/293)
+* Fix kotlin master compilation by [@Mr3zee](https://github.com/Mr3zee) in [#306](https://github.com/Kotlin/kotlinx-rpc/pull/306)
+
+#### Other Changes 🧹 {id=Other_Changes_0_6_0}
+* Upgrade Gradle to 8.12.1 by [@Mr3zee](https://github.com/Mr3zee) in [#286](https://github.com/Kotlin/kotlinx-rpc/pull/286)
+* Version 0.6.0-SNAPSHOT by [@Mr3zee](https://github.com/Mr3zee) in [#283](https://github.com/Kotlin/kotlinx-rpc/pull/283)
+* Update leftover sources from jvm-only to kmp by [@Mr3zee](https://github.com/Mr3zee) in [#300](https://github.com/Kotlin/kotlinx-rpc/pull/300)
+* KRPC-129 Move compatibility tests from Toolbox to Kotlin RPC repo by [@Mr3zee](https://github.com/Mr3zee) in [#304](https://github.com/Kotlin/kotlinx-rpc/pull/304)
+* Dependency bump by [@Mr3zee](https://github.com/Mr3zee) in [#303](https://github.com/Kotlin/kotlinx-rpc/pull/303)
+* Better compiler error message for checked annotations by [@Mr3zee](https://github.com/Mr3zee) in [#302](https://github.com/Kotlin/kotlinx-rpc/pull/302)
+
+
+## 0.5.1
+> Published 12 February 2025
+
+**Full Changelog**: [0.5.0...0.5.1](https://github.com/Kotlin/kotlinx-rpc/compare/0.5.0...0.5.1)
+
+#### Features 🎉 {id=Features_0_5_1}
+* 2.1.10 by [@Mr3zee](https://github.com/Mr3zee) in [#271](https://github.com/Kotlin/kotlinx-rpc/pull/271)
+
+#### Documentation 📗 {id=Documentation_0_5_1}
+* Fix typo in README.md by [@SebastianAigner](https://github.com/SebastianAigner) in [#266](https://github.com/Kotlin/kotlinx-rpc/pull/266)
+* Added IDE plugin docs by [@Mr3zee](https://github.com/Mr3zee) in [#273](https://github.com/Kotlin/kotlinx-rpc/pull/273)
+
+#### Infra 🚧 {id=Infra_0_5_1}
+* Update for IDE configs by [@Mr3zee](https://github.com/Mr3zee) in [#272](https://github.com/Kotlin/kotlinx-rpc/pull/272)
+* Added python deps automerge by [@Mr3zee](https://github.com/Mr3zee) in [#276](https://github.com/Kotlin/kotlinx-rpc/pull/276)
+
+#### Other Changes 🧹 {id=Other_Changes_0_5_1}
+* Update README.md by [@pambrose](https://github.com/pambrose) in [#268](https://github.com/Kotlin/kotlinx-rpc/pull/268)
+* Added monitor app for deps publication by [@Mr3zee](https://github.com/Mr3zee) in [#265](https://github.com/Kotlin/kotlinx-rpc/pull/265)
+* Fix kotlin master by [@Mr3zee](https://github.com/Mr3zee) in [#274](https://github.com/Kotlin/kotlinx-rpc/pull/274)
+* Fix println tests by [@Mr3zee](https://github.com/Mr3zee) in [#277](https://github.com/Kotlin/kotlinx-rpc/pull/277)
+* Update Python Monitor Dependencies by [@renovate](https://github.com/renovate) in [#278](https://github.com/Kotlin/kotlinx-rpc/pull/278)
+
+### New Contributors {id=New_Contributors_0_5_1}
+* [@SebastianAigner](https://github.com/SebastianAigner) made their first contribution in [#266](https://github.com/Kotlin/kotlinx-rpc/pull/266)
+* [@pambrose](https://github.com/pambrose) made their first contribution in [#268](https://github.com/Kotlin/kotlinx-rpc/pull/268)
+
+
+## 0.5.0
+> Published 27 January 2025
+
+**Full Changelog**: [0.4.0...0.5.0](https://github.com/Kotlin/kotlinx-rpc/compare/0.4.0...0.5.0)
+
+#### Features 🎉 {id=Features_0_5_0}
+* Update Service Descriptors Generation by [@Mr3zee](https://github.com/Mr3zee) in [#227](https://github.com/Kotlin/kotlinx-rpc/pull/227)
+* Kotlin 2.1.0 by [@Mr3zee](https://github.com/Mr3zee) in [#244](https://github.com/Kotlin/kotlinx-rpc/pull/244)
+* Added basic CheckedTypeAnnotation impl with compiler plugin check by [@Mr3zee](https://github.com/Mr3zee) in [#240](https://github.com/Kotlin/kotlinx-rpc/pull/240)
+* Strict mode by [@Mr3zee](https://github.com/Mr3zee) in [#243](https://github.com/Kotlin/kotlinx-rpc/pull/243)
+
+#### Breaking Changes 🔴 {id=Breaking_Changes_0_5_0}
+* Api naming by [@Mr3zee](https://github.com/Mr3zee) in [#236](https://github.com/Kotlin/kotlinx-rpc/pull/236)
+* Update Service Descriptors Generation by [@Mr3zee](https://github.com/Mr3zee) in [#227](https://github.com/Kotlin/kotlinx-rpc/pull/227)
+* Added basic CheckedTypeAnnotation impl with compiler plugin check by [@Mr3zee](https://github.com/Mr3zee) in [#240](https://github.com/Kotlin/kotlinx-rpc/pull/240)
+
+#### Deprecations ⚠️ {id=Deprecations_0_5_0}
+* Api naming by [@Mr3zee](https://github.com/Mr3zee) in [#236](https://github.com/Kotlin/kotlinx-rpc/pull/236)
+* Strict mode by [@Mr3zee](https://github.com/Mr3zee) in [#243](https://github.com/Kotlin/kotlinx-rpc/pull/243)
+
+#### Infra 🚧 {id=Infra_0_5_0}
+* Update the project structure to work with kotlin-master by [@Mr3zee](https://github.com/Mr3zee) in [#234](https://github.com/Kotlin/kotlinx-rpc/pull/234)
+* Fixed version formatting with ENV vars by [@Mr3zee](https://github.com/Mr3zee) in [#235](https://github.com/Kotlin/kotlinx-rpc/pull/235)
+* Fix Kotlin master compilation by [@Mr3zee](https://github.com/Mr3zee) in [#245](https://github.com/Kotlin/kotlinx-rpc/pull/245)
+* Opt-out from annotations type safety analysis by [@Mr3zee](https://github.com/Mr3zee) in [#246](https://github.com/Kotlin/kotlinx-rpc/pull/246)
+
+#### Other Changes 🧹 {id=Other_Changes_0_5_0}
+* Added test for non-serializable params by [@Mr3zee](https://github.com/Mr3zee) in [#237](https://github.com/Kotlin/kotlinx-rpc/pull/237)
+* Updated descriptor to use `RpcType` instead of `KType` directly by [@Mr3zee](https://github.com/Mr3zee) in [#239](https://github.com/Kotlin/kotlinx-rpc/pull/239)
+
+
+## 0.4.0
+> Published 5 November 2024
+
+**Full Changelog**: [0.3.0...0.4.0](https://github.com/Kotlin/kotlinx-rpc/compare/0.3.0...0.4.0)
+
+#### Features 🎉 {id=Features_0_4_0}
+* Experimental support for: KRPC-125 Manual stream scope management by [@Mr3zee](https://github.com/Mr3zee) in [#214](https://github.com/Kotlin/kotlinx-rpc/pull/214)
+* Introduce [@Rpc](https://github.com/Rpc) annotation by [@Mr3zee](https://github.com/Mr3zee) in [#216](https://github.com/Kotlin/kotlinx-rpc/pull/216)
+* Support Kotlin 2.0.21 and 2.0.20 by [@Mr3zee](https://github.com/Mr3zee) in [#217](https://github.com/Kotlin/kotlinx-rpc/pull/217)
+
+#### Breaking Changes 🔴 {id=Breaking_Changes_0_4_0}
+* Introduce [@Rpc](https://github.com/Rpc) annotation by [@Mr3zee](https://github.com/Mr3zee) in [#216](https://github.com/Kotlin/kotlinx-rpc/pull/216)
+* Remove support for Kotlin versions prior to 2.0 by [@Mr3zee](https://github.com/Mr3zee) in [#218](https://github.com/Kotlin/kotlinx-rpc/pull/218)
+
+#### Infra 🚧 {id=Infra_0_4_0}
+* Added proxy repository settings by [@Mr3zee](https://github.com/Mr3zee) in [#191](https://github.com/Kotlin/kotlinx-rpc/pull/191)
+* Added Kotlin for ide configs to project by [@Mr3zee](https://github.com/Mr3zee) in [#219](https://github.com/Kotlin/kotlinx-rpc/pull/219)
+
+#### Bug fixes 🐛 {id=Bug_fixes_0_4_0}
+* Fix for KT-41082 by [@Mr3zee](https://github.com/Mr3zee) in [#225](https://github.com/Kotlin/kotlinx-rpc/pull/225)
+
+#### Other Changes 🧹 {id=Other_Changes_0_4_0}
+* Bump core deps by [@Mr3zee](https://github.com/Mr3zee) in [#220](https://github.com/Kotlin/kotlinx-rpc/pull/220)
+
+
+## 0.3.0
+> Published 1 October 2024
+
+**Full Changelog**: [0.2.4...0.3.0](https://github.com/Kotlin/kotlinx-rpc/compare/0.2.4...0.3.0)
+
+#### Features 🎉 {id=Features_0_3_0}
+* Wasm Support by [@Mr3zee](https://github.com/Mr3zee) in [#190](https://github.com/Kotlin/kotlinx-rpc/pull/190)
+
+#### Breaking Changes 🔴 {id=Breaking_Changes_0_3_0}
+* Move kRPC declarations from core by [@Mr3zee](https://github.com/Mr3zee) in [#186](https://github.com/Kotlin/kotlinx-rpc/pull/186)
+
+#### Bug fixes 🐛 {id=Bug_fixes_0_3_0}
+* Fix kotlin/js code and samples by [@Mr3zee](https://github.com/Mr3zee) in [#179](https://github.com/Kotlin/kotlinx-rpc/pull/179)
+* Fix regression of nested declarations in RPC interfaces by [@Mr3zee](https://github.com/Mr3zee) in [#181](https://github.com/Kotlin/kotlinx-rpc/pull/181)
+
+#### Documentation 📗 {id=Documentation_0_3_0}
+* Wording fixes by [@Mr3zee](https://github.com/Mr3zee) in [#175](https://github.com/Kotlin/kotlinx-rpc/pull/175)
+
+#### Infra 🚧 {id=Infra_0_3_0}
+* Infra enhancements by [@Mr3zee](https://github.com/Mr3zee) in [#206](https://github.com/Kotlin/kotlinx-rpc/pull/206)
+* Fixed Wasm Publication by [@Mr3zee](https://github.com/Mr3zee) in [#208](https://github.com/Kotlin/kotlinx-rpc/pull/208)
+* Update renovate configs by [@Mr3zee](https://github.com/Mr3zee) in [#185](https://github.com/Kotlin/kotlinx-rpc/pull/185)
+* Configure JPMS checks by [@Mr3zee](https://github.com/Mr3zee) in [#187](https://github.com/Kotlin/kotlinx-rpc/pull/187)
+* Update some ide configs by [@Mr3zee](https://github.com/Mr3zee) in [#188](https://github.com/Kotlin/kotlinx-rpc/pull/188)
+* Added Gradle Doctor to the build by [@Mr3zee](https://github.com/Mr3zee) in [#189](https://github.com/Kotlin/kotlinx-rpc/pull/189)
+* Added build cache and develocity plugin by [@Mr3zee](https://github.com/Mr3zee) in [#192](https://github.com/Kotlin/kotlinx-rpc/pull/192)
+* Support variable Kotlin and project versions by [@Mr3zee](https://github.com/Mr3zee) in [#201](https://github.com/Kotlin/kotlinx-rpc/pull/201)
+* Update renovate and some deps by [@Mr3zee](https://github.com/Mr3zee) in [#198](https://github.com/Kotlin/kotlinx-rpc/pull/198)
+
+#### Other Changes 🧹 {id=Other_Changes_0_3_0}
+* Bump version to 0.3.0-SNAPSHOT by [@Mr3zee](https://github.com/Mr3zee) in [#174](https://github.com/Kotlin/kotlinx-rpc/pull/174)
+* Fix compiler tests after #172 by [@Mr3zee](https://github.com/Mr3zee) in [#180](https://github.com/Kotlin/kotlinx-rpc/pull/180)
+* Remove unused and inactive annotation by [@kez-lab](https://github.com/kez-lab) in [#182](https://github.com/Kotlin/kotlinx-rpc/pull/182)
+* Use built-in JsClass getter by [@Mr3zee](https://github.com/Mr3zee) in [#184](https://github.com/Kotlin/kotlinx-rpc/pull/184)
+* Update actions/configure-pages action to v5 by [@renovate](https://github.com/renovate) in [#200](https://github.com/Kotlin/kotlinx-rpc/pull/200)
+* Update Samples dependencies by [@renovate](https://github.com/renovate) in [#199](https://github.com/Kotlin/kotlinx-rpc/pull/199)
+* Update Core dependencies (non-major) by [@renovate](https://github.com/renovate) in [#194](https://github.com/Kotlin/kotlinx-rpc/pull/194)
+* Update Core dependencies (non-major) by [@renovate](https://github.com/renovate) in [#205](https://github.com/Kotlin/kotlinx-rpc/pull/205)
+
+### New Contributors {id=New_Contributors_0_3_0}
+* [@kez-lab](https://github.com/kez-lab) made their first contribution in [#182](https://github.com/Kotlin/kotlinx-rpc/pull/182)
+
+
+## 0.2.4
+> Published 20 August 2024
+
+**Full Changelog**: [0.2.2...0.2.4](https://github.com/Kotlin/kotlinx-rpc/compare/0.2.2...0.2.4)
+
+#### Features {id=Features_0_2_4}
+* KRPC-18 Add K2 and IR code generation plugins, preserve KSP for K1 by [@Mr3zee](https://github.com/Mr3zee) in [#105](https://github.com/Kotlin/kotlinx-rpc/pull/105)
+* Added 1.9.25 and 2.0.10 Kotlin Versions by [@Mr3zee](https://github.com/Mr3zee) in [#168](https://github.com/Kotlin/kotlinx-rpc/pull/168)
+
+#### Bug fixes {id=Bug_fixes_0_2_4}
+* KRPC-101 Check if the entire stream is not already closed. by [@pikinier20](https://github.com/pikinier20) in [#158](https://github.com/Kotlin/kotlinx-rpc/pull/158)
+* KRPC-119 Exception Deserialization by [@Mr3zee](https://github.com/Mr3zee) in [#170](https://github.com/Kotlin/kotlinx-rpc/pull/170)
+* Fix compilation on Kotlin/Native by [@Mr3zee](https://github.com/Mr3zee) in [#172](https://github.com/Kotlin/kotlinx-rpc/pull/172)
+
+#### Infra {id=Infra_0_2_4}
+* Add issue templates by [@Mr3zee](https://github.com/Mr3zee) in [#167](https://github.com/Kotlin/kotlinx-rpc/pull/167)
+
+### New Contributors {id=New_Contributors_0_2_4}
+* [@pikinier20](https://github.com/pikinier20) made their first contribution in [#158](https://github.com/Kotlin/kotlinx-rpc/pull/158)
+
+
+## 0.2.2
+> Published 5 August 2024
+
+**Full Changelog**: [0.2.1...0.2.2](https://github.com/Kotlin/kotlinx-rpc/compare/0.2.1...0.2.2)
+
+#### Bug fixes {id=Bug_fixes_0_2_2}
+* Fix log error messages by [@Mr3zee](https://github.com/Mr3zee) in [#139](https://github.com/Kotlin/kotlinx-rpc/pull/139)
+* KRPC-97 Race condition in stream cancellation locks the transport by [@Mr3zee](https://github.com/Mr3zee) in [#138](https://github.com/Kotlin/kotlinx-rpc/pull/138)
+* Fix call cancellation by [@Mr3zee](https://github.com/Mr3zee) in [#141](https://github.com/Kotlin/kotlinx-rpc/pull/141)
+
+
+
+## 0.2.1
+> Published 1 July 2024
+
+**Full Changelog**: [0.1.0...0.2.1](https://github.com/Kotlin/kotlinx-rpc/compare/0.1.0...0.2.1)
+
+#### Breaking changes {id=Breaking_changes_0_2_1}
+Release contains breaking changes, see the [migration guide](https://kotlin.github.io/kotlinx-rpc/0-2-0.html)
+
+* Update the project structure to use a new versioning by [@Mr3zee](https://github.com/Mr3zee) in [#92](https://github.com/Kotlin/kotlinx-rpc/pull/92)
+* Consistent module structure by [@Mr3zee](https://github.com/Mr3zee) in [#114](https://github.com/Kotlin/kotlinx-rpc/pull/114)
+* KRPC-63 Reorganize modules into a logical structure by [@Mr3zee](https://github.com/Mr3zee) in [#110](https://github.com/Kotlin/kotlinx-rpc/pull/110)
+
+#### Features {id=Features_0_2_1}
+* KRPC-62 WebSocketSession KtorRPCClient by [@Mr3zee](https://github.com/Mr3zee) in [#107](https://github.com/Kotlin/kotlinx-rpc/pull/107)
+
+#### Bug fixes {id=Bug_fixes_0_2_1}
+* Fix typo by [@fatalistt](https://github.com/fatalistt) in [#76](https://github.com/Kotlin/kotlinx-rpc/pull/76)
+* Fix README by [@Mr3zee](https://github.com/Mr3zee) in [#79](https://github.com/Kotlin/kotlinx-rpc/pull/79)
+* Remove todos from repo links by [@Mr3zee](https://github.com/Mr3zee) in [#85](https://github.com/Kotlin/kotlinx-rpc/pull/85)
+* Fix typo in README.md by [@zhelenskiy](https://github.com/zhelenskiy) in [#87](https://github.com/Kotlin/kotlinx-rpc/pull/87)
+* Fix KDoc reference by [@Mr3zee](https://github.com/Mr3zee) in [#103](https://github.com/Kotlin/kotlinx-rpc/pull/103)
+* Fix native targets compiler plugins (#93) by [@Mr3zee](https://github.com/Mr3zee) in [#112](https://github.com/Kotlin/kotlinx-rpc/pull/112)
+
+#### Deprecations {id=Deprecations_0_2_1}
+* KRPC-59 streamScoped has internal package by [@Mr3zee](https://github.com/Mr3zee) in [#104](https://github.com/Kotlin/kotlinx-rpc/pull/104)
+
+#### Documentation {id=Documentation_0_2_1}
+* Updated links on the docs website by [@Mr3zee](https://github.com/Mr3zee) in [#71](https://github.com/Kotlin/kotlinx-rpc/pull/71)
+* Added search indexes publication to Algolia action by [@Mr3zee](https://github.com/Mr3zee) in [#73](https://github.com/Kotlin/kotlinx-rpc/pull/73)
+* Fix algolia artifact in GH Actions by [@Mr3zee](https://github.com/Mr3zee) in [#80](https://github.com/Kotlin/kotlinx-rpc/pull/80)
+* Docs: Add structure to existing content by [@vnikolova](https://github.com/vnikolova) in [#86](https://github.com/Kotlin/kotlinx-rpc/pull/86)
+* Added build and test docs on PR by [@Mr3zee](https://github.com/Mr3zee) in [#97](https://github.com/Kotlin/kotlinx-rpc/pull/97)
+* Fixed GH Actions for docs by [@Mr3zee](https://github.com/Mr3zee) in [#99](https://github.com/Kotlin/kotlinx-rpc/pull/99)
+* Disable docs website autoupdate by [@Mr3zee](https://github.com/Mr3zee) in [#108](https://github.com/Kotlin/kotlinx-rpc/pull/108)
+* KRPC-60 Update docs to match the new versioning scheme by [@Mr3zee](https://github.com/Mr3zee) in [#109](https://github.com/Kotlin/kotlinx-rpc/pull/109)
+
+#### Infra {id=Infra_0_2_1}
+* Update version to 0.1.1-SNAPSHOT by [@Mr3zee](https://github.com/Mr3zee) in [#64](https://github.com/Kotlin/kotlinx-rpc/pull/64)
+* Version updates by [@Mr3zee](https://github.com/Mr3zee) in [#72](https://github.com/Kotlin/kotlinx-rpc/pull/72)
+* Signing and Publication by [@Mr3zee](https://github.com/Mr3zee) in [#74](https://github.com/Kotlin/kotlinx-rpc/pull/74)
+* IDEA. Issue links by [@turansky](https://github.com/turansky) in [#96](https://github.com/Kotlin/kotlinx-rpc/pull/96)
+* IDEA. Vector icon by [@turansky](https://github.com/turansky) in [#98](https://github.com/Kotlin/kotlinx-rpc/pull/98)
+* KRPC-71 Type-safe project accessors by [@Mr3zee](https://github.com/Mr3zee) in [#106](https://github.com/Kotlin/kotlinx-rpc/pull/106)
+
+### New Contributors {id=New_Contributors_0_2_1}
+* [@jvmusin](https://github.com/jvmusin) made their first contribution in [#69](https://github.com/Kotlin/kotlinx-rpc/pull/69)
+* [@fatalistt](https://github.com/fatalistt) made their first contribution in [#76](https://github.com/Kotlin/kotlinx-rpc/pull/76)
+* [@zhelenskiy](https://github.com/zhelenskiy) made their first contribution in [#87](https://github.com/Kotlin/kotlinx-rpc/pull/87)
+* [@turansky](https://github.com/turansky) made their first contribution in [#96](https://github.com/Kotlin/kotlinx-rpc/pull/96)
+* [@vnikolova](https://github.com/vnikolova) made their first contribution in [#86](https://github.com/Kotlin/kotlinx-rpc/pull/86)
+

--- a/dokka-plugin/gradle.properties
+++ b/dokka-plugin/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.parallel=true
 org.gradle.workers.max=8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configureondemand=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/dokka-plugin/gradle.properties
+++ b/dokka-plugin/gradle.properties
@@ -6,10 +6,10 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=8

--- a/gradle-conventions/src/main/kotlin/conventions-dokka-spec.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/conventions-dokka-spec.gradle.kts
@@ -4,7 +4,6 @@
 
 import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
 import util.KOTLINX_RPC_PREFIX
-import util.other.asDokkaVersion
 import util.other.libs
 import java.time.Year
 
@@ -24,7 +23,7 @@ dokka {
     dokkaSourceSets.configureEach {
         sourceLink {
             localDirectory = rootDir
-            remoteUrl("https://github.com/Kotlin/kotlinx-rpc/blob/${libs.versions.kotlinx.rpc.get().asDokkaVersion()}")
+            remoteUrl("https://github.com/Kotlin/kotlinx-rpc/blob/${libs.versions.kotlinx.rpc.get()}")
             remoteLineSuffix = "#L"
 
             documentedVisibilities = setOf(

--- a/gradle-conventions/src/main/kotlin/conventions-gradle-doctor.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/conventions-gradle-doctor.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 doctor {
     enableTestCaching.assign(false)
-    warnWhenNotUsingParallelGC.assign(true)
     disallowMultipleDaemons.assign(false)
     GCFailThreshold.assign(0.5f)
 }

--- a/gradle-conventions/src/main/kotlin/conventions-root.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/conventions-root.gradle.kts
@@ -2,7 +2,6 @@
  * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import util.other.asDokkaVersion
 import util.other.libs
 import util.tasks.configureNpm
 import util.tasks.registerChangelogTask
@@ -29,9 +28,9 @@ allprojects {
 }
 
 dokka {
-    val libDokkaVersion = libs.versions.kotlinx.rpc.get().asDokkaVersion()
+    val libVersion = libs.versions.kotlinx.rpc.get()
 
-    moduleVersion.set(libDokkaVersion)
+    moduleVersion.set(libVersion)
 
     val pagesDirectory = layout.projectDirectory
         .dir("docs")
@@ -61,6 +60,13 @@ dokka {
 
     dokkaPublications.html {
         outputDirectory = dokkaVersionsDirectory
+    }
+
+    tasks.dokkaGenerate {
+        doFirst {
+            dokkaVersionsDirectory.mkdirs()
+            dokkaVersionsDirectory.resolve("version.txt").writeText(libVersion)
+        }
     }
 
     tasks.clean {

--- a/gradle-conventions/src/main/kotlin/util/other/dokkaUtil.kt
+++ b/gradle-conventions/src/main/kotlin/util/other/dokkaUtil.kt
@@ -1,7 +1,0 @@
-/*
- * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
- */
-
-package util.other
-
-fun String.asDokkaVersion() = removeSuffix("-SNAPSHOT")

--- a/gradle-conventions/src/main/kotlin/util/targets/jvm.kt
+++ b/gradle-conventions/src/main/kotlin/util/targets/jvm.kt
@@ -10,8 +10,15 @@ import org.gradle.kotlin.dsl.attributes
 import org.gradle.kotlin.dsl.getByName
 import util.other.files
 import util.other.libs
+import util.other.optionalProperty
 
 fun Project.configureJvm(isKmp: Boolean) {
+    val excludeJvm by optionalProperty("exclude")
+
+    if (isKmp && excludeJvm) {
+        return
+    }
+
     tasks.getByName<Jar>(if (isKmp) "jvmJar" else "jar").apply {
         manifest {
             attributes(

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.parallel=true
 org.gradle.workers.max=8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configureondemand=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -6,10 +6,10 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=8

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.parallel=true
 org.gradle.workers.max=8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configureondemand=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,10 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=8

--- a/renovate.json5
+++ b/renovate.json5
@@ -104,6 +104,7 @@
       "description": "Ignore Develocity updates",
       "matchDepNames": [
         "com.gradle:develocity-gradle-plugin*",
+        "com.gradle.develocity*",
       ],
       "enabled": false,
     },

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,8 +19,7 @@ plugins {
     id("conventions-repositories")
     id("conventions-version-resolution")
     id("conventions-develocity")
-    // rollback to 0.9.0, as 1.0.0 requires JDK_17 on CI, which I have no time to set up
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {

--- a/updateSitemap.sh
+++ b/updateSitemap.sh
@@ -31,13 +31,13 @@ current_date=$(date +%Y-%m-%d)
 # Create a temporary file to store the updated sitemap
 temp_file=$(mktemp)
 
-# Extract the XML header (everything before the closing urlset tag)
-sed -n '1,/<\/urlset>/p' "$sitemap_file" | sed '$d' > "$temp_file"
+# Extract the first line from sitemap file (XML header), removing closing urlset tag if present
+head -n 1 "$sitemap_file" | sed -En 's/<\/urlset>//' > "$temp_file"
 
 # Find all HTML files in the API docs directory recursively
 find "$api_docs_dir" -type f -name "*.html" | while read -r html_file; do
   # Convert the file path to a URL path (remove the docs/pages/ prefix)
-  url_path=$(echo "$html_file" | sed 's|^docs/pages/||')
+  url_path="${html_file/#$api_docs_dir/api}"
 
   # Create the full URL
   url="https://kotlin.github.io/kotlinx-rpc/$url_path"
@@ -48,7 +48,7 @@ find "$api_docs_dir" -type f -name "*.html" | while read -r html_file; do
         <loc>$url</loc>
         <lastmod>$current_date</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.35</priority>
+        <priority>0.15</priority>
     </url>
 EOF
 done


### PR DESCRIPTION
**Subsystem**
Gradle, GA

**Problem Description**
Docs publication has some drawbacks to it:
- Long
- Hard to test

**Solution**
- Separate dokka generation into TC configs
- Add 'assemble all' step for all docs

Other updates:
- Foojay version 1.0.0
- Allow `exclude.jvm` options
- Commit changelog from docs
- Automated changelog verification
- Fix updateSitemap.sh
- Update renovate to ignore develocity
