### PR TITLE
Release 0.9.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ env:
   ALGOLIA_INDEX_NAME: 'prod_kotlin_rpc'
   ALGOLIA_KEY: '${{ secrets.ALGOLIA_KEY }}'
   CONFIG_JSON_PRODUCT: 'kotlinx-rpc'
-  CONFIG_JSON_VERSION: '0.8.1'
+  CONFIG_JSON_VERSION: '0.9.0'
   DOKKA_ARTIFACT: 'dokka.zip'
   ASSEMBLE_DIR: '__docs_assembled'
   ASSEMBLE_ARTIFACT: 'assembled.zip'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 0.9.0
+> Published 17 July 2025
+
+### Bug fixes 🐛
+* Support nullable contextual serializers by @yakivy in https://github.com/Kotlin/kotlinx-rpc/pull/392
+* Make WS plugin installation for Ktor server more flexible by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/398
+* Make KtorRpcClient inherit KrpcClient by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/396
+
+### Documentation 📗
+* Update gRPC doc by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/391
+* Add stub targets tags for platforms table by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/397
+
+### Infra 🚧
+* Remove the monitor application by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/388
+
+### Other Changes 🧹
+* Update version for 0.9.0-SNAPSHOT by @Mr3zee in https://github.com/Kotlin/kotlinx-rpc/pull/387
+
+**Full Changelog**: https://github.com/Kotlin/kotlinx-rpc/compare/0.8.1...0.9.0
+
 # 0.8.1
 > Published 9 July 2025
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Example of a setup in a project's `build.gradle.kts`:
 plugins {
     kotlin("multiplatform") version "2.2.0"
     kotlin("plugin.serialization") version "2.2.0"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.8.1"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.9.0"
 }
 ```
 
@@ -151,15 +151,15 @@ And now you can add dependencies to your project:
 ```kotlin
 dependencies {
     // Client API
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-client:0.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-client:0.9.0")
     // Server API
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-server:0.8.1") 
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-server:0.9.0") 
     // Serialization module. Also, protobuf and cbor are provided
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json:0.8.1") 
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json:0.9.0") 
 
     // Transport implementation for Ktor
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-client:0.8.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-server:0.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-client:0.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-server:0.9.0")
 
     // Ktor API
     implementation("io.ktor:ktor-client-cio-jvm:$ktor_version")

--- a/docs/pages/kotlinx-rpc/help-versions.json
+++ b/docs/pages/kotlinx-rpc/help-versions.json
@@ -1,3 +1,3 @@
 [
-  {"version":"0.8.1","url":"/kotlinx-rpc/0.8.1/","isCurrent":true}
+  {"version":"0.9.0","url":"/kotlinx-rpc/0.9.0/","isCurrent":true}
 ]

--- a/docs/pages/kotlinx-rpc/topics/changelog.md
+++ b/docs/pages/kotlinx-rpc/topics/changelog.md
@@ -2,6 +2,27 @@
 
 This page contains all changes throughout releases of the library.
 
+## 0.9.0
+> Published 17 July 2025
+
+**Full Changelog**: [0.8.1...0.9.0](https://github.com/Kotlin/kotlinx-rpc/compare/0.8.1...0.9.0)
+
+#### Bug fixes 🐛 {id=Bug_fixes_0_9_0}
+* Support nullable contextual serializers by [@yakivy](https://github.com/yakivy) in [#392](https://github.com/Kotlin/kotlinx-rpc/pull/392)
+* Make WS plugin installation for Ktor server more flexible by [@Mr3zee](https://github.com/Mr3zee) in [#398](https://github.com/Kotlin/kotlinx-rpc/pull/398)
+* Make KtorRpcClient inherit KrpcClient by [@Mr3zee](https://github.com/Mr3zee) in [#396](https://github.com/Kotlin/kotlinx-rpc/pull/396)
+
+#### Documentation 📗 {id=Documentation_0_9_0}
+* Update gRPC doc by [@Mr3zee](https://github.com/Mr3zee) in [#391](https://github.com/Kotlin/kotlinx-rpc/pull/391)
+* Add stub targets tags for platforms table by [@Mr3zee](https://github.com/Mr3zee) in [#397](https://github.com/Kotlin/kotlinx-rpc/pull/397)
+
+#### Infra 🚧 {id=Infra_0_9_0}
+* Remove the monitor application by [@Mr3zee](https://github.com/Mr3zee) in [#388](https://github.com/Kotlin/kotlinx-rpc/pull/388)
+
+#### Other Changes 🧹 {id=Other_Changes_0_9_0}
+* Update version for 0.9.0-SNAPSHOT by [@Mr3zee](https://github.com/Mr3zee) in [#387](https://github.com/Kotlin/kotlinx-rpc/pull/387)
+
+
 ## 0.8.1
 > Published 9 July 2025
 

--- a/docs/pages/kotlinx-rpc/v.list
+++ b/docs/pages/kotlinx-rpc/v.list
@@ -14,6 +14,6 @@
     <var name="host" value="https://kotlin.github.io"/>
 
     <!--  Library versions  -->
-    <var name="kotlinx-rpc-version" value="0.8.1"/>
+    <var name="kotlinx-rpc-version" value="0.9.0"/>
     <var name="kotlin-version" value="2.2.0"/>
 </vars>

--- a/docs/pages/kotlinx-rpc/writerside.cfg
+++ b/docs/pages/kotlinx-rpc/writerside.cfg
@@ -12,5 +12,5 @@
     <images dir="images" web-path="images/"/>
     <categories src="c.list"/>
     <vars src="v.list"/>
-    <instance src="rpc.tree" version="0.8.1" web-path="/kotlinx-rpc/"/>
+    <instance src="rpc.tree" version="0.9.0" web-path="/kotlinx-rpc/"/>
 </ihp>

--- a/kotlin-js-store/package-lock.json
+++ b/kotlin-js-store/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kotlinx-rpc",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kotlinx-rpc",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "workspaces": [
         "packages/kotlinx-rpc-core",
         "packages/kotlinx-rpc-core-test",
@@ -4424,11 +4424,11 @@
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4447,11 +4447,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-client": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-client-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4470,11 +4470,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4493,14 +4493,14 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-client": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "ws": "8.18.0"
       },
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-client-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0",
         "ws": "8.18.0"
@@ -4520,11 +4520,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4543,11 +4543,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-server": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-server-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4566,11 +4566,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-logging": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-logging-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4589,11 +4589,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-cbor": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-cbor-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4612,11 +4612,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4635,11 +4635,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-json": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-json-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4658,11 +4658,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-protobuf": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-protobuf-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4681,11 +4681,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-server": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-server-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4704,11 +4704,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-test-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4727,11 +4727,11 @@
       }
     },
     "packages/kotlinx-rpc-utils": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-utils-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },

--- a/kotlin-js-store/wasm/package-lock.json
+++ b/kotlin-js-store/wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kotlinx-rpc",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kotlinx-rpc",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "workspaces": [
         "packages/kotlinx-rpc-core",
         "packages/kotlinx-rpc-core-test",
@@ -4424,11 +4424,11 @@
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4446,11 +4446,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-client": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-client-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4468,11 +4468,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4490,14 +4490,14 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-client": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "ws": "8.18.0"
       },
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-client-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0",
         "ws": "8.18.0"
@@ -4516,11 +4516,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4538,11 +4538,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-server": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-ktor-krpc-ktor-server-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4560,11 +4560,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-logging": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-logging-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4582,11 +4582,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-cbor": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-cbor-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4604,11 +4604,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-core": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-core-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4626,11 +4626,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-json": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-json-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4648,11 +4648,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-protobuf": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-serialization-krpc-serialization-protobuf-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4670,11 +4670,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-server": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-server-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4692,11 +4692,11 @@
       }
     },
     "packages/kotlinx-rpc-krpc-krpc-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-krpc-krpc-test-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },
@@ -4714,11 +4714,11 @@
       }
     },
     "packages/kotlinx-rpc-utils": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {}
     },
     "packages/kotlinx-rpc-utils-test": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "puppeteer": "24.9.0"
       },

