### PR TITLE
Add stub targets tags for platforms table

### DIFF
--- a/docs/pages/kotlinx-rpc/topics/platforms.topic
+++ b/docs/pages/kotlinx-rpc/topics/platforms.topic
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  - Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+  -->
+
 <!DOCTYPE topic
         SYSTEM "https://resources.jetbrains.com/writerside/1.0/xhtml-entities.dtd">
 <!--suppress WrsMissingSpaceChecker -->
@@ -47,8 +51,13 @@
     </table>
 
     <p>
-        The following table contains a list of all published modules and their supported platforms:
+        The following table contains a list of all published modules and their supported platforms.
     </p>
+    <note>
+        Targets marked with the <b>[stub]</b> tag have published artifacts,
+        but their runtime functionally is not supported.
+        This is done to make sure that user projects sync without errors when some target is not present.
+    </note>
     <table>
         <tr>
             <td>Module</td>

--- a/gradle-conventions/src/main/kotlin/util/targets/kmpConfig.kt
+++ b/gradle-conventions/src/main/kotlin/util/targets/kmpConfig.kt
@@ -56,7 +56,7 @@ class KmpConfig(
     private val excludeJvm: Boolean by optionalProperty("exclude")
     private val excludeJs: Boolean by optionalProperty("exclude")
     private val excludeWasmJs: Boolean by optionalProperty("exclude")
-    private val excludeWasmJsD8: Boolean by optionalProperty("exclude")
+    private val excludeWasmJsD8: Boolean by optionalProperty("exclude", "wasmJs")
     private val excludeWasmWasi: Boolean by optionalProperty("exclude")
     val excludeNative: Boolean by optionalProperty("exclude")
 

--- a/krpc/gradle.properties
+++ b/krpc/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+# Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
 #
 
 # https://github.com/oshai/kotlin-logging/issues/433

--- a/krpc/krpc-test/gradle.properties
+++ b/krpc/krpc-test/gradle.properties
@@ -3,4 +3,4 @@
 #
 
 # tests fail with some obscure reason
-kotlinx.rpc.exclude.wasmJsD8=true
+kotlinx.rpc.exclude.wasmJs.d8=true


### PR DESCRIPTION
**Subsystem**
Docs, Gradle

**Problem Description**
Sometimes (gRPC I'm looking at you) we have published targets, but they don't actually work and are just stubs.

**Solution**
Reflect these semantics in the platforms table.

**ATTENTION**
Provide this pull request with proper labels, it is important to simplify generation of releases.
