### PR TITLE
Make KtorRpcClient inherit KrpcClient

### DIFF
--- a/krpc/krpc-ktor/krpc-ktor-client/api/krpc-ktor-client.api
+++ b/krpc/krpc-ktor/krpc-ktor-client/api/krpc-ktor-client.api
@@ -13,7 +13,8 @@ public final class kotlinx/rpc/krpc/ktor/client/KtorClientDslKt {
 	public static synthetic fun rpcConfig$default (Lio/ktor/client/request/HttpRequestBuilder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 }
 
-public abstract interface class kotlinx/rpc/krpc/ktor/client/KtorRpcClient : kotlinx/rpc/RpcClient {
+public abstract class kotlinx/rpc/krpc/ktor/client/KtorRpcClient : kotlinx/rpc/krpc/client/KrpcClient {
+	public fun <init> ()V
 	public abstract fun getWebSocketSession ()Lkotlinx/coroutines/Deferred;
 }
 

--- a/krpc/krpc-ktor/krpc-ktor-client/api/krpc-ktor-client.klib.api
+++ b/krpc/krpc-ktor/krpc-ktor-client/api/krpc-ktor-client.klib.api
@@ -6,7 +6,9 @@
 // - Show declarations: true
 
 // Library unique name: <org.jetbrains.kotlinx:krpc-ktor-client>
-abstract interface kotlinx.rpc.krpc.ktor.client/KtorRpcClient : kotlinx.rpc/RpcClient { // kotlinx.rpc.krpc.ktor.client/KtorRpcClient|null[0]
+abstract class kotlinx.rpc.krpc.ktor.client/KtorRpcClient : kotlinx.rpc.krpc.client/KrpcClient { // kotlinx.rpc.krpc.ktor.client/KtorRpcClient|null[0]
+    constructor <init>() // kotlinx.rpc.krpc.ktor.client/KtorRpcClient.<init>|<init>(){}[0]
+
     abstract val webSocketSession // kotlinx.rpc.krpc.ktor.client/KtorRpcClient.webSocketSession|{}webSocketSession[0]
         abstract fun <get-webSocketSession>(): kotlinx.coroutines/Deferred<io.ktor.websocket/WebSocketSession> // kotlinx.rpc.krpc.ktor.client/KtorRpcClient.webSocketSession.<get-webSocketSession>|<get-webSocketSession>(){}[0]
 }

--- a/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorRpcClient.kt
+++ b/krpc/krpc-ktor/krpc-ktor-client/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/client/KtorRpcClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc.krpc.ktor.client
@@ -22,11 +22,11 @@ import kotlinx.rpc.krpc.rpcClientConfig
  * Client is cold, meaning the connection will be established on the first request.
  * [webSocketSession] will be completed when the connection is established.
  */
-public interface KtorRpcClient : RpcClient {
+public abstract class KtorRpcClient : KrpcClient() {
     /**
      * Cold [WebSocketSession] object. Instantiated when the connection is established on the first request.
      */
-    public val webSocketSession: Deferred<WebSocketSession>
+    public abstract val webSocketSession: Deferred<WebSocketSession>
 }
 
 internal class KtorKrpcClientImpl(
@@ -34,7 +34,7 @@ internal class KtorKrpcClientImpl(
     private val webSocketSessionFactory: suspend (
         configSetter: (KrpcConfigBuilder.Client.() -> Unit) -> Unit,
     ) -> WebSocketSession,
-): KrpcClient(), KtorRpcClient {
+): KtorRpcClient() {
     private var requestConfigBuilder: KrpcConfigBuilder.Client.() -> Unit = {}
 
     private val _webSocketSession = CompletableDeferred<WebSocketSession>()


### PR DESCRIPTION
**Subsystem**
kRPC

**Problem Description**
We had a weird inheritance chain in `KtorRpcClient`, which didn't reflect that it is `KrpcClient`, so there is no way to cal `close()`, for example, without casting

**Solution**
Fix it!

