### PR TITLE
Make WS plugin installation for Ktor server more flexible

### DIFF
--- a/krpc/krpc-ktor/krpc-ktor-server/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/server/Krpc.kt
+++ b/krpc/krpc-ktor/krpc-ktor-server/src/commonMain/kotlin/kotlinx/rpc/krpc/ktor/server/Krpc.kt
@@ -18,6 +18,9 @@ public val Krpc: ApplicationPlugin<KrpcConfigBuilder.Server> = createApplication
     name = "Krpc",
     createConfiguration = { KrpcConfigBuilder.Server() },
 ) {
-    application.install(WebSockets)
+    application.pluginOrNull(WebSockets) ?: run {
+        application.install(WebSockets)
+    }
+
     application.attributes.put(KrpcServerPluginAttributesKey, pluginConfig)
 }


### PR DESCRIPTION
**Subsystem**
kRPC

**Problem Description**
Ktor plugin installed WebSockets twice if there was already a plugin before

**Solution**
Fix it!