--- a/samples/ktor-all-platforms-app/gradle/libs.versions.toml
+++ b/samples/ktor-all-platforms-app/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ ktor = "3.2.1"
 logback = "1.5.18"
 serialization = "1.8.1"
 coroutines = "1.10.2"
-kotlinx-rpc = "0.8.1"
+kotlinx-rpc = "0.9.0"
 
 [libraries]
 # kotlin

--- a/samples/ktor-android-app/gradle/libs.versions.toml
+++ b/samples/ktor-android-app/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ ktor = "3.2.1"
 kotlinx-serialization-json = "1.8.1"
 kotlinx-coroutines-core = "1.10.2"
 logback = "1.5.18"
-kotlinx-rpc = "0.8.1"
+kotlinx-rpc = "0.9.0"
 
 [libraries]
 # kotlin

--- a/samples/ktor-web-app/gradle/libs.versions.toml
+++ b/samples/ktor-web-app/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ ktor = "3.2.1"
 kotlinx-serialization-json = "1.8.1"
 kotlinx-coroutines-core = "1.10.2"
 logback = "1.5.18"
-kotlinx-rpc = "0.8.1"
+kotlinx-rpc = "0.9.0"
 
 [libraries]
 # kotlin

--- a/samples/simple-ktor-app/build.gradle.kts
+++ b/samples/simple-ktor-app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     kotlin("jvm") version "2.2.0"
     kotlin("plugin.serialization") version "2.2.0"
     id("io.ktor.plugin") version "3.2.1"
-    id("org.jetbrains.kotlinx.rpc.plugin") version "0.8.1"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.9.0"
 }
 
 group = "kotlinx.rpc.sample"
@@ -28,12 +28,12 @@ kotlin {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-client:0.8.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-server:0.8.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json:0.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-client:0.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-server:0.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json:0.9.0")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-client:0.8.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-server:0.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-client:0.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-server:0.9.0")
 
     implementation("io.ktor:ktor-client-cio")
     implementation("io.ktor:ktor-server-netty-jvm")

--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # core library version
-kotlinx-rpc = "0.9.0-SNAPSHOT"
+kotlinx-rpc = "0.9.0"
 
 # kotlin
 kotlin-lang = "2.2.0" # or env.KOTLIN_VERSION


### PR DESCRIPTION
# Release 0.9.0

Minor release due to a breaking change in https://github.com/Kotlin/kotlinx-rpc/pull/396

Also this release fixes the metadata problem during the publication for unresolved Apple and Windows targets. The issue was on TC, so no PR linked