### PR TITLE
Added gRPC service generation to the compiler plugin

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -922,8 +922,6 @@ internal class RpcStubGenerator(
                 visibility = DescriptorVisibilities.PUBLIC
                 modality = Modality.FINAL
             }.apply function@{
-                parameters = listOf(this@generateCallablesProperty.thisReceiver!!.copyTo(this))
-
                 val functionThisReceiver = vsApi {
                     stubCompanionObjectThisReceiver.copyToVS(this@function, origin = IrDeclarationOrigin.DEFINED)
                 }.also {

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueSymbol
 import org.jetbrains.kotlin.ir.types.*
@@ -36,7 +38,9 @@ private object Stub {
 
 private object Descriptor {
     const val CALLABLE_MAP = "callableMap"
+    const val CALLABLES = "callables"
     const val FQ_NAME = "fqName"
+    const val SIMPLE_NAME = "simpleName"
     const val GET_CALLABLE = "getCallable"
     const val CREATE_INSTANCE = "createInstance"
 }
@@ -287,7 +291,7 @@ internal class RpcStubGenerator(
      * __rpc_client.call(RpcCall(
      *     descriptor = Companion,
      *     callableName = "<method-name>",
-     *     parameters = arrayOf(<method-arg-0>, ...),
+     *     arguments = arrayOf(<method-arg-0>, ...),
      *     serviceId = __rpc_stub_id,
      * ))
      * ```
@@ -319,7 +323,7 @@ internal class RpcStubGenerator(
                     ctx.irBuiltIns.arrayOf
                 }
 
-                val parametersParameter = irCall(callee, type = ctx.arrayOfAnyNullable).apply arrayOfCall@{
+                val argumentsParameter = irCall(callee, type = ctx.arrayOfAnyNullable).apply arrayOfCall@{
                     if (arguments.isEmpty()) {
                         arguments {
                             types { +ctx.anyNullable }
@@ -352,7 +356,7 @@ internal class RpcStubGenerator(
 
                         +stringConst(method.function.name.asString())
 
-                        +parametersParameter
+                        +argumentsParameter
 
                         +irCallProperty(
                             clazz = stubClass,
@@ -479,6 +483,8 @@ internal class RpcStubGenerator(
     }
 
     private fun IrClass.generateCompanionObjectContent() {
+        generateSimpleName()
+
         generateFqName()
 
         generateInvokators()
@@ -486,6 +492,8 @@ internal class RpcStubGenerator(
         generateCallableMapProperty()
 
         generateGetCallableFunction()
+
+        generateCallablesProperty()
 
         generateCreateInstanceFunction()
 
@@ -495,34 +503,33 @@ internal class RpcStubGenerator(
     }
 
     /**
+     * `simpleName` property of the descriptor.
+     *
+     * ```kotlin
+     * override val simpleName = "MyService"
+     * ```
+     */
+    private fun IrClass.generateSimpleName() {
+        generateStringOverriddenProperty(
+            propertyName = Descriptor.SIMPLE_NAME,
+            propertySymbol = ctx.properties.rpcServiceDescriptorSimpleName,
+            value = declaration.simpleName,
+        )
+    }
+
+    /**
      * `fqName` property of the descriptor.
      *
      * ```kotlin
-     * override val fqName = "MyService"
+     * override val fqName = "my.pkg.MyService"
      * ```
      */
     private fun IrClass.generateFqName() {
-        addProperty {
-            name = Name.identifier(Descriptor.FQ_NAME)
-            visibility = DescriptorVisibilities.PUBLIC
-        }.apply {
-            overriddenSymbols = listOf(ctx.properties.rpcServiceDescriptorFqName)
-
-            addBackingFieldUtil {
-                visibility = DescriptorVisibilities.PRIVATE
-                type = ctx.irBuiltIns.stringType
-                vsApi { isFinalVS = true }
-            }.apply {
-                initializer = factory.createExpressionBody(
-                    stringConst(declaration.fqName)
-                )
-            }
-
-            addDefaultGetter(this@generateFqName, ctx.irBuiltIns) {
-                visibility = DescriptorVisibilities.PUBLIC
-                overriddenSymbols = listOf(ctx.properties.rpcServiceDescriptorFqName.owner.getterOrFail.symbol)
-            }
-        }
+        generateStringOverriddenProperty(
+            propertyName = Descriptor.FQ_NAME,
+            propertySymbol = ctx.properties.rpcServiceDescriptorFqName,
+            value = declaration.fqName,
+        )
     }
 
     private val invokators = mutableMapOf<String, IrProperty>()
@@ -536,19 +543,31 @@ internal class RpcStubGenerator(
     /**
      * Generates an invokator (`RpcInvokator`) for this callable.
      *
-     * For methods:
+     * For suspend methods:
      * ```kotlin
-     * private val <method-name>Invokator = RpcInvokator.Method<MyService> {
-     *     service: MyService, parameters: Array<Any?> ->
+     * private val <method-name>Invokator = RpcInvokator.UnaryResponse<MyService> {
+     *     service: MyService, arguments: Array<Any?> ->
      *
-     *     service.<method-name>(parameters[0] as<?> <parameter-type-1>, ..., $completion)
+     *     service.<method-name>(arguments[0] as<?> <argument-type-1>, ...)
      * }
      * ```
      *
+     * For flow methods:
+     * ```kotlin
+     * private val <method-name>Invokator = RpcInvokator.FlowResponse<MyService> {
+     *     service: MyService, arguments: Array<Any?> ->
+     *
+     *     service.<method-name>(arguments[0] as<?> <argument-type-1>, ...)
+     * }
+     * ```
+     *
+     * Difference is:
+     * - for RpcInvokator.UnaryResponse the lambda is `suspend` and returns Any?
+     * - for RpcInvokator.FlowResponse the lambda is not `suspend` and returns Flow<Any?>
+     *
      * Where:
      *  - `<method-name>` - the name of the method
-     *  - <parameter-type-k> - type of the kth parameter
-     *  - `$completion` - Continuation<Any?> parameter
+     *  - <argument-type-k> - type of the kth argument
      */
     @Suppress(
         "detekt.NestedBlockDepth",
@@ -556,11 +575,25 @@ internal class RpcStubGenerator(
         "detekt.CyclomaticComplexMethod",
     )
     private fun IrClass.generateInvokator(callable: ServiceDeclaration.Callable) {
+        check(callable is ServiceDeclaration.Method) {
+            "Only methods are allowed here"
+        }
+
         invokators[callable.name] = addProperty {
             name = Name.identifier("${callable.name}Invokator")
             visibility = DescriptorVisibilities.PRIVATE
         }.apply {
-            val propertyType = ctx.rpcInvokatorMethod.typeWith(declaration.serviceType)
+            val returnsFlow = !callable.function.isSuspend
+
+            val propertyType = when {
+                returnsFlow -> ctx.rpcInvokatorFlowResponse.typeWith(declaration.serviceType)
+                else -> ctx.rpcInvokatorUnaryResponse.typeWith(declaration.serviceType)
+            }
+
+            val resultType = when {
+                returnsFlow -> ctx.flow.typeWith(ctx.anyNullable)
+                else -> ctx.anyNullable
+            }
 
             addBackingFieldUtil {
                 visibility = DescriptorVisibilities.PRIVATE
@@ -572,8 +605,8 @@ internal class RpcStubGenerator(
                     name = SpecialNames.ANONYMOUS
                     visibility = DescriptorVisibilities.LOCAL
                     modality = Modality.FINAL
-                    returnType = ctx.anyNullable
-                    if (callable is ServiceDeclaration.Method) {
+                    returnType = resultType
+                    if (!returnsFlow) {
                         isSuspend = true
                     }
                 }.apply {
@@ -584,11 +617,9 @@ internal class RpcStubGenerator(
                         type = declaration.serviceType
                     }
 
-                    val parametersParameter = when (callable) {
-                        is ServiceDeclaration.Method -> addValueParameter {
-                            name = Name.identifier("parameters")
-                            type = ctx.arrayOfAnyNullable
-                        }
+                    val argumentsParameter = addValueParameter {
+                        name = Name.identifier("arguments")
+                        type = ctx.arrayOfAnyNullable
                     }
 
                     body = irBuilder(symbol).irBlockBody {
@@ -598,14 +629,14 @@ internal class RpcStubGenerator(
 
                                 values {
                                     callable.arguments.forEachIndexed { argIndex, arg ->
-                                        val parameter = irCall(
+                                        val argument = irCall(
                                             callee = ctx.functions.arrayGet.symbol,
                                             type = ctx.anyNullable,
                                         ).apply {
                                             vsApi { originVS = IrStatementOrigin.GET_ARRAY_ELEMENT }
 
                                             arguments {
-                                                dispatchReceiver = irGet(parametersParameter)
+                                                dispatchReceiver = irGet(argumentsParameter)
 
                                                 values {
                                                     +intConst(argIndex)
@@ -614,9 +645,9 @@ internal class RpcStubGenerator(
                                         }
 
                                         if (vsApi { arg.type.isNullableVS() }) {
-                                            +irSafeAs(parameter, arg.type)
+                                            +irSafeAs(argument, arg.type)
                                         } else {
-                                            +irAs(parameter, arg.type)
+                                            +irAs(argument, arg.type)
                                         }
                                     }
                                 }
@@ -627,11 +658,17 @@ internal class RpcStubGenerator(
                     }
                 }
 
-                val lambdaType = when (callable) {
-                    is ServiceDeclaration.Method -> ctx.suspendFunction2.typeWith(
+                val lambdaType = when {
+                    returnsFlow -> ctx.irBuiltIns.functionN(2).typeWith(
                         declaration.serviceType, // service
-                        ctx.anyNullable, // data
-                        ctx.anyNullable, // returnType
+                        ctx.arrayOfAnyNullable, // data
+                        resultType, // returnType
+                    )
+
+                    else -> ctx.irBuiltIns.suspendFunctionN(2).typeWith(
+                        declaration.serviceType, // service
+                        ctx.arrayOfAnyNullable, // data
+                        resultType, // returnType
                     )
                 }
 
@@ -682,46 +719,21 @@ internal class RpcStubGenerator(
      *  - `<callable-name-k>` - the name of the k-th callable in the service
      */
     private fun IrClass.generateCallableMapProperty() {
-        callableMap = addProperty {
-            name = Name.identifier(Descriptor.CALLABLE_MAP)
-            visibility = DescriptorVisibilities.PRIVATE
-            modality = Modality.FINAL
-        }.apply {
-            val rpcCallableType = ctx.rpcCallable.typeWith(declaration.serviceType)
-            val mapType = ctx.irBuiltIns.mapClass.typeWith(ctx.irBuiltIns.stringType, rpcCallableType)
-
-            addBackingFieldUtil {
-                type = mapType
-                vsApi { isFinalVS = true }
-                visibility = DescriptorVisibilities.PRIVATE
-            }.apply {
-                val isEmpty = declaration.methods.isEmpty()
-
-                initializer = factory.createExpressionBody(
-                    irMapOf(
-                        keyType = ctx.irBuiltIns.stringType,
-                        valueType = rpcCallableType,
-                        elements = declaration.methods.map { callable ->
-                            stringConst(callable.name) to irRpcCallable(callable)
-                        },
-                        isEmpty = isEmpty,
-                    )
-                )
-            }
-
-            addDefaultGetter(this@generateCallableMapProperty, ctx.irBuiltIns) {
-                visibility = DescriptorVisibilities.PRIVATE
-            }
-        }
+        callableMap = generateMapProperty(
+            propertyName = Descriptor.CALLABLE_MAP,
+            values = declaration.methods.memoryOptimizedMap { callable ->
+                stringConst(callable.name) to irRpcCallable(callable)
+            },
+            valueType = ctx.rpcCallable.typeWith(declaration.serviceType),
+        )
     }
 
     /**
-     * A call to constructor of the RpcCallable.
+     * A call to constructor of the RpcCallableDefault.
      *
      * ```kotlin
-     * RpcCallable<MyService>(
+     * RpcCallableDefault<MyService>(
      *     name = "<callable-name>",
-     *     dataType = RpcCall(typeOf<<callable-data-type>>()),
      *     returnType = RpcCall(typeOf<<callable-return-type>>()),
      *     invokator = <callable-invokator>,
      *     parameters = arrayOf( // or emptyArray()
@@ -732,7 +744,6 @@ internal class RpcStubGenerator(
      *         ),
      *         ...
      *     ),
-     *     isNonSuspendFunction = !function.isSuspend,
      * )
      *```
      *
@@ -753,7 +764,7 @@ internal class RpcStubGenerator(
                 type = ctx.rpcCallable.typeWith(declaration.serviceType),
                 symbol = ctx.rpcCallableDefault.constructors.single(),
                 typeArgumentsCount = 1,
-                valueArgumentsCount = 5,
+                valueArgumentsCount = if (declaration.isGrpc) 5 else 4,
                 constructorTypeArgumentsCount = 1,
             )
         }.apply {
@@ -847,50 +858,24 @@ internal class RpcStubGenerator(
 
             arguments {
                 values {
+                    // name
                     +stringConst(callable.name)
 
+                    // returnType
                     +irRpcTypeCall(returnType)
 
+                    // invokator
                     +irCallProperty(stubCompanionObject.owner, invokator)
 
+                    // parameters
                     +arrayOfCall
-
-                    +booleanConst(!callable.function.isSuspend)
                 }
             }
         }
     }
 
     private fun irListOfAnnotations(container: IrAnnotationContainer): IrCallImpl {
-        val isEmpty = container.annotations.isEmpty()
-        return vsApi {
-            IrCallImplVS(
-                startOffset = UNDEFINED_OFFSET,
-                endOffset = UNDEFINED_OFFSET,
-                symbol = if (isEmpty) ctx.functions.emptyList else ctx.functions.listOf,
-                type = ctx.listOfAnnotations,
-                typeArgumentsCount = 1,
-                valueArgumentsCount = if (isEmpty) 0 else 1,
-            )
-        }.apply applyIrListOfAnnotations@{
-            arguments {
-                types { +ctx.irBuiltIns.annotationType }
-
-                if (isEmpty) {
-                    return@applyIrListOfAnnotations
-                }
-
-                values {
-                    +IrVarargImpl(
-                        startOffset = UNDEFINED_OFFSET,
-                        endOffset = UNDEFINED_OFFSET,
-                        type = ctx.arrayOfAnnotations,
-                        varargElementType = ctx.irBuiltIns.annotationType,
-                        elements = container.annotations,
-                    )
-                }
-            }
-        }
+        return irListOf(ctx.irBuiltIns.annotationType, container.annotations)
     }
 
     private fun IrSimpleFunction.isNonSuspendingWithFlowReturn(): Boolean {
@@ -906,47 +891,59 @@ internal class RpcStubGenerator(
      * ```
      */
     private fun IrClass.generateGetCallableFunction() {
-        val resultType = ctx.rpcCallable.createType(hasQuestionMark = true, emptyList())
+        generateGetFromStringMap(
+            functionName = Descriptor.GET_CALLABLE,
+            resultType = ctx.rpcCallable.createType(hasQuestionMark = true, emptyList()),
+            overriddenSymbol = ctx.rpcServiceDescriptor.functionByName(Descriptor.GET_CALLABLE),
+            mapProperty = callableMap,
+        )
+    }
 
-        addFunction {
-            name = Name.identifier(Descriptor.GET_CALLABLE)
+    /**
+     * Accessor function for the `callableMap` property
+     * Defined in `RpcServiceDescriptor`
+     *
+     * ```kotlin
+     *  final override val callables: Collection<RpcCallable<MyService>> get() = callableMap.values
+     * ```
+     */
+    private fun IrClass.generateCallablesProperty() {
+        addProperty {
+            name = Name.identifier(Descriptor.CALLABLES)
             visibility = DescriptorVisibilities.PUBLIC
-            modality = Modality.OPEN
-            returnType = resultType
+            modality = Modality.FINAL
         }.apply {
-            overriddenSymbols = listOf(ctx.rpcServiceDescriptor.functionByName(Descriptor.GET_CALLABLE))
+            overriddenSymbols = listOf(ctx.properties.rpcServiceDescriptorCallables)
 
-            val functionThisReceiver = vsApi {
-                stubCompanionObjectThisReceiver.copyToVS(this@apply, origin = IrDeclarationOrigin.DEFINED)
-            }.also {
-                vsApi {
-                    dispatchReceiverParameterVS = it
+            val collectionType = ctx.irBuiltIns.collectionClass.typeWith(ctx.rpcCallable.typeWith(declaration.serviceType))
+
+            addGetter {
+                returnType = collectionType
+                visibility = DescriptorVisibilities.PUBLIC
+                modality = Modality.FINAL
+            }.apply function@{
+                parameters = listOf(this@generateCallablesProperty.thisReceiver!!.copyTo(this))
+
+                val functionThisReceiver = vsApi {
+                    stubCompanionObjectThisReceiver.copyToVS(this@function, origin = IrDeclarationOrigin.DEFINED)
+                }.also {
+                    vsApi {
+                        dispatchReceiverParameterVS = it
+                    }
                 }
-            }
 
-            val parameter = addValueParameter {
-                name = Name.identifier("name")
-                type = ctx.irBuiltIns.stringType
-            }
-
-            body = irBuilder(symbol).irBlockBody {
-                +irReturn(
-                    irCall(ctx.functions.mapGet.symbol, resultType).apply {
-                        vsApi { originVS = IrStatementOrigin.GET_ARRAY_ELEMENT }
-
-                        arguments {
-                            dispatchReceiver = irCallProperty(
-                                clazz = this@generateGetCallableFunction,
+                body = irBuilder(symbol).irBlockBody {
+                    +irReturn(
+                        irCallProperty(
+                            receiver = irCallProperty(
+                                clazz = this@generateCallablesProperty,
                                 property = callableMap,
                                 symbol = functionThisReceiver.symbol,
-                            )
-
-                            values {
-                                +irGet(parameter)
-                            }
-                        }
-                    }
-                )
+                            ),
+                            property = ctx.properties.mapValues.owner,
+                        )
+                    )
+                }
             }
         }
     }
@@ -1003,37 +1000,287 @@ internal class RpcStubGenerator(
     }
 
     /**
-     * override val delegate: GrpcDelegate = MyServiceDelegate
+     * ```kotlin
+     * override fun delegate(resolver: MessageCodecResolver): GrpcServiceDelegate {
+     *     val methodDescriptorMap = ...
+     *     val serviceDescriptor = ...
+     *
+     *     return GrpcServiceDelegate(methodDescriptorMap, serviceDescriptor)
+     * }
+     * ```
      */
     private fun IrClass.generateGrpcDelegateProperty() {
-        addProperty {
+        addFunction {
             name = Name.identifier(GrpcDescriptor.DELEGATE)
+            modality = Modality.FINAL
             visibility = DescriptorVisibilities.PUBLIC
-        }.apply {
-            overriddenSymbols = listOf(ctx.properties.grpcServiceDescriptorDelegate)
+            returnType = ctx.grpcServiceDelegate.defaultType
+        }.apply delegate@{
+            overriddenSymbols = listOf(ctx.functions.grpcServiceDescriptorDelegate.symbol)
 
-            addBackingFieldUtil {
-                visibility = DescriptorVisibilities.PRIVATE
-                type = ctx.grpcDelegate.defaultType
-                vsApi { isFinalVS = true }
-            }.apply {
-                initializer = factory.createExpressionBody(
-                    IrGetObjectValueImpl(
-                        startOffset = UNDEFINED_OFFSET,
-                        endOffset = UNDEFINED_OFFSET,
-                        type = ctx.grpcDelegate.defaultType,
-                        symbol = ctx.getIrClassSymbol(
-                            declaration.service.packageFqName?.asString()
-                                ?: error("Expected package name fro service ${declaration.service.name}"),
-                            "${declaration.service.name.asString()}Delegate",
-                        ),
-                    )
-                )
+            vsApi {
+                dispatchReceiverParameterVS = stubCompanionObjectThisReceiver
+                    .copyToVS(this@delegate, origin = IrDeclarationOrigin.DEFINED)
             }
 
-            addDefaultGetter(this@generateGrpcDelegateProperty, ctx.irBuiltIns) {
-                visibility = DescriptorVisibilities.PUBLIC
-                overriddenSymbols = listOf(ctx.properties.grpcServiceDescriptorDelegate.owner.getterOrFail.symbol)
+            val resolver = addValueParameter {
+                name = Name.identifier("resolver")
+                type = ctx.grpcMessageCodecResolver.defaultType
+            }
+
+            body = irBuilder(symbol).irBlockBody {
+                val methodDescriptorMap = irTemporary(
+                    value = irMethodDescriptorMap(resolver),
+                    nameHint = "methodDescriptorMap",
+                )
+
+                val serviceDescriptor = irTemporary(
+                    value = irServiceDescriptor(methodDescriptorMap),
+                    nameHint = "serviceDescriptor",
+                )
+
+                +irReturn(
+                    irCall(
+                        callee = ctx.grpcServiceDelegate.owner.primaryConstructor!!.symbol,
+                        type = ctx.grpcServiceDelegate.defaultType,
+                    ).apply {
+                        arguments {
+                            values {
+                                +irGet(methodDescriptorMap)
+                                +irGet(serviceDescriptor)
+                            }
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    /**
+     * A map that holds MethodDescriptors.
+     *
+     * ```kotlin
+     *  mapOf<String, MethodDescriptors<*, *>>(
+     *      Pair("<callable-name-1>", methodDescriptor(...)),
+     *      ...
+     *      Pair("<callable-name-n>", methodDescriptor(...)),
+     *  )
+     *
+     *  // when n=0:
+     *  emptyMap<String, MethodDescriptors<*, *>>()
+     * ```
+     *
+     * Where:
+     *  - `<callable-name-k>` - the name of the k-th callable in the service
+     */
+    private fun irMethodDescriptorMap(resolver: IrValueParameter): IrCallImpl {
+        return irMapOf(
+            keyType = ctx.irBuiltIns.stringType,
+            valueType = ctx.grpcPlatformMethodDescriptor.starProjectedType,
+            declaration.methods.memoryOptimizedMap { callable ->
+                stringConst(callable.name) to irMethodDescriptor(callable, resolver)
+            },
+        )
+    }
+
+    /**
+     * Ir call to `serviceDescriptor`
+     *
+     * ```kotlin
+     * serviceDescriptor(
+     *     name = MyService, // simpleName
+     *     methods = methodDescriptorMap.values, // Collection<MethodDescriptor<*, *>>
+     *     schemaDescriptor = null, // for now, only null
+     * )
+     * ```
+     */
+    private fun irServiceDescriptor(methodDescriptorMap: IrVariable): IrCallImpl {
+        return vsApi {
+            IrCallImplVS(
+                startOffset = UNDEFINED_OFFSET,
+                endOffset = UNDEFINED_OFFSET,
+                type = ctx.grpcPlatformServiceDescriptor.defaultType,
+                symbol = ctx.functions.serviceDescriptor,
+                typeArgumentsCount = 0,
+                valueArgumentsCount = 3,
+            )
+        }.apply {
+            arguments {
+                values {
+                    +stringConst(declaration.simpleName)
+
+                    +irCallProperty(
+                        receiver = IrGetValueImpl(
+                            startOffset = UNDEFINED_OFFSET,
+                            endOffset = UNDEFINED_OFFSET,
+                            type = methodDescriptorMap.type,
+                            symbol = methodDescriptorMap.symbol,
+                        ),
+                        property = ctx.properties.mapValues.owner,
+                    )
+
+                    +nullConst(ctx.anyNullable)
+                }
+            }
+        }
+    }
+
+    /**
+     * gRPC Platform MethodDescriptor call
+     *
+     * ```kotlin
+     * // In scope: resolver: MessageCodecResolver
+     *
+     * methodDescriptor<<request-type>, <response-type>>(
+     *     fullMethodName = "${descriptor.simpleName}/${callable.name}",
+     *     requestCodec = <request-codec>,
+     *     responseCodec = <response-codec>,
+     *     type = MethodType.<method-type>,
+     *     schemaDescriptor = null, // null for now
+     *     // todo understand these values
+     *     idempotent = true,
+     *     safe = true,
+     *     sampledToLocalTracing = true,
+     * )
+     * ```
+     *
+     * Where:
+     *   - <request-type> - the type of the request, namely the first parameter, unwrapped if a Flow
+     *   - <response-type> - the type of the response, unwrapped if a Flow
+     *   - <method-name> - the name of the method
+     *   - <method-type> - one of MethodType.UNARY, MethodType.SERVER_STREAMING,
+     *   MethodType.CLIENT_STREAMING, MethodType.BIDI_STREAMING
+     *   - <request-codec>/<response-codec> - a MessageCodec getter, see [irCodec]
+     */
+    private fun irMethodDescriptor(callable: ServiceDeclaration.Callable, resolver: IrValueParameter): IrCall {
+        check(callable is ServiceDeclaration.Method) {
+            "Only methods are allowed here"
+        }
+
+        check(callable.arguments.size == 1) {
+            "Only single argument methods are allowed here"
+        }
+
+        val requestParameterType = callable.arguments[0].type
+        val responseParameterType = callable.function.returnType
+
+        val requestType: IrType = requestParameterType.unwrapFlow()
+        val responseType: IrType = responseParameterType.unwrapFlow()
+
+        val methodDescriptorType = ctx.grpcPlatformMethodDescriptor.typeWith(requestType, responseType)
+
+        return vsApi {
+            IrCallImplVS(
+                startOffset = UNDEFINED_OFFSET,
+                endOffset = UNDEFINED_OFFSET,
+                type = methodDescriptorType,
+                symbol = ctx.functions.methodDescriptor,
+                typeArgumentsCount = 2,
+                valueArgumentsCount = 8,
+            )
+        }.apply {
+            arguments {
+                types {
+                    +requestType
+                    +responseType
+                }
+
+                values {
+                    // fullMethodName
+                    +stringConst("${declaration.simpleName}/${callable.name}")
+
+                    // requestCodec
+                    +irCodec(requestType, resolver)
+
+                    // responseCodec
+                    +irCodec(responseType, resolver)
+
+                    // type
+                    +IrGetEnumValueImpl(
+                        startOffset = UNDEFINED_OFFSET,
+                        endOffset = UNDEFINED_OFFSET,
+                        type = ctx.grpcPlatformMethodType.defaultType,
+                        symbol = when {
+                            requestParameterType.classOrNull == ctx.flow && responseParameterType.classOrNull == ctx.flow -> {
+                                ctx.grpcPlatformMethodTypeBidiStreaming
+                            }
+
+                            requestParameterType.classOrNull == ctx.flow && responseParameterType.classOrNull != ctx.flow -> {
+                                ctx.grpcPlatformMethodTypeClientStreaming
+                            }
+
+                            requestParameterType.classOrNull != ctx.flow && responseParameterType.classOrNull == ctx.flow -> {
+                                ctx.grpcPlatformMethodTypeServerStreaming
+                            }
+
+                            else -> {
+                                ctx.grpcPlatformMethodTypeUnary
+                            }
+                        },
+                    )
+
+                    // schemaDescriptor
+                    +nullConst(ctx.anyNullable)
+
+                    // todo figure out these
+                    // idempotent
+                    +booleanConst(true)
+
+                    // safe
+                    +booleanConst(true)
+
+                    // sampledToLocalTracing
+                    +booleanConst(true)
+                }
+            }
+        }
+    }
+
+    /**
+     * If [type] is annotated with [RpcIrContext.withCodecAnnotation],
+     * we use its codec object
+     *
+     * If not, use [resolver].resolve()
+     */
+    private fun irCodec(type: IrType, resolver: IrValueParameter): IrExpression {
+        val owner = type.classOrFail.owner
+        val protobufMessage = owner.getAnnotation(ctx.withCodecAnnotation.owner.kotlinFqName)
+
+        return if (protobufMessage != null) {
+            val classReference = protobufMessage.arguments.single() as? IrClassReference
+                ?: error("Expected IrClassReference for ${ctx.withCodecAnnotation.owner.kotlinFqName} parameter")
+
+            val codec = classReference.classType
+
+            IrGetObjectValueImpl(
+                startOffset = UNDEFINED_OFFSET,
+                endOffset = UNDEFINED_OFFSET,
+                type = codec,
+                symbol = codec.classOrFail,
+            )
+        } else {
+            vsApi {
+                IrCallImplVS(
+                    startOffset = UNDEFINED_OFFSET,
+                    endOffset = UNDEFINED_OFFSET,
+                    type = ctx.grpcMessageCodec.typeWith(type),
+                    symbol = ctx.functions.grpcMessageCodecResolverResolve.symbol,
+                    typeArgumentsCount = 0,
+                    valueArgumentsCount = 1,
+                )
+            }.apply {
+                arguments {
+                    dispatchReceiver = IrGetValueImpl(
+                        startOffset = UNDEFINED_OFFSET,
+                        endOffset = UNDEFINED_OFFSET,
+                        type = resolver.type,
+                        symbol = resolver.symbol,
+                    )
+
+                    values {
+                        +irTypeOfCall(type)
+                    }
+                }
             }
         }
     }
@@ -1277,6 +1524,165 @@ internal class RpcStubGenerator(
         }
     }
 
+    private fun irListOf(
+        valueType: IrType,
+        elements: List<IrExpression>,
+        isEmpty: Boolean = elements.isEmpty(),
+    ): IrCallImpl {
+        return vsApi {
+            IrCallImplVS(
+                startOffset = UNDEFINED_OFFSET,
+                endOffset = UNDEFINED_OFFSET,
+                type = ctx.irBuiltIns.listClass.typeWith(valueType),
+                symbol = if (isEmpty) ctx.functions.emptyList else ctx.functions.listOf,
+                typeArgumentsCount = 1,
+                valueArgumentsCount = if (isEmpty) 0 else 1,
+            )
+        }.apply listApply@{
+            if (isEmpty) {
+                arguments {
+                    types {
+                        +valueType
+                    }
+                }
+
+                return@listApply
+            }
+
+            val varargType = ctx.irBuiltIns.arrayClass.typeWith(valueType, Variance.OUT_VARIANCE)
+
+            val vararg = IrVarargImpl(
+                startOffset = UNDEFINED_OFFSET,
+                endOffset = UNDEFINED_OFFSET,
+                type = varargType,
+                varargElementType = valueType,
+                elements = elements,
+            )
+
+            arguments {
+                types {
+                    +valueType
+                }
+
+                values {
+                    +vararg
+                }
+            }
+        }
+    }
+
+    private fun IrClass.generateStringOverriddenProperty(
+        propertyName: String,
+        propertySymbol: IrPropertySymbol,
+        value: String,
+    ) {
+        addProperty {
+            name = Name.identifier(propertyName)
+            visibility = DescriptorVisibilities.PUBLIC
+        }.apply {
+            overriddenSymbols = listOf(propertySymbol)
+
+            addBackingFieldUtil {
+                visibility = DescriptorVisibilities.PRIVATE
+                type = ctx.irBuiltIns.stringType
+                vsApi { isFinalVS = true }
+            }.apply {
+                initializer = factory.createExpressionBody(
+                    stringConst(value)
+                )
+            }
+
+            addDefaultGetter(this@generateStringOverriddenProperty, ctx.irBuiltIns) {
+                visibility = DescriptorVisibilities.PUBLIC
+                overriddenSymbols = listOf(propertySymbol.owner.getterOrFail.symbol)
+            }
+        }
+    }
+
+    private fun IrClass.generateMapProperty(
+        propertyName: String,
+        values: List<Pair<IrExpression, IrExpression>>,
+        valueType: IrType,
+    ): IrProperty {
+        return addProperty {
+            name = Name.identifier(propertyName)
+            visibility = DescriptorVisibilities.PRIVATE
+            modality = Modality.FINAL
+        }.apply {
+            val mapType = ctx.irBuiltIns.mapClass.typeWith(ctx.irBuiltIns.stringType, valueType)
+
+            addBackingFieldUtil {
+                type = mapType
+                vsApi { isFinalVS = true }
+                visibility = DescriptorVisibilities.PRIVATE
+            }.apply {
+                val isEmpty = values.isEmpty()
+
+                initializer = factory.createExpressionBody(
+                    irMapOf(
+                        keyType = ctx.irBuiltIns.stringType,
+                        valueType = valueType,
+                        elements = values,
+                        isEmpty = isEmpty,
+                    )
+                )
+            }
+
+            addDefaultGetter(this@generateMapProperty, ctx.irBuiltIns) {
+                visibility = DescriptorVisibilities.PRIVATE
+            }
+        }
+    }
+
+    private fun IrClass.generateGetFromStringMap(
+        functionName: String,
+        resultType: IrType,
+        overriddenSymbol: IrSimpleFunctionSymbol,
+        mapProperty: IrProperty,
+    ) {
+        addFunction {
+            name = Name.identifier(functionName)
+            visibility = DescriptorVisibilities.PUBLIC
+            modality = Modality.FINAL
+            returnType = resultType
+        }.apply {
+            overriddenSymbols = listOf(overriddenSymbol)
+
+            val functionThisReceiver = vsApi {
+                stubCompanionObjectThisReceiver.copyToVS(this@apply, origin = IrDeclarationOrigin.DEFINED)
+            }.also {
+                vsApi {
+                    dispatchReceiverParameterVS = it
+                }
+            }
+
+            val parameter = addValueParameter {
+                name = Name.identifier("name")
+                type = ctx.irBuiltIns.stringType
+            }
+
+            body = irBuilder(symbol).irBlockBody {
+                +irReturn(
+                    irCall(ctx.functions.mapGet.symbol, resultType).apply {
+                        vsApi { originVS = IrStatementOrigin.GET_ARRAY_ELEMENT }
+
+                        arguments {
+                            dispatchReceiver = irCallProperty(
+                                clazz = this@generateGetFromStringMap,
+                                property = mapProperty,
+                                symbol = functionThisReceiver.symbol,
+                            )
+
+                            values {
+                                +irGet(parameter)
+                            }
+                        }
+                    }
+                )
+            }
+        }
+    }
+
     // adds fake overrides for toString(), equals(), hashCode() for a class
     private fun IrClass.addAnyOverrides(parent: IrClass? = null) {
         val anyClass = ctx.irBuiltIns.anyClass.owner
@@ -1354,6 +1760,12 @@ internal class RpcStubGenerator(
         value = value,
     )
 
+    private fun nullConst(type: IrType) = IrConstImpl.constNull(
+        startOffset = UNDEFINED_OFFSET,
+        endOffset = UNDEFINED_OFFSET,
+        type = type,
+    )
+
     private fun intConst(value: Int) = IrConstImpl.int(
         startOffset = UNDEFINED_OFFSET,
         endOffset = UNDEFINED_OFFSET,
@@ -1367,6 +1779,14 @@ internal class RpcStubGenerator(
         type = ctx.irBuiltIns.booleanType,
         value = value,
     )
+
+    private fun IrType.unwrapFlow(): IrType {
+        return if (classOrNull == ctx.flow) {
+            (this as IrSimpleType).arguments[0].typeOrFail
+        } else {
+            this
+        }
+    }
 
     private inline fun <T> vsApi(body: VersionSpecificApi.() -> T): T {
         return ctx.versionSpecificApi.body()

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/ServiceDeclaration.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/ServiceDeclaration.kt
@@ -20,6 +20,7 @@ class ServiceDeclaration(
 ) {
     // todo change to extension after KRPC-178
     val isGrpc = service.hasAnnotation(RpcClassId.grpcAnnotation)
+    val simpleName = service.kotlinFqName.shortName().asString()
     val fqName = service.kotlinFqName.asString()
 
     val serviceType = service.defaultType

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -3,9 +3,9 @@ public abstract interface class kotlinx/rpc/RemoteService {
 
 public final class kotlinx/rpc/RpcCall {
 	public fun <init> (Lkotlinx/rpc/descriptor/RpcServiceDescriptor;Ljava/lang/String;[Ljava/lang/Object;J)V
+	public final fun getArguments ()[Ljava/lang/Object;
 	public final fun getCallableName ()Ljava/lang/String;
 	public final fun getDescriptor ()Lkotlinx/rpc/descriptor/RpcServiceDescriptor;
-	public final fun getParameters ()[Ljava/lang/Object;
 	public final fun getServiceId ()J
 }
 
@@ -35,13 +35,20 @@ public abstract interface class kotlinx/rpc/descriptor/RpcCallable {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getParameters ()[Lkotlinx/rpc/descriptor/RpcParameter;
 	public abstract fun getReturnType ()Lkotlinx/rpc/descriptor/RpcType;
-	public abstract fun isNonSuspendFunction ()Z
 }
 
 public abstract interface class kotlinx/rpc/descriptor/RpcInvokator {
 }
 
+public abstract interface class kotlinx/rpc/descriptor/RpcInvokator$FlowResponse : kotlinx/rpc/descriptor/RpcInvokator {
+	public abstract fun call (Ljava/lang/Object;[Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public abstract interface class kotlinx/rpc/descriptor/RpcInvokator$Method : kotlinx/rpc/descriptor/RpcInvokator {
+	public abstract fun call (Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class kotlinx/rpc/descriptor/RpcInvokator$UnaryResponse : kotlinx/rpc/descriptor/RpcInvokator {
 	public abstract fun call (Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -55,10 +62,14 @@ public abstract interface class kotlinx/rpc/descriptor/RpcParameter {
 public abstract interface class kotlinx/rpc/descriptor/RpcServiceDescriptor {
 	public abstract fun createInstance (JLkotlinx/rpc/RpcClient;)Ljava/lang/Object;
 	public abstract fun getCallable (Ljava/lang/String;)Lkotlinx/rpc/descriptor/RpcCallable;
+	public abstract fun getCallables ()Ljava/util/Collection;
 	public abstract fun getFqName ()Ljava/lang/String;
+	public abstract fun getSimpleName ()Ljava/lang/String;
 }
 
 public final class kotlinx/rpc/descriptor/RpcServiceDescriptorKt {
+	public static final fun getFlowInvokator (Lkotlinx/rpc/descriptor/RpcCallable;)Lkotlinx/rpc/descriptor/RpcInvokator$FlowResponse;
+	public static final fun getUnaryInvokator (Lkotlinx/rpc/descriptor/RpcCallable;)Lkotlinx/rpc/descriptor/RpcInvokator$UnaryResponse;
 	public static final fun serviceDescriptorOf (Lkotlin/reflect/KClass;)Lkotlinx/rpc/descriptor/RpcServiceDescriptor;
 	public static final fun serviceDescriptorOf (Lkotlin/reflect/KType;)Lkotlinx/rpc/descriptor/RpcServiceDescriptor;
 }

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -17,8 +17,6 @@ open annotation class kotlinx.rpc.annotations/Rpc : kotlin/Annotation { // kotli
 abstract interface <#A: kotlin/Any> kotlinx.rpc.descriptor/RpcCallable { // kotlinx.rpc.descriptor/RpcCallable|null[0]
     abstract val invokator // kotlinx.rpc.descriptor/RpcCallable.invokator|{}invokator[0]
         abstract fun <get-invokator>(): kotlinx.rpc.descriptor/RpcInvokator<#A> // kotlinx.rpc.descriptor/RpcCallable.invokator.<get-invokator>|<get-invokator>(){}[0]
-    abstract val isNonSuspendFunction // kotlinx.rpc.descriptor/RpcCallable.isNonSuspendFunction|{}isNonSuspendFunction[0]
-        abstract fun <get-isNonSuspendFunction>(): kotlin/Boolean // kotlinx.rpc.descriptor/RpcCallable.isNonSuspendFunction.<get-isNonSuspendFunction>|<get-isNonSuspendFunction>(){}[0]
     abstract val name // kotlinx.rpc.descriptor/RpcCallable.name|{}name[0]
         abstract fun <get-name>(): kotlin/String // kotlinx.rpc.descriptor/RpcCallable.name.<get-name>|<get-name>(){}[0]
     abstract val parameters // kotlinx.rpc.descriptor/RpcCallable.parameters|{}parameters[0]
@@ -28,8 +26,12 @@ abstract interface <#A: kotlin/Any> kotlinx.rpc.descriptor/RpcCallable { // kotl
 }
 
 abstract interface <#A: kotlin/Any> kotlinx.rpc.descriptor/RpcServiceDescriptor { // kotlinx.rpc.descriptor/RpcServiceDescriptor|null[0]
+    abstract val callables // kotlinx.rpc.descriptor/RpcServiceDescriptor.callables|{}callables[0]
+        abstract fun <get-callables>(): kotlin.collections/Collection<kotlinx.rpc.descriptor/RpcCallable<#A>> // kotlinx.rpc.descriptor/RpcServiceDescriptor.callables.<get-callables>|<get-callables>(){}[0]
     abstract val fqName // kotlinx.rpc.descriptor/RpcServiceDescriptor.fqName|{}fqName[0]
         abstract fun <get-fqName>(): kotlin/String // kotlinx.rpc.descriptor/RpcServiceDescriptor.fqName.<get-fqName>|<get-fqName>(){}[0]
+    abstract val simpleName // kotlinx.rpc.descriptor/RpcServiceDescriptor.simpleName|{}simpleName[0]
+        abstract fun <get-simpleName>(): kotlin/String // kotlinx.rpc.descriptor/RpcServiceDescriptor.simpleName.<get-simpleName>|<get-simpleName>(){}[0]
 
     abstract fun createInstance(kotlin/Long, kotlinx.rpc/RpcClient): #A // kotlinx.rpc.descriptor/RpcServiceDescriptor.createInstance|createInstance(kotlin.Long;kotlinx.rpc.RpcClient){}[0]
     abstract fun getCallable(kotlin/String): kotlinx.rpc.descriptor/RpcCallable<#A>? // kotlinx.rpc.descriptor/RpcServiceDescriptor.getCallable|getCallable(kotlin.String){}[0]
@@ -66,23 +68,32 @@ abstract interface kotlinx.rpc/RpcServer { // kotlinx.rpc/RpcServer|null[0]
 }
 
 sealed interface <#A: kotlin/Any> kotlinx.rpc.descriptor/RpcInvokator { // kotlinx.rpc.descriptor/RpcInvokator|null[0]
-    abstract fun interface <#A1: kotlin/Any> Method : kotlinx.rpc.descriptor/RpcInvokator<#A1> { // kotlinx.rpc.descriptor/RpcInvokator.Method|null[0]
-        abstract suspend fun call(#A1, kotlin/Array<kotlin/Any?>): kotlin/Any? // kotlinx.rpc.descriptor/RpcInvokator.Method.call|call(1:0;kotlin.Array<kotlin.Any?>){}[0]
+    abstract fun interface <#A1: kotlin/Any> FlowResponse : kotlinx.rpc.descriptor/RpcInvokator<#A1> { // kotlinx.rpc.descriptor/RpcInvokator.FlowResponse|null[0]
+        abstract fun call(#A1, kotlin/Array<kotlin/Any?>): kotlinx.coroutines.flow/Flow<kotlin/Any?> // kotlinx.rpc.descriptor/RpcInvokator.FlowResponse.call|call(1:0;kotlin.Array<kotlin.Any?>){}[0]
+    }
+
+    abstract fun interface <#A1: kotlin/Any> UnaryResponse : kotlinx.rpc.descriptor/RpcInvokator<#A1> { // kotlinx.rpc.descriptor/RpcInvokator.UnaryResponse|null[0]
+        abstract suspend fun call(#A1, kotlin/Array<kotlin/Any?>): kotlin/Any? // kotlinx.rpc.descriptor/RpcInvokator.UnaryResponse.call|call(1:0;kotlin.Array<kotlin.Any?>){}[0]
     }
 }
 
 final class kotlinx.rpc/RpcCall { // kotlinx.rpc/RpcCall|null[0]
     constructor <init>(kotlinx.rpc.descriptor/RpcServiceDescriptor<*>, kotlin/String, kotlin/Array<kotlin/Any?>, kotlin/Long) // kotlinx.rpc/RpcCall.<init>|<init>(kotlinx.rpc.descriptor.RpcServiceDescriptor<*>;kotlin.String;kotlin.Array<kotlin.Any?>;kotlin.Long){}[0]
 
+    final val arguments // kotlinx.rpc/RpcCall.arguments|{}arguments[0]
+        final fun <get-arguments>(): kotlin/Array<kotlin/Any?> // kotlinx.rpc/RpcCall.arguments.<get-arguments>|<get-arguments>(){}[0]
     final val callableName // kotlinx.rpc/RpcCall.callableName|{}callableName[0]
         final fun <get-callableName>(): kotlin/String // kotlinx.rpc/RpcCall.callableName.<get-callableName>|<get-callableName>(){}[0]
     final val descriptor // kotlinx.rpc/RpcCall.descriptor|{}descriptor[0]
         final fun <get-descriptor>(): kotlinx.rpc.descriptor/RpcServiceDescriptor<*> // kotlinx.rpc/RpcCall.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
-    final val parameters // kotlinx.rpc/RpcCall.parameters|{}parameters[0]
-        final fun <get-parameters>(): kotlin/Array<kotlin/Any?> // kotlinx.rpc/RpcCall.parameters.<get-parameters>|<get-parameters>(){}[0]
     final val serviceId // kotlinx.rpc/RpcCall.serviceId|{}serviceId[0]
         final fun <get-serviceId>(): kotlin/Long // kotlinx.rpc/RpcCall.serviceId.<get-serviceId>|<get-serviceId>(){}[0]
 }
+
+final val kotlinx.rpc.descriptor/flowInvokator // kotlinx.rpc.descriptor/flowInvokator|@kotlinx.rpc.descriptor.RpcCallable<0:0>{0§<kotlin.Any>}flowInvokator[0]
+    final fun <#A1: kotlin/Any> (kotlinx.rpc.descriptor/RpcCallable<#A1>).<get-flowInvokator>(): kotlinx.rpc.descriptor/RpcInvokator.FlowResponse<#A1> // kotlinx.rpc.descriptor/flowInvokator.<get-flowInvokator>|<get-flowInvokator>@kotlinx.rpc.descriptor.RpcCallable<0:0>(){0§<kotlin.Any>}[0]
+final val kotlinx.rpc.descriptor/unaryInvokator // kotlinx.rpc.descriptor/unaryInvokator|@kotlinx.rpc.descriptor.RpcCallable<0:0>{0§<kotlin.Any>}unaryInvokator[0]
+    final fun <#A1: kotlin/Any> (kotlinx.rpc.descriptor/RpcCallable<#A1>).<get-unaryInvokator>(): kotlinx.rpc.descriptor/RpcInvokator.UnaryResponse<#A1> // kotlinx.rpc.descriptor/unaryInvokator.<get-unaryInvokator>|<get-unaryInvokator>@kotlinx.rpc.descriptor.RpcCallable<0:0>(){0§<kotlin.Any>}[0]
 
 final fun <#A: kotlin/Any> (kotlinx.rpc/RpcClient).kotlinx.rpc/withService(kotlin.reflect/KClass<#A>): #A // kotlinx.rpc/withService|withService@kotlinx.rpc.RpcClient(kotlin.reflect.KClass<0:0>){0§<kotlin.Any>}[0]
 final fun <#A: kotlin/Any> (kotlinx.rpc/RpcClient).kotlinx.rpc/withService(kotlin.reflect/KType): #A // kotlinx.rpc/withService|withService@kotlinx.rpc.RpcClient(kotlin.reflect.KType){0§<kotlin.Any>}[0]

--- a/core/src/commonMain/kotlin/kotlinx/rpc/RpcCall.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/RpcCall.kt
@@ -11,12 +11,12 @@ import kotlinx.rpc.descriptor.RpcServiceDescriptor
  *
  * @property descriptor [RpcServiceDescriptor] of a service that made the call.
  * @property callableName The name of the method being called.
- * @property parameters array of parameters for the call
+ * @property arguments array of arguments for the call
  * @property serviceId The id of the service that made the call.
  */
 public class RpcCall(
     public val descriptor: RpcServiceDescriptor<*>,
     public val callableName: String,
-    public val parameters: Array<Any?>,
+    public val arguments: Array<Any?>,
     public val serviceId: Long,
 )

--- a/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.rpc.descriptor
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.rpc.RpcClient
 import kotlinx.rpc.annotations.Rpc
 import kotlinx.rpc.internal.*
@@ -12,23 +13,23 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 @ExperimentalRpcApi
-public inline fun <@Rpc reified T : Any> serviceDescriptorOf(): RpcServiceDescriptor<T> {
-    return serviceDescriptorOf(T::class)
+public inline fun <@Rpc reified Service : Any> serviceDescriptorOf(): RpcServiceDescriptor<Service> {
+    return serviceDescriptorOf(Service::class)
 }
 
 @ExperimentalRpcApi
-public fun <@Rpc T : Any> serviceDescriptorOf(kType: KType): RpcServiceDescriptor<T> {
+public fun <@Rpc Service : Any> serviceDescriptorOf(kType: KType): RpcServiceDescriptor<Service> {
     return serviceDescriptorOf(kType.rpcInternalKClass())
 }
 
 @ExperimentalRpcApi
-public fun <@Rpc T : Any> serviceDescriptorOf(kClass: KClass<T>): RpcServiceDescriptor<T> {
+public fun <@Rpc Service : Any> serviceDescriptorOf(kClass: KClass<Service>): RpcServiceDescriptor<Service> {
     val maybeDescriptor = internalServiceDescriptorOf(kClass)
         ?: internalRpcError("Unable to find a service descriptor of the $kClass")
 
     if (maybeDescriptor is RpcServiceDescriptor<*>) {
         @Suppress("UNCHECKED_CAST")
-        return maybeDescriptor as RpcServiceDescriptor<T>
+        return maybeDescriptor as RpcServiceDescriptor<Service>
     }
 
     internalRpcError(
@@ -39,28 +40,44 @@ public fun <@Rpc T : Any> serviceDescriptorOf(kClass: KClass<T>): RpcServiceDesc
 }
 
 @ExperimentalRpcApi
-public interface RpcServiceDescriptor<@Rpc T : Any> {
+public interface RpcServiceDescriptor<@Rpc Service : Any> {
+    public val simpleName: String
+
     public val fqName: String
 
-    public fun getCallable(name: String): RpcCallable<T>?
+    public fun getCallable(name: String): RpcCallable<Service>?
 
-    public fun createInstance(serviceId: Long, client: RpcClient): T
+    public val callables: Collection<RpcCallable<Service>>
+
+    public fun createInstance(serviceId: Long, client: RpcClient): Service
 }
 
 @ExperimentalRpcApi
-public interface RpcCallable<@Rpc T : Any> {
+public interface RpcCallable<@Rpc Service : Any> {
     public val name: String
     public val returnType: RpcType
-    public val invokator: RpcInvokator<T>
+    public val invokator: RpcInvokator<Service>
     public val parameters: Array<out RpcParameter>
-    public val isNonSuspendFunction: Boolean
 }
 
 @ExperimentalRpcApi
-public sealed interface RpcInvokator<@Rpc T : Any> {
+public val <@Rpc Service : Any> RpcCallable<Service>.unaryInvokator: RpcInvokator.UnaryResponse<Service>
+    get() = invokator as RpcInvokator.UnaryResponse<Service>
+
+@ExperimentalRpcApi
+public val <@Rpc Service : Any> RpcCallable<Service>.flowInvokator: RpcInvokator.FlowResponse<Service>
+    get() = invokator as RpcInvokator.FlowResponse<Service>
+
+@ExperimentalRpcApi
+public sealed interface RpcInvokator<@Rpc Service : Any> {
     @ExperimentalRpcApi
-    public fun interface Method<@Rpc T : Any> : RpcInvokator<T> {
-        public suspend fun call(service: T, parameters: Array<Any?>): Any?
+    public fun interface UnaryResponse<@Rpc Service : Any> : RpcInvokator<Service> {
+        public suspend fun call(service: Service, arguments: Array<Any?>): Any?
+    }
+
+    @ExperimentalRpcApi
+    public fun interface FlowResponse<@Rpc Service : Any> : RpcInvokator<Service> {
+        public fun call(service: Service, arguments: Array<Any?>): Flow<Any?>
     }
 }
 

--- a/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptorDefault.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptorDefault.kt
@@ -9,13 +9,12 @@ import kotlinx.rpc.internal.utils.InternalRpcApi
 import kotlin.reflect.KType
 
 @InternalRpcApi
-public class RpcCallableDefault<@Rpc T : Any>(
+public class RpcCallableDefault<@Rpc Service : Any>(
     override val name: String,
     override val returnType: RpcType,
-    override val invokator: RpcInvokator<T>,
+    override val invokator: RpcInvokator<Service>,
     override val parameters: Array<out RpcParameter>,
-    override val isNonSuspendFunction: Boolean,
-) : RpcCallable<T>
+) : RpcCallable<Service>
 
 @InternalRpcApi
 public class RpcParameterDefault(

--- a/grpc/grpc-codec-kotlinx-serialization/api/grpc-codec-kotlinx-serialization.api
+++ b/grpc/grpc-codec-kotlinx-serialization/api/grpc-codec-kotlinx-serialization.api
@@ -1,0 +1,9 @@
+public final class kotlinx/rpc/grpc/codec/kotlinx/serialization/KotlinxSerializationCodecResolver : kotlinx/rpc/grpc/codec/MessageCodecResolver {
+	public fun <init> (Lkotlinx/serialization/SerialFormat;)V
+	public fun resolve (Lkotlin/reflect/KType;)Lkotlinx/rpc/grpc/codec/MessageCodec;
+}
+
+public final class kotlinx/rpc/grpc/codec/kotlinx/serialization/KotlinxSerializationCodecResolverKt {
+	public static final fun asCodecResolver (Lkotlinx/serialization/SerialFormat;)Lkotlinx/rpc/grpc/codec/MessageCodecResolver;
+}
+

--- a/grpc/grpc-codec-kotlinx-serialization/api/grpc-codec-kotlinx-serialization.klib.api
+++ b/grpc/grpc-codec-kotlinx-serialization/api/grpc-codec-kotlinx-serialization.klib.api
@@ -1,0 +1,15 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.jetbrains.kotlinx:grpc-codec-kotlinx-serialization>
+final class kotlinx.rpc.grpc.codec.kotlinx.serialization/KotlinxSerializationCodecResolver : kotlinx.rpc.grpc.codec/MessageCodecResolver { // kotlinx.rpc.grpc.codec.kotlinx.serialization/KotlinxSerializationCodecResolver|null[0]
+    constructor <init>(kotlinx.serialization/SerialFormat) // kotlinx.rpc.grpc.codec.kotlinx.serialization/KotlinxSerializationCodecResolver.<init>|<init>(kotlinx.serialization.SerialFormat){}[0]
+
+    final fun resolve(kotlin.reflect/KType): kotlinx.rpc.grpc.codec/MessageCodec<*> // kotlinx.rpc.grpc.codec.kotlinx.serialization/KotlinxSerializationCodecResolver.resolve|resolve(kotlin.reflect.KType){}[0]
+}
+
+final fun (kotlinx.serialization/SerialFormat).kotlinx.rpc.grpc.codec.kotlinx.serialization/asCodecResolver(): kotlinx.rpc.grpc.codec/MessageCodecResolver // kotlinx.rpc.grpc.codec.kotlinx.serialization/asCodecResolver|asCodecResolver@kotlinx.serialization.SerialFormat(){}[0]

--- a/grpc/grpc-codec-kotlinx-serialization/build.gradle.kts
+++ b/grpc/grpc-codec-kotlinx-serialization/build.gradle.kts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+plugins {
+    alias(libs.plugins.conventions.kmp)
+}
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(projects.grpc.grpcCodec)
+                api(libs.serialization.core)
+                api(libs.kotlinx.io.core)
+            }
+        }
+    }
+}

--- a/grpc/grpc-codec-kotlinx-serialization/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/kotlinx/serialization/KotlinxSerializationCodecResolver.kt
+++ b/grpc/grpc-codec-kotlinx-serialization/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/kotlinx/serialization/KotlinxSerializationCodecResolver.kt
@@ -52,7 +52,9 @@ private class KotlinxSerializationCodec<T>(
                 }
             }
 
-            else -> error("Only ${StringFormat::class.simpleName} and ${BinaryFormat::class.simpleName} are supported")
+            else -> {
+                error("Only ${StringFormat::class.simpleName} and ${BinaryFormat::class.simpleName} are supported")
+            }
         }
     }
 
@@ -66,7 +68,9 @@ private class KotlinxSerializationCodec<T>(
                 serialFormat.decodeFromByteArray(serializer, stream.readByteArray())
             }
 
-            else -> error("Only ${StringFormat::class.simpleName} and ${BinaryFormat::class.simpleName} are supported")
+            else -> {
+                error("Only ${StringFormat::class.simpleName} and ${BinaryFormat::class.simpleName} are supported")
+            }
         }
     }
 }

--- a/grpc/grpc-codec/api/grpc-codec.api
+++ b/grpc/grpc-codec/api/grpc-codec.api
@@ -1,0 +1,18 @@
+public final class kotlinx/rpc/grpc/codec/EmptyMessageCodecResolver : kotlinx/rpc/grpc/codec/MessageCodecResolver {
+	public static final field INSTANCE Lkotlinx/rpc/grpc/codec/EmptyMessageCodecResolver;
+	public fun resolve (Lkotlin/reflect/KType;)Lkotlinx/rpc/grpc/codec/MessageCodec;
+}
+
+public abstract interface class kotlinx/rpc/grpc/codec/MessageCodec {
+	public abstract fun decode (Lkotlinx/io/Source;)Ljava/lang/Object;
+	public abstract fun encode (Ljava/lang/Object;)Lkotlinx/io/Source;
+}
+
+public abstract interface class kotlinx/rpc/grpc/codec/MessageCodecResolver {
+	public abstract fun resolve (Lkotlin/reflect/KType;)Lkotlinx/rpc/grpc/codec/MessageCodec;
+}
+
+public abstract interface annotation class kotlinx/rpc/grpc/codec/WithCodec : java/lang/annotation/Annotation {
+	public abstract fun codec ()Ljava/lang/Class;
+}
+

--- a/grpc/grpc-codec/api/grpc-codec.klib.api
+++ b/grpc/grpc-codec/api/grpc-codec.klib.api
@@ -1,0 +1,27 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <org.jetbrains.kotlinx:grpc-codec>
+open annotation class kotlinx.rpc.grpc.codec/WithCodec : kotlin/Annotation { // kotlinx.rpc.grpc.codec/WithCodec|null[0]
+    constructor <init>(kotlin.reflect/KClass<out kotlinx.rpc.grpc.codec/MessageCodec<*>>) // kotlinx.rpc.grpc.codec/WithCodec.<init>|<init>(kotlin.reflect.KClass<out|kotlinx.rpc.grpc.codec.MessageCodec<*>>){}[0]
+
+    final val codec // kotlinx.rpc.grpc.codec/WithCodec.codec|{}codec[0]
+        final fun <get-codec>(): kotlin.reflect/KClass<out kotlinx.rpc.grpc.codec/MessageCodec<*>> // kotlinx.rpc.grpc.codec/WithCodec.codec.<get-codec>|<get-codec>(){}[0]
+}
+
+abstract fun interface kotlinx.rpc.grpc.codec/MessageCodecResolver { // kotlinx.rpc.grpc.codec/MessageCodecResolver|null[0]
+    abstract fun resolve(kotlin.reflect/KType): kotlinx.rpc.grpc.codec/MessageCodec<*> // kotlinx.rpc.grpc.codec/MessageCodecResolver.resolve|resolve(kotlin.reflect.KType){}[0]
+}
+
+abstract interface <#A: kotlin/Any?> kotlinx.rpc.grpc.codec/MessageCodec { // kotlinx.rpc.grpc.codec/MessageCodec|null[0]
+    abstract fun decode(kotlinx.io/Source): #A // kotlinx.rpc.grpc.codec/MessageCodec.decode|decode(kotlinx.io.Source){}[0]
+    abstract fun encode(#A): kotlinx.io/Source // kotlinx.rpc.grpc.codec/MessageCodec.encode|encode(1:0){}[0]
+}
+
+final object kotlinx.rpc.grpc.codec/EmptyMessageCodecResolver : kotlinx.rpc.grpc.codec/MessageCodecResolver { // kotlinx.rpc.grpc.codec/EmptyMessageCodecResolver|null[0]
+    final fun resolve(kotlin.reflect/KType): kotlinx.rpc.grpc.codec/MessageCodec<*> // kotlinx.rpc.grpc.codec/EmptyMessageCodecResolver.resolve|resolve(kotlin.reflect.KType){}[0]
+}

--- a/grpc/grpc-codec/build.gradle.kts
+++ b/grpc/grpc-codec/build.gradle.kts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+plugins {
+    alias(libs.plugins.conventions.kmp)
+}
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(projects.utils)
+                api(libs.kotlinx.io.core)
+            }
+        }
+    }
+}

--- a/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/MessageCodec.kt
+++ b/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/MessageCodec.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.codec
+
+import kotlinx.io.Source
+import kotlinx.rpc.internal.utils.ExperimentalRpcApi
+import kotlin.reflect.KType
+
+@ExperimentalRpcApi
+public fun interface MessageCodecResolver {
+    public fun resolve(kType: KType): MessageCodec<*>
+}
+
+@ExperimentalRpcApi
+public object EmptyMessageCodecResolver : MessageCodecResolver {
+    override fun resolve(kType: KType): MessageCodec<*> {
+        error("No codec found for type $kType")
+    }
+}
+
+@ExperimentalRpcApi
+public interface MessageCodec<T> {
+    public fun encode(value: T): Source
+    public fun decode(stream: Source): T
+}

--- a/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/WithCodec.kt
+++ b/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/WithCodec.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.codec
+
+import kotlinx.rpc.internal.utils.ExperimentalRpcApi
+import kotlin.reflect.KClass
+
+@ExperimentalRpcApi
+public annotation class WithCodec(val codec: KClass<out MessageCodec<*>>)

--- a/grpc/grpc-core/api/grpc-core.api
+++ b/grpc/grpc-core/api/grpc-core.api
@@ -8,10 +8,10 @@ public final class kotlinx/rpc/grpc/GrpcClient : kotlinx/rpc/RpcClient {
 }
 
 public final class kotlinx/rpc/grpc/GrpcClientKt {
-	public static final fun GrpcClient (Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcClient;
-	public static final fun GrpcClient (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcClient;
-	public static synthetic fun GrpcClient$default (Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcClient;
-	public static synthetic fun GrpcClient$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcClient;
+	public static final fun GrpcClient (Ljava/lang/String;ILkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcClient;
+	public static final fun GrpcClient (Ljava/lang/String;Lkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcClient;
+	public static synthetic fun GrpcClient$default (Ljava/lang/String;ILkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcClient;
+	public static synthetic fun GrpcClient$default (Ljava/lang/String;Lkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcClient;
 }
 
 public final class kotlinx/rpc/grpc/GrpcServer : kotlinx/rpc/RpcServer, kotlinx/rpc/grpc/Server {
@@ -30,8 +30,8 @@ public final class kotlinx/rpc/grpc/GrpcServer : kotlinx/rpc/RpcServer, kotlinx/
 }
 
 public final class kotlinx/rpc/grpc/GrpcServerKt {
-	public static final fun GrpcServer (ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcServer;
-	public static synthetic fun GrpcServer$default (ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcServer;
+	public static final fun GrpcServer (ILkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcServer;
+	public static synthetic fun GrpcServer$default (ILkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcServer;
 }
 
 public abstract interface class kotlinx/rpc/grpc/ManagedChannel {
@@ -43,13 +43,16 @@ public abstract interface class kotlinx/rpc/grpc/ManagedChannel {
 	public abstract fun shutdownNow ()Lkotlinx/rpc/grpc/ManagedChannel;
 }
 
+public final class kotlinx/rpc/grpc/ManagedChannel$DefaultImpls {
+	public static synthetic fun awaitTermination-VtjQ1oo$default (Lkotlinx/rpc/grpc/ManagedChannel;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class kotlinx/rpc/grpc/ManagedChannel_jvmKt {
 	public static final fun toKotlin (Lio/grpc/ManagedChannel;)Lkotlinx/rpc/grpc/ManagedChannel;
 }
 
 public abstract interface class kotlinx/rpc/grpc/Server {
 	public abstract fun awaitTermination-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun awaitTermination-VtjQ1oo$default (Lkotlinx/rpc/grpc/Server;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getPort ()I
 	public abstract fun isShutdown ()Z
 	public abstract fun isTerminated ()Z
@@ -93,6 +96,9 @@ public final class kotlinx/rpc/grpc/Status_jvmKt {
 	public static final fun getCode (Lio/grpc/Status;)Lkotlinx/rpc/grpc/StatusCode;
 }
 
+public abstract interface annotation class kotlinx/rpc/grpc/annotations/Grpc : java/lang/annotation/Annotation {
+}
+
 public abstract interface class kotlinx/rpc/grpc/descriptor/GrpcClientDelegate {
 	public abstract fun call (Lkotlinx/rpc/RpcCall;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun callServerStreaming (Lkotlinx/rpc/RpcCall;)Lkotlinx/coroutines/flow/Flow;
@@ -101,9 +107,5 @@ public abstract interface class kotlinx/rpc/grpc/descriptor/GrpcClientDelegate {
 public abstract interface class kotlinx/rpc/grpc/descriptor/GrpcDelegate {
 	public abstract fun clientProvider (Lkotlinx/rpc/grpc/ManagedChannel;)Lkotlinx/rpc/grpc/descriptor/GrpcClientDelegate;
 	public abstract fun definitionFor (Ljava/lang/Object;)Lio/grpc/ServerServiceDefinition;
-}
-
-public abstract interface class kotlinx/rpc/grpc/descriptor/GrpcServiceDescriptor : kotlinx/rpc/descriptor/RpcServiceDescriptor {
-	public abstract fun getDelegate ()Lkotlinx/rpc/grpc/descriptor/GrpcDelegate;
 }
 

--- a/grpc/grpc-core/api/grpc-core.klib.api
+++ b/grpc/grpc-core/api/grpc-core.klib.api
@@ -6,6 +6,10 @@
 // - Show declarations: true
 
 // Library unique name: <org.jetbrains.kotlinx:grpc-core>
+open annotation class kotlinx.rpc.grpc.annotations/Grpc : kotlin/Annotation { // kotlinx.rpc.grpc.annotations/Grpc|null[0]
+    constructor <init>() // kotlinx.rpc.grpc.annotations/Grpc.<init>|<init>(){}[0]
+}
+
 final enum class kotlinx.rpc.grpc/StatusCode : kotlin/Enum<kotlinx.rpc.grpc/StatusCode> { // kotlinx.rpc.grpc/StatusCode|null[0]
     enum entry ABORTED // kotlinx.rpc.grpc/StatusCode.ABORTED|null[0]
     enum entry ALREADY_EXISTS // kotlinx.rpc.grpc/StatusCode.ALREADY_EXISTS|null[0]
@@ -36,21 +40,6 @@ final enum class kotlinx.rpc.grpc/StatusCode : kotlin/Enum<kotlinx.rpc.grpc/Stat
     final fun values(): kotlin/Array<kotlinx.rpc.grpc/StatusCode> // kotlinx.rpc.grpc/StatusCode.values|values#static(){}[0]
 }
 
-abstract interface <#A: kotlin/Any> kotlinx.rpc.grpc.descriptor/GrpcDelegate { // kotlinx.rpc.grpc.descriptor/GrpcDelegate|null[0]
-    abstract fun clientProvider(kotlinx.rpc.grpc/ManagedChannel): kotlinx.rpc.grpc.descriptor/GrpcClientDelegate // kotlinx.rpc.grpc.descriptor/GrpcDelegate.clientProvider|clientProvider(kotlinx.rpc.grpc.ManagedChannel){}[0]
-    abstract fun definitionFor(#A): kotlinx.rpc.grpc/ServerServiceDefinition // kotlinx.rpc.grpc.descriptor/GrpcDelegate.definitionFor|definitionFor(1:0){}[0]
-}
-
-abstract interface <#A: kotlin/Any> kotlinx.rpc.grpc.descriptor/GrpcServiceDescriptor : kotlinx.rpc.descriptor/RpcServiceDescriptor<#A> { // kotlinx.rpc.grpc.descriptor/GrpcServiceDescriptor|null[0]
-    abstract val delegate // kotlinx.rpc.grpc.descriptor/GrpcServiceDescriptor.delegate|{}delegate[0]
-        abstract fun <get-delegate>(): kotlinx.rpc.grpc.descriptor/GrpcDelegate<#A> // kotlinx.rpc.grpc.descriptor/GrpcServiceDescriptor.delegate.<get-delegate>|<get-delegate>(){}[0]
-}
-
-abstract interface kotlinx.rpc.grpc.descriptor/GrpcClientDelegate { // kotlinx.rpc.grpc.descriptor/GrpcClientDelegate|null[0]
-    abstract fun <#A1: kotlin/Any?> callServerStreaming(kotlinx.rpc/RpcCall): kotlinx.coroutines.flow/Flow<#A1> // kotlinx.rpc.grpc.descriptor/GrpcClientDelegate.callServerStreaming|callServerStreaming(kotlinx.rpc.RpcCall){0§<kotlin.Any?>}[0]
-    abstract suspend fun <#A1: kotlin/Any?> call(kotlinx.rpc/RpcCall): #A1 // kotlinx.rpc.grpc.descriptor/GrpcClientDelegate.call|call(kotlinx.rpc.RpcCall){0§<kotlin.Any?>}[0]
-}
-
 abstract interface kotlinx.rpc.grpc/ManagedChannel { // kotlinx.rpc.grpc/ManagedChannel|null[0]
     abstract val isShutdown // kotlinx.rpc.grpc/ManagedChannel.isShutdown|{}isShutdown[0]
         abstract fun <get-isShutdown>(): kotlin/Boolean // kotlinx.rpc.grpc/ManagedChannel.isShutdown.<get-isShutdown>|<get-isShutdown>(){}[0]
@@ -61,7 +50,7 @@ abstract interface kotlinx.rpc.grpc/ManagedChannel { // kotlinx.rpc.grpc/Managed
 
     abstract fun shutdown(): kotlinx.rpc.grpc/ManagedChannel // kotlinx.rpc.grpc/ManagedChannel.shutdown|shutdown(){}[0]
     abstract fun shutdownNow(): kotlinx.rpc.grpc/ManagedChannel // kotlinx.rpc.grpc/ManagedChannel.shutdownNow|shutdownNow(){}[0]
-    abstract suspend fun awaitTermination(kotlin.time/Duration): kotlin/Boolean // kotlinx.rpc.grpc/ManagedChannel.awaitTermination|awaitTermination(kotlin.time.Duration){}[0]
+    abstract suspend fun awaitTermination(kotlin.time/Duration = ...): kotlin/Boolean // kotlinx.rpc.grpc/ManagedChannel.awaitTermination|awaitTermination(kotlin.time.Duration){}[0]
 }
 
 abstract interface kotlinx.rpc.grpc/Server { // kotlinx.rpc.grpc/Server|null[0]
@@ -162,7 +151,7 @@ final class kotlinx.rpc.grpc/StatusRuntimeException : kotlin/RuntimeException { 
 final val kotlinx.rpc.grpc/code // kotlinx.rpc.grpc/code|@kotlinx.rpc.grpc.Status{}code[0]
     final fun (kotlinx.rpc.grpc/Status).<get-code>(): kotlinx.rpc.grpc/StatusCode // kotlinx.rpc.grpc/code.<get-code>|<get-code>@kotlinx.rpc.grpc.Status(){}[0]
 
-final fun kotlinx.rpc.grpc/GrpcClient(kotlin/String, kotlin/Function1<kotlinx.rpc.grpc/ManagedChannelBuilder<*>, kotlin/Unit> = ...): kotlinx.rpc.grpc/GrpcClient // kotlinx.rpc.grpc/GrpcClient|GrpcClient(kotlin.String;kotlin.Function1<kotlinx.rpc.grpc.ManagedChannelBuilder<*>,kotlin.Unit>){}[0]
-final fun kotlinx.rpc.grpc/GrpcClient(kotlin/String, kotlin/Int, kotlin/Function1<kotlinx.rpc.grpc/ManagedChannelBuilder<*>, kotlin/Unit> = ...): kotlinx.rpc.grpc/GrpcClient // kotlinx.rpc.grpc/GrpcClient|GrpcClient(kotlin.String;kotlin.Int;kotlin.Function1<kotlinx.rpc.grpc.ManagedChannelBuilder<*>,kotlin.Unit>){}[0]
-final fun kotlinx.rpc.grpc/GrpcServer(kotlin/Int, kotlin/Function1<kotlinx.rpc.grpc/ServerBuilder<*>, kotlin/Unit> = ..., kotlin/Function1<kotlinx.rpc/RpcServer, kotlin/Unit> = ...): kotlinx.rpc.grpc/GrpcServer // kotlinx.rpc.grpc/GrpcServer|GrpcServer(kotlin.Int;kotlin.Function1<kotlinx.rpc.grpc.ServerBuilder<*>,kotlin.Unit>;kotlin.Function1<kotlinx.rpc.RpcServer,kotlin.Unit>){}[0]
+final fun kotlinx.rpc.grpc/GrpcClient(kotlin/String, kotlin/Int, kotlinx.rpc.grpc.codec/MessageCodecResolver = ..., kotlin/Function1<kotlinx.rpc.grpc/ManagedChannelBuilder<*>, kotlin/Unit> = ...): kotlinx.rpc.grpc/GrpcClient // kotlinx.rpc.grpc/GrpcClient|GrpcClient(kotlin.String;kotlin.Int;kotlinx.rpc.grpc.codec.MessageCodecResolver;kotlin.Function1<kotlinx.rpc.grpc.ManagedChannelBuilder<*>,kotlin.Unit>){}[0]
+final fun kotlinx.rpc.grpc/GrpcClient(kotlin/String, kotlinx.rpc.grpc.codec/MessageCodecResolver = ..., kotlin/Function1<kotlinx.rpc.grpc/ManagedChannelBuilder<*>, kotlin/Unit> = ...): kotlinx.rpc.grpc/GrpcClient // kotlinx.rpc.grpc/GrpcClient|GrpcClient(kotlin.String;kotlinx.rpc.grpc.codec.MessageCodecResolver;kotlin.Function1<kotlinx.rpc.grpc.ManagedChannelBuilder<*>,kotlin.Unit>){}[0]
+final fun kotlinx.rpc.grpc/GrpcServer(kotlin/Int, kotlinx.rpc.grpc.codec/MessageCodecResolver = ..., kotlin.coroutines/CoroutineContext = ..., kotlin/Function1<kotlinx.rpc.grpc/ServerBuilder<*>, kotlin/Unit> = ..., kotlin/Function1<kotlinx.rpc/RpcServer, kotlin/Unit> = ...): kotlinx.rpc.grpc/GrpcServer // kotlinx.rpc.grpc/GrpcServer|GrpcServer(kotlin.Int;kotlinx.rpc.grpc.codec.MessageCodecResolver;kotlin.coroutines.CoroutineContext;kotlin.Function1<kotlinx.rpc.grpc.ServerBuilder<*>,kotlin.Unit>;kotlin.Function1<kotlinx.rpc.RpcServer,kotlin.Unit>){}[0]
 final fun kotlinx.rpc.grpc/Status(kotlinx.rpc.grpc/StatusCode, kotlin/String? = ..., kotlin/Throwable? = ...): kotlinx.rpc.grpc/Status // kotlinx.rpc.grpc/Status|Status(kotlinx.rpc.grpc.StatusCode;kotlin.String?;kotlin.Throwable?){}[0]

--- a/grpc/grpc-core/build.gradle.kts
+++ b/grpc/grpc-core/build.gradle.kts
@@ -13,9 +13,8 @@ plugins {
     alias(libs.plugins.conventions.kmp)
     alias(libs.plugins.kotlinx.rpc)
     alias(libs.plugins.atomicfu)
+    alias(libs.plugins.serialization) // for tests
 }
-
-
 
 kotlin {
     compilerOptions {
@@ -28,6 +27,7 @@ kotlin {
                 api(projects.core)
                 api(projects.utils)
                 api(libs.coroutines.core)
+                api(projects.grpc.grpcCodec)
 
                 implementation(libs.atomicfu)
                 implementation(libs.kotlinx.io.core)
@@ -40,6 +40,9 @@ kotlin {
                 implementation(libs.kotlin.test)
                 implementation(libs.coroutines.test)
                 implementation(libs.atomicfu)
+                implementation(libs.serialization.json)
+
+                implementation(projects.grpc.grpcCodecKotlinxSerialization)
             }
         }
 

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcServer.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcServer.kt
@@ -5,25 +5,54 @@
 package kotlinx.rpc.grpc
 
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.job
 import kotlinx.rpc.RpcServer
+import kotlinx.rpc.descriptor.RpcCallable
+import kotlinx.rpc.descriptor.flowInvokator
 import kotlinx.rpc.descriptor.serviceDescriptorOf
+import kotlinx.rpc.descriptor.unaryInvokator
 import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.rpc.grpc.codec.EmptyMessageCodecResolver
+import kotlinx.rpc.grpc.codec.MessageCodecResolver
 import kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor
+import kotlinx.rpc.grpc.internal.MethodDescriptor
+import kotlinx.rpc.grpc.internal.MethodType
+import kotlinx.rpc.grpc.internal.ServerMethodDefinition
+import kotlinx.rpc.grpc.internal.bidiStreamingServerMethodDefinition
+import kotlinx.rpc.grpc.internal.clientStreamingServerMethodDefinition
+import kotlinx.rpc.grpc.internal.serverStreamingServerMethodDefinition
+import kotlinx.rpc.grpc.internal.type
+import kotlinx.rpc.grpc.internal.unaryServerMethodDefinition
 import kotlinx.rpc.internal.utils.map.RpcInternalConcurrentHashMap
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.reflect.KClass
 import kotlin.time.Duration
+
+private typealias RequestServer = Any
+private typealias ResponseServer = Any
 
 /**
  * GrpcServer is an implementation of both [RpcServer] and [Server] interfaces,
  * providing the ability to host gRPC services.
  *
  * @property port Specifies the port used by the server to listen for incoming connections.
+ * @param parentContext
  * @param configure exposes platform-specific Server builder.
  */
 public class GrpcServer internal constructor(
     override val port: Int = 8080,
+    private val messageCodecResolver: MessageCodecResolver = EmptyMessageCodecResolver,
+    parentContext: CoroutineContext = EmptyCoroutineContext,
     configure: ServerBuilder<*>.() -> Unit,
 ) : RpcServer, Server {
+    private val internalContext = SupervisorJob(parentContext.job)
+    private val internalScope = CoroutineScope(parentContext + internalContext)
+
     private var isBuilt = false
     private lateinit var internalServer: Server
 
@@ -59,11 +88,59 @@ public class GrpcServer internal constructor(
         service: Service,
         serviceKClass: KClass<Service>,
     ): ServerServiceDefinition {
-        val descriptor = serviceDescriptorOf(serviceKClass)
-        val grpc = (descriptor as? GrpcServiceDescriptor<Service>)
-            ?: error("Service ${descriptor.fqName} is not a gRPC service")
+        @Suppress("UNCHECKED_CAST")
+        val descriptor = serviceDescriptorOf(serviceKClass) as? GrpcServiceDescriptor<Service>
+            ?: error("Service $serviceKClass is not a gRPC service")
 
-        return grpc.delegate.definitionFor(service)
+        val delegate = descriptor.delegate(messageCodecResolver)
+
+        val methods = descriptor.callables.map {
+            @Suppress("UNCHECKED_CAST")
+            val methodDescriptor = delegate.getMethodDescriptor(it.name)
+                    as? MethodDescriptor<RequestServer, ResponseServer>
+                ?: error("Expected a gRPC method descriptor")
+
+            it.toDefinitionOn(methodDescriptor, service)
+        }
+
+        return serverServiceDefinition(delegate.serviceDescriptor, methods)
+    }
+
+    private fun <@Grpc Service : Any> RpcCallable<Service>.toDefinitionOn(
+        descriptor: MethodDescriptor<RequestServer, ResponseServer>,
+        service: Service,
+    ): ServerMethodDefinition<RequestServer, ResponseServer> {
+        return when (descriptor.type) {
+            MethodType.UNARY -> {
+                internalScope.unaryServerMethodDefinition(descriptor) { request ->
+                    unaryInvokator.call(service, arrayOf(request)) as ResponseServer
+                }
+            }
+
+            MethodType.CLIENT_STREAMING -> {
+                internalScope.clientStreamingServerMethodDefinition(descriptor) { requests ->
+                    unaryInvokator.call(service, arrayOf(requests)) as ResponseServer
+                }
+            }
+
+            MethodType.SERVER_STREAMING -> {
+                internalScope.serverStreamingServerMethodDefinition(descriptor) { request ->
+                    @Suppress("UNCHECKED_CAST")
+                    flowInvokator.call(service, arrayOf(request)) as Flow<ResponseServer>
+                }
+            }
+
+            MethodType.BIDI_STREAMING -> {
+                internalScope.bidiStreamingServerMethodDefinition(descriptor) { requests ->
+                    @Suppress("UNCHECKED_CAST")
+                    flowInvokator.call(service, arrayOf(requests)) as Flow<ResponseServer>
+                }
+            }
+
+            MethodType.UNKNOWN -> {
+                error("Unsupported method type ${descriptor.type} for ${descriptor.getFullMethodName()}")
+            }
+        }
     }
 
     private val buildLock = atomic(false)
@@ -87,16 +164,19 @@ public class GrpcServer internal constructor(
     }
 
     override fun shutdown(): GrpcServer {
+        internalContext.cancel("Shutting down server")
         internalServer.shutdown()
         return this
     }
 
     override fun shutdownNow(): GrpcServer {
+        internalContext.cancel("Shutting down server now")
         internalServer.shutdownNow()
         return this
     }
 
     override suspend fun awaitTermination(duration: Duration): GrpcServer {
+        internalContext.join()
         internalServer.awaitTermination(duration)
         return this
     }
@@ -107,8 +187,10 @@ public class GrpcServer internal constructor(
  */
 public fun GrpcServer(
     port: Int,
+    messageCodecResolver: MessageCodecResolver = EmptyMessageCodecResolver,
+    parentContext: CoroutineContext = EmptyCoroutineContext,
     configure: ServerBuilder<*>.() -> Unit = {},
     builder: RpcServer.() -> Unit = {},
 ): GrpcServer {
-    return GrpcServer(port, configure).apply(builder).apply { build() }
+    return GrpcServer(port, messageCodecResolver, parentContext, configure).apply(builder).apply { build() }
 }

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/annotations/Grpc.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/annotations/Grpc.kt
@@ -9,10 +9,7 @@ import kotlinx.rpc.internal.utils.InternalRpcApi
 
 /**
  * Annotation used for marking gRPC services.
- *
- * Internal use only.
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.TYPE_PARAMETER)
 @Rpc
-@InternalRpcApi
 public annotation class Grpc

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/descriptor/GrpcServiceDescriptor.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/descriptor/GrpcServiceDescriptor.kt
@@ -4,29 +4,32 @@
 
 package kotlinx.rpc.grpc.descriptor
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.rpc.RpcCall
 import kotlinx.rpc.descriptor.RpcServiceDescriptor
-import kotlinx.rpc.grpc.ManagedChannel
-import kotlinx.rpc.grpc.ServerServiceDefinition
 import kotlinx.rpc.grpc.annotations.Grpc
-import kotlinx.rpc.internal.utils.ExperimentalRpcApi
+import kotlinx.rpc.grpc.codec.MessageCodecResolver
+import kotlinx.rpc.grpc.internal.MethodDescriptor
+import kotlinx.rpc.grpc.internal.ServiceDescriptor
+import kotlinx.rpc.internal.utils.InternalRpcApi
 
-@ExperimentalRpcApi
+@InternalRpcApi
 public interface GrpcServiceDescriptor<@Grpc T : Any> : RpcServiceDescriptor<T> {
-    public val delegate: GrpcDelegate<T>
+    public fun delegate(resolver: MessageCodecResolver): GrpcServiceDelegate
 }
 
-@ExperimentalRpcApi
-public interface GrpcDelegate<@Grpc T : Any> {
-    public fun clientProvider(channel: ManagedChannel): GrpcClientDelegate
-
-    public fun definitionFor(impl: T): ServerServiceDefinition
+@InternalRpcApi
+public class GrpcServiceDelegate(
+    private val methodDescriptorMap: Map<String, MethodDescriptor<*, *>>,
+    public val serviceDescriptor: ServiceDescriptor,
+) {
+    public fun getMethodDescriptor(methodName: String): MethodDescriptor<*, *>? = methodDescriptorMap[methodName]
 }
 
-@ExperimentalRpcApi
-public interface GrpcClientDelegate {
-    public suspend fun <R> call(rpcCall: RpcCall): R
-
-    public fun <R> callServerStreaming(rpcCall: RpcCall): Flow<R>
-}
+//@ExperimentalRpcApi
+//public class GrpcMethod {
+//    @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+//    public annotation class Meta(
+//        val safe: Boolean = true,
+//        val idempotent: Boolean = true,
+//        val sampledToLocalTracing: Boolean = true,
+//    )
+//}

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/descriptor/GrpcServiceDescriptor.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/descriptor/GrpcServiceDescriptor.kt
@@ -23,13 +23,3 @@ public class GrpcServiceDelegate(
 ) {
     public fun getMethodDescriptor(methodName: String): MethodDescriptor<*, *>? = methodDescriptorMap[methodName]
 }
-
-//@ExperimentalRpcApi
-//public class GrpcMethod {
-//    @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
-//    public annotation class Meta(
-//        val safe: Boolean = true,
-//        val idempotent: Boolean = true,
-//        val sampledToLocalTracing: Boolean = true,
-//    )
-//}

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/internal/MethodDescriptor.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/internal/MethodDescriptor.kt
@@ -4,17 +4,11 @@
 
 package kotlinx.rpc.grpc.internal
 
-import kotlinx.io.Source
+import kotlinx.rpc.grpc.codec.MessageCodec
 import kotlinx.rpc.internal.utils.InternalRpcApi
 
 @InternalRpcApi
 public expect abstract class InputStream
-
-@InternalRpcApi
-public interface MessageCodec<T> {
-    public fun encode(value: T): Source
-    public fun decode(stream: Source): T
-}
 
 @InternalRpcApi
 public expect class MethodDescriptor<Request, Response> {
@@ -56,11 +50,3 @@ public expect fun <Request, Response> methodDescriptor(
     safe: Boolean,
     sampledToLocalTracing: Boolean,
 ): MethodDescriptor<Request, Response>
-
-public val MethodType.clientSendsOneMessage: Boolean get() {
-    return this == MethodType.UNARY || this == MethodType.SERVER_STREAMING
-}
-
-public val MethodType.serverSendsOneMessage: Boolean get() {
-    return this == MethodType.SERVER_STREAMING || this == MethodType.CLIENT_STREAMING
-}

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/internal/suspendClientCalls.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/internal/suspendClientCalls.kt
@@ -43,7 +43,7 @@ public suspend fun <Request, Response> unaryRpc(
         channel = channel,
         descriptor = descriptor,
         callOptions = callOptions,
-        headers = trailers,
+        trailers = trailers,
         request = ClientRequest.Unary(request)
     ).singleOrStatus("request", descriptor)
 }
@@ -54,7 +54,7 @@ public fun <Request, Response> serverStreamingRpc(
     descriptor: MethodDescriptor<Request, Response>,
     request: Request,
     callOptions: GrpcCallOptions = GrpcDefaultCallOptions,
-    headers: GrpcTrailers = GrpcTrailers(),
+    trailers: GrpcTrailers = GrpcTrailers(),
 ): Flow<Response> {
     val type = descriptor.type
     require(type == MethodType.SERVER_STREAMING) {
@@ -65,7 +65,7 @@ public fun <Request, Response> serverStreamingRpc(
         channel = channel,
         descriptor = descriptor,
         callOptions = callOptions,
-        headers = headers,
+        trailers = trailers,
         request = ClientRequest.Unary(request)
     )
 }
@@ -76,7 +76,7 @@ public suspend fun <Request, Response> clientStreamingRpc(
     descriptor: MethodDescriptor<Request, Response>,
     requests: Flow<Request>,
     callOptions: GrpcCallOptions = GrpcDefaultCallOptions,
-    headers: GrpcTrailers = GrpcTrailers(),
+    trailers: GrpcTrailers = GrpcTrailers(),
 ): Response {
     val type = descriptor.type
     require(type == MethodType.CLIENT_STREAMING) {
@@ -87,7 +87,7 @@ public suspend fun <Request, Response> clientStreamingRpc(
         channel = channel,
         descriptor = descriptor,
         callOptions = callOptions,
-        headers = headers,
+        trailers = trailers,
         request = ClientRequest.Flowing(requests)
     ).singleOrStatus("response", descriptor)
 }
@@ -98,7 +98,7 @@ public fun <Request, Response> bidirectionalStreamingRpc(
     descriptor: MethodDescriptor<Request, Response>,
     requests: Flow<Request>,
     callOptions: GrpcCallOptions = GrpcDefaultCallOptions,
-    headers: GrpcTrailers = GrpcTrailers(),
+    trailers: GrpcTrailers = GrpcTrailers(),
 ): Flow<Response> {
     val type = descriptor.type
     check(type == MethodType.BIDI_STREAMING) {
@@ -109,7 +109,7 @@ public fun <Request, Response> bidirectionalStreamingRpc(
         channel = channel,
         descriptor = descriptor,
         callOptions = callOptions,
-        headers = headers,
+        trailers = trailers,
         request = ClientRequest.Flowing(requests)
     )
 }
@@ -147,7 +147,7 @@ private fun <Request, Response> rpcImpl(
     channel: GrpcChannel,
     descriptor: MethodDescriptor<Request, Response>,
     callOptions: GrpcCallOptions,
-    headers: GrpcTrailers,
+    trailers: GrpcTrailers,
     request: ClientRequest<Request>,
 ): Flow<Response> = flow {
     coroutineScope {
@@ -161,7 +161,7 @@ private fun <Request, Response> rpcImpl(
         val responses = Channel<Response>(1)
         val ready = Ready { handler.isReady() }
 
-        handler.start(channelResponseListener(responses, ready), headers)
+        handler.start(channelResponseListener(responses, ready), trailers)
 
         val fullMethodName = descriptor.getFullMethodName()
         val sender = launch(CoroutineName("grpc-send-message-$fullMethodName")) {

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/RawClientServerTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/RawClientServerTest.kt
@@ -14,8 +14,8 @@ import kotlinx.io.Buffer
 import kotlinx.io.Source
 import kotlinx.io.readString
 import kotlinx.io.writeString
+import kotlinx.rpc.grpc.codec.MessageCodec
 import kotlinx.rpc.grpc.internal.GrpcChannel
-import kotlinx.rpc.grpc.internal.MessageCodec
 import kotlinx.rpc.grpc.internal.MethodDescriptor
 import kotlinx.rpc.grpc.internal.MethodType
 import kotlinx.rpc.grpc.internal.ServerMethodDefinition

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/pb/ProtosTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/pb/ProtosTest.kt
@@ -8,7 +8,7 @@ import OneOfMsg
 import OneOfMsgInternal
 import invoke
 import kotlinx.io.Buffer
-import kotlinx.rpc.grpc.internal.MessageCodec
+import kotlinx.rpc.grpc.codec.MessageCodec
 import kotlinx.rpc.grpc.test.Enum
 import kotlinx.rpc.grpc.test.UsingEnum
 import kotlinx.rpc.grpc.test.UsingEnumInternal

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/GrpcService.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/GrpcService.kt
@@ -15,7 +15,7 @@ import kotlinx.rpc.grpc.annotations.Grpc
 import kotlinx.rpc.grpc.codec.MessageCodec
 import kotlinx.rpc.grpc.codec.MessageCodecResolver
 import kotlinx.rpc.grpc.codec.WithCodec
-import kotlinx.rpc.grpc.codec.kotlinx.serialization.KotlinxSerializationCodecResolver
+import kotlinx.rpc.grpc.codec.kotlinx.serialization.asCodecResolver
 import kotlinx.rpc.registerService
 import kotlinx.rpc.withService
 import kotlinx.serialization.Serializable
@@ -91,7 +91,7 @@ class GrpcGeneratedServiceTest {
 
     @Test
     fun testSerializationCodec() = runServiceTest<GrpcServiceSerializable>(
-        resolver = KotlinxSerializationCodecResolver(Json),
+        resolver = Json.asCodecResolver(),
         impl = GrpcServiceSerializableImpl(),
     ) { service ->
         assertEquals("test test", service.plainString("test"))

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/GrpcService.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/GrpcService.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.service
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import kotlinx.rpc.grpc.GrpcClient
+import kotlinx.rpc.grpc.GrpcServer
+import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.rpc.grpc.codec.MessageCodec
+import kotlinx.rpc.grpc.codec.MessageCodecResolver
+import kotlinx.rpc.grpc.codec.WithCodec
+import kotlinx.rpc.grpc.codec.kotlinx.serialization.KotlinxSerializationCodecResolver
+import kotlinx.rpc.registerService
+import kotlinx.rpc.withService
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@WithCodec(Message.Companion::class)
+class Message(val value: String) {
+    companion object : MessageCodec<Message> {
+        override fun encode(value: Message): Source {
+            return Buffer().apply { writeString(value.value) }
+        }
+        override fun decode(stream: Source): Message {
+            return Message(stream.readString())
+        }
+    }
+}
+
+@Serializable
+class SerializableMessage(val value: String)
+
+@Grpc
+interface GrpcService {
+    suspend fun plainString(value: String): String
+
+    suspend fun message(value: Message): Message
+}
+
+@Grpc
+interface GrpcServiceSerializable {
+    suspend fun plainString(value: String): String
+
+    suspend fun serialization(value: SerializableMessage): SerializableMessage
+}
+
+class GrpcServiceImpl : GrpcService {
+    override suspend fun plainString(value: String): String {
+        return "$value $value"
+    }
+
+    override suspend fun message(value: Message): Message {
+        return Message("${value.value} ${value.value}")
+    }
+}
+
+class GrpcServiceSerializableImpl : GrpcServiceSerializable {
+    override suspend fun plainString(value: String): String {
+        return "$value $value"
+    }
+
+    override suspend fun serialization(value: SerializableMessage): SerializableMessage {
+        return SerializableMessage("${value.value} ${value.value}")
+    }
+}
+
+class GrpcGeneratedServiceTest {
+    @Test
+    fun testCodecResolver() = runServiceTest<GrpcService>(
+        resolver = stringResolver,
+        impl = GrpcServiceImpl(),
+    ) { service ->
+        assertEquals("test test", service.plainString("test"))
+    }
+
+    @Test
+    fun testAnnotationCodec() = runServiceTest<GrpcService>(
+        resolver = stringResolver,
+        impl = GrpcServiceImpl(),
+    ) { service ->
+        assertEquals("test test", service.message(Message("test")).value)
+    }
+
+    @Test
+    fun testSerializationCodec() = runServiceTest<GrpcServiceSerializable>(
+        resolver = KotlinxSerializationCodecResolver(Json),
+        impl = GrpcServiceSerializableImpl(),
+    ) { service ->
+        assertEquals("test test", service.plainString("test"))
+
+        assertEquals("test test", service.serialization(SerializableMessage("test")).value)
+    }
+
+    private inline fun <@Grpc reified Service : Any> runServiceTest(
+        resolver: MessageCodecResolver,
+        impl: Service,
+        crossinline block: suspend (Service) -> Unit,
+    ) = runTest {
+        val server = GrpcServer(
+            port = PORT,
+            messageCodecResolver = resolver,
+            parentContext = coroutineContext,
+            builder = {
+                registerService<Service> { impl }
+            }
+        )
+
+        server.start()
+
+        val client = GrpcClient("localhost", PORT, messageCodecResolver = resolver) {
+            usePlaintext()
+        }
+
+        val service = client.withService<Service>()
+
+        block(service)
+
+        client.shutdown()
+        client.awaitTermination()
+        server.shutdown()
+        server.awaitTermination()
+    }
+
+    companion object {
+        private const val PORT = 8082
+
+        private val stringResolver = MessageCodecResolver { kType ->
+            check(kType.classifier == String::class) { "Unsupported type: $kType" }
+            simpleCodec
+        }
+
+        val simpleCodec = object : MessageCodec<String> {
+            override fun encode(value: String): Source {
+                return Buffer().apply { writeString(value) }
+            }
+
+            override fun decode(stream: Source): String {
+                return stream.readString()
+            }
+        }
+    }
+}

--- a/grpc/grpc-core/src/jvmMain/kotlin/kotlinx/rpc/grpc/internal/MethodDescriptor.jvm.kt
+++ b/grpc/grpc-core/src/jvmMain/kotlin/kotlinx/rpc/grpc/internal/MethodDescriptor.jvm.kt
@@ -7,6 +7,7 @@ package kotlinx.rpc.grpc.internal
 import kotlinx.io.asInputStream
 import kotlinx.io.asSource
 import kotlinx.io.buffered
+import kotlinx.rpc.grpc.codec.MessageCodec
 import kotlinx.rpc.internal.utils.InternalRpcApi
 
 internal actual typealias InputStream = java.io.InputStream

--- a/grpc/grpc-core/src/nativeMain/kotlin/kotlinx/rpc/grpc/internal/MethodDescriptor.native.kt
+++ b/grpc/grpc-core/src/nativeMain/kotlin/kotlinx/rpc/grpc/internal/MethodDescriptor.native.kt
@@ -4,6 +4,7 @@
 
 package kotlinx.rpc.grpc.internal
 
+import kotlinx.rpc.grpc.codec.MessageCodec
 import kotlinx.rpc.internal.utils.InternalRpcApi
 
 @InternalRpcApi

--- a/grpc/grpc-ktor-server/api/grpc-ktor-server.api
+++ b/grpc/grpc-ktor-server/api/grpc-ktor-server.api
@@ -5,7 +5,7 @@ public final class kotlinx/rpc/grpc/ktor/server/GrpcConfigKeys {
 
 public final class kotlinx/rpc/grpc/ktor/server/ServerKt {
 	public static final fun getGrpcServerKey ()Lio/ktor/util/AttributeKey;
-	public static final fun grpc (Lio/ktor/server/application/Application;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcServer;
-	public static synthetic fun grpc$default (Lio/ktor/server/application/Application;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcServer;
+	public static final fun grpc (Lio/ktor/server/application/Application;ILkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/GrpcServer;
+	public static synthetic fun grpc$default (Lio/ktor/server/application/Application;ILkotlinx/rpc/grpc/codec/MessageCodecResolver;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/rpc/grpc/GrpcServer;
 }
 

--- a/grpc/grpc-ktor-server/api/grpc-ktor-server.klib.api
+++ b/grpc/grpc-ktor-server/api/grpc-ktor-server.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [macosArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
@@ -14,4 +14,4 @@ final object kotlinx.rpc.grpc.ktor.server/GrpcConfigKeys { // kotlinx.rpc.grpc.k
 final val kotlinx.rpc.grpc.ktor.server/GrpcServerKey // kotlinx.rpc.grpc.ktor.server/GrpcServerKey|{}GrpcServerKey[0]
     final fun <get-GrpcServerKey>(): io.ktor.util/AttributeKey<kotlinx.rpc.grpc/GrpcServer> // kotlinx.rpc.grpc.ktor.server/GrpcServerKey.<get-GrpcServerKey>|<get-GrpcServerKey>(){}[0]
 
-final fun (io.ktor.server.application/Application).kotlinx.rpc.grpc.ktor.server/grpc(kotlin/Int = ..., kotlin/Function1<kotlinx.rpc.grpc/ServerBuilder<*>, kotlin/Unit> = ..., kotlin/Function1<kotlinx.rpc/RpcServer, kotlin/Unit>): kotlinx.rpc.grpc/GrpcServer // kotlinx.rpc.grpc.ktor.server/grpc|grpc@io.ktor.server.application.Application(kotlin.Int;kotlin.Function1<kotlinx.rpc.grpc.ServerBuilder<*>,kotlin.Unit>;kotlin.Function1<kotlinx.rpc.RpcServer,kotlin.Unit>){}[0]
+final fun (io.ktor.server.application/Application).kotlinx.rpc.grpc.ktor.server/grpc(kotlin/Int = ..., kotlinx.rpc.grpc.codec/MessageCodecResolver = ..., kotlin/Function1<kotlinx.rpc.grpc/ServerBuilder<*>, kotlin/Unit> = ..., kotlin/Function1<kotlinx.rpc/RpcServer, kotlin/Unit>): kotlinx.rpc.grpc/GrpcServer // kotlinx.rpc.grpc.ktor.server/grpc|grpc@io.ktor.server.application.Application(kotlin.Int;kotlinx.rpc.grpc.codec.MessageCodecResolver;kotlin.Function1<kotlinx.rpc.grpc.ServerBuilder<*>,kotlin.Unit>;kotlin.Function1<kotlinx.rpc.RpcServer,kotlin.Unit>){}[0]

--- a/krpc/krpc-client/src/commonMain/kotlin/kotlinx/rpc/krpc/client/KrpcClient.kt
+++ b/krpc/krpc-client/src/commonMain/kotlin/kotlinx/rpc/krpc/client/KrpcClient.kt
@@ -397,7 +397,7 @@ public abstract class KrpcClient : RpcClient, KrpcEndpoint {
         return when (serialFormat) {
             is StringFormat -> {
                 val stringValue = clientStreamContext.scoped(callId, call.serviceId) {
-                    serialFormat.encodeToString(parametersSerializer, call.parameters)
+                    serialFormat.encodeToString(parametersSerializer, call.arguments)
                 }
 
                 KrpcCallMessage.CallDataString(
@@ -414,7 +414,7 @@ public abstract class KrpcClient : RpcClient, KrpcEndpoint {
 
             is BinaryFormat -> {
                 val binaryValue = clientStreamContext.scoped(callId, call.serviceId) {
-                    serialFormat.encodeToByteArray(parametersSerializer, call.parameters)
+                    serialFormat.encodeToByteArray(parametersSerializer, call.arguments)
                 }
 
                 KrpcCallMessage.CallDataBinary(
@@ -529,9 +529,11 @@ public abstract class KrpcClient : RpcClient, KrpcEndpoint {
         config.serialFormatInitializer.applySerializersModuleAndBuild(module)
     }
 
+    @Suppress("SameReturnValue")
     private fun RpcCallable<*>.toMessageCallType(): KrpcCallMessage.CallType {
         return when (invokator) {
-            is RpcInvokator.Method -> KrpcCallMessage.CallType.Method
+            is RpcInvokator.FlowResponse -> KrpcCallMessage.CallType.Method
+            is RpcInvokator.UnaryResponse<*> -> KrpcCallMessage.CallType.Method
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,8 @@ dependencyResolutionManagement {
 include(":grpc")
 includePublic(":grpc:grpc-core")
 includePublic(":grpc:grpc-ktor-server")
+includePublic(":grpc:grpc-codec")
+includePublic(":grpc:grpc-codec-kotlinx-serialization")
 
 includePublic(":bom")
 

--- a/tests/compiler-plugin-tests/build.gradle.kts
+++ b/tests/compiler-plugin-tests/build.gradle.kts
@@ -113,6 +113,9 @@ tasks.test {
 
     useJUnitPlatform()
 
+    systemProperty("idea.ignore.disabled.plugins", "true")
+    systemProperty("idea.home.path", rootDir)
+
     systemPropertyLogged("kotlinx.rpc.globalRootDir", globalRootDir)
     systemPropertyLogged("kotlin.test.update.test.data", updateTestData)
 

--- a/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/AbstractBoxTest.kt
+++ b/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/AbstractBoxTest.kt
@@ -4,14 +4,17 @@
 
 package kotlinx.rpc.codegen.test.runners
 
+import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.DUMP_IR
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.WITH_STDLIB
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.WITH_REFLECT
+import org.jetbrains.kotlin.test.runners.codegen.AbstractFirBlackBoxCodegenTestBase
 import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
 import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
 
-open class AbstractBoxTest : BaseTestRunner() {
+open class AbstractBoxTest : AbstractFirBlackBoxCodegenTestBase(FirParser.LightTree) {
     override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider {
         return EnvironmentBasedStandardLibrariesPathProvider
     }

--- a/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/AbstractBoxTest.kt
+++ b/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/AbstractBoxTest.kt
@@ -6,7 +6,6 @@ package kotlinx.rpc.codegen.test.runners
 
 import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
-import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.DUMP_IR
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.WITH_STDLIB
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.WITH_REFLECT

--- a/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/AbstractDiagnosticTest.kt
+++ b/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/AbstractDiagnosticTest.kt
@@ -4,9 +4,17 @@
 
 package kotlinx.rpc.codegen.test.runners
 
+import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.runners.AbstractFirPhasedDiagnosticTest
+import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
 
-open class AbstractDiagnosticTest : BaseTestRunner() {
+open class AbstractDiagnosticTest : AbstractFirPhasedDiagnosticTest(FirParser.LightTree) {
+    override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider {
+        return EnvironmentBasedStandardLibrariesPathProvider
+    }
+
     override fun configure(builder: TestConfigurationBuilder) {
         super.configure(builder)
 

--- a/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/BaseTestRunner.kt
+++ b/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/runners/BaseTestRunner.kt
@@ -7,35 +7,16 @@ package kotlinx.rpc.codegen.test.runners
 import kotlinx.rpc.codegen.test.services.ExtensionRegistrarConfigurator
 import kotlinx.rpc.codegen.test.services.RpcCompileClasspathProvider
 import kotlinx.rpc.codegen.test.services.RpcRuntimeClasspathProvider
-import org.jetbrains.kotlin.test.FirParser
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives
 import org.jetbrains.kotlin.test.directives.FirDiagnosticsDirectives
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
-import org.jetbrains.kotlin.test.initIdeaConfiguration
-import org.jetbrains.kotlin.test.runners.AbstractFirPhasedDiagnosticTest
-import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
-import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
-import org.junit.jupiter.api.BeforeAll
-
-abstract class BaseTestRunner : AbstractFirPhasedDiagnosticTest(FirParser.LightTree) {
-    companion object {
-        @BeforeAll
-        @JvmStatic
-        fun setUp() {
-            initIdeaConfiguration()
-        }
-    }
-
-    override fun createKotlinStandardLibrariesPathProvider(): KotlinStandardLibrariesPathProvider {
-        return EnvironmentBasedStandardLibrariesPathProvider
-    }
-}
 
 fun TestConfigurationBuilder.commonFirWithPluginFrontendConfiguration() {
     defaultDirectives {
         +FirDiagnosticsDirectives.ENABLE_PLUGIN_PHASES
         +FirDiagnosticsDirectives.FIR_DUMP
+
         +JvmEnvironmentConfigurationDirectives.FULL_JDK
         +CodegenTestDirectives.IGNORE_DEXING
     }

--- a/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/services/ExtensionRegistrarConfigurator.kt
+++ b/tests/compiler-plugin-tests/src/test/kotlin/kotlinx/rpc/codegen/test/services/ExtensionRegistrarConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
 package kotlinx.rpc.codegen.test.services

--- a/tests/compiler-plugin-tests/src/testData/box/customParameterTypes.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/customParameterTypes.fir.ir.txt
@@ -1,49 +1,49 @@
 FILE fqName:<root> fileName:/customParameterTypes.kt
   CLASS CLASS name:TestData modality:FINAL visibility:public [data] superTypes:[kotlin.Any]
-    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.TestData
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.TestData
     PROPERTY name:value visibility:public modality:FINAL [val]
       FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]
         EXPRESSION_BODY
           GET_VAR 'value: kotlin.String declared in <root>.TestData.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-value> visibility:public modality:FINAL <> ($this:<root>.TestData) returnType:kotlin.String
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-value> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestData
         correspondingProperty: PROPERTY name:value visibility:public modality:FINAL [val]
-        $this: VALUE_PARAMETER name:<this> type:<root>.TestData
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public final fun <get-value> (): kotlin.String declared in <root>.TestData'
             GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
               receiver: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.<get-value>' type=<root>.TestData origin=null
-    CONSTRUCTOR visibility:public <> (value:kotlin.String) returnType:<root>.TestData [primary]
-      VALUE_PARAMETER name:value index:0 type:kotlin.String
+    CONSTRUCTOR visibility:public returnType:<root>.TestData [primary]
+      VALUE_PARAMETER kind:Regular name:value index:0 type:kotlin.String
       BLOCK_BODY
         DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
         INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:TestData modality:FINAL visibility:public [data] superTypes:[kotlin.Any]' type=kotlin.Unit
-    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL <> ($this:<root>.TestData) returnType:kotlin.String [operator]
-      $this: VALUE_PARAMETER name:<this> type:<root>.TestData
+    FUN GENERATED_DATA_CLASS_MEMBER name:component1 visibility:public modality:FINAL returnType:kotlin.String [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestData
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun component1 (): kotlin.String declared in <root>.TestData'
           GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
             receiver: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.component1' type=<root>.TestData origin=null
-    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL <> ($this:<root>.TestData, value:kotlin.String) returnType:<root>.TestData
-      $this: VALUE_PARAMETER name:<this> type:<root>.TestData
-      VALUE_PARAMETER name:value index:0 type:kotlin.String
+    FUN GENERATED_DATA_CLASS_MEMBER name:copy visibility:public modality:FINAL returnType:<root>.TestData
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestData
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.String
         EXPRESSION_BODY
           GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
             receiver: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.copy' type=<root>.TestData origin=null
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public final fun copy (value: kotlin.String): <root>.TestData declared in <root>.TestData'
           CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.String) declared in <root>.TestData' type=<root>.TestData origin=null
-            value: GET_VAR 'value: kotlin.String declared in <root>.TestData.copy' type=kotlin.String origin=null
-    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN <> ($this:<root>.TestData, other:kotlin.Any?) returnType:kotlin.Boolean [operator]
+            ARG value: GET_VAR 'value: kotlin.String declared in <root>.TestData.copy' type=kotlin.String origin=null
+    FUN GENERATED_DATA_CLASS_MEMBER name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestData
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:<root>.TestData
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
       BLOCK_BODY
         WHEN type=kotlin.Unit origin=null
           BRANCH
             if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
-              arg0: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.equals' type=<root>.TestData origin=null
-              arg1: GET_VAR 'other: kotlin.Any? declared in <root>.TestData.equals' type=kotlin.Any? origin=null
+              ARG arg0: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.equals' type=<root>.TestData origin=null
+              ARG arg1: GET_VAR 'other: kotlin.Any? declared in <root>.TestData.equals' type=kotlin.Any? origin=null
             then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.TestData'
               CONST Boolean type=kotlin.Boolean value=true
         WHEN type=kotlin.Unit origin=null
@@ -58,28 +58,28 @@ FILE fqName:<root> fileName:/customParameterTypes.kt
         WHEN type=kotlin.Unit origin=null
           BRANCH
             if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
-              $this: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
-                arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                ARG arg0: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
                   receiver: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.equals' type=<root>.TestData origin=null
-                arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                ARG arg1: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
                   receiver: GET_VAR 'val tmp_0: <root>.TestData declared in <root>.TestData.equals' type=<root>.TestData origin=null
             then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.TestData'
               CONST Boolean type=kotlin.Boolean value=false
         RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.TestData'
           CONST Boolean type=kotlin.Boolean value=true
-    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN <> ($this:<root>.TestData) returnType:kotlin.Int
+    FUN GENERATED_DATA_CLASS_MEMBER name:hashCode visibility:public modality:OPEN returnType:kotlin.Int
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestData
       overridden:
         public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:<root>.TestData
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public open fun hashCode (): kotlin.Int declared in <root>.TestData'
           CALL 'public open fun hashCode (): kotlin.Int declared in kotlin.String' type=kotlin.Int origin=null
-            $this: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+            ARG <this>: GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:value type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
               receiver: GET_VAR '<this>: <root>.TestData declared in <root>.TestData.hashCode' type=<root>.TestData origin=null
-    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN <> ($this:<root>.TestData) returnType:kotlin.String
+    FUN GENERATED_DATA_CLASS_MEMBER name:toString visibility:public modality:OPEN returnType:kotlin.String
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.TestData
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:<root>.TestData
       BLOCK_BODY
         RETURN type=kotlin.Nothing from='public open fun toString (): kotlin.String declared in <root>.TestData'
           STRING_CONCATENATION type=kotlin.String
@@ -91,16 +91,16 @@ FILE fqName:<root> fileName:/customParameterTypes.kt
   CLASS INTERFACE name:BoxService modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
     annotations:
       Rpc
-    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService
     CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]
-      $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub
       PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
         FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_stub_id: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlin.Long origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlin.Long
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL returnType:kotlin.Long
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]' type=kotlin.Long origin=null
@@ -109,295 +109,321 @@ FILE fqName:<root> fileName:/customParameterTypes.kt
         FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlinx.rpc.RpcClient origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlinx.rpc.RpcClient
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL returnType:kotlinx.rpc.RpcClient
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]' type=kotlinx.rpc.RpcClient origin=null
                 receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_client>' type=<root>.BoxService.$rpcServiceStub origin=null
       CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]
-        $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        PROPERTY name:simpleName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract simpleName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:simpleName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-simpleName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-simpleName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:fqName visibility:public modality:FINAL [val]
           overridden:
             public abstract fqName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]
             EXPRESSION_BODY
               CONST String type=kotlin.String value="BoxService"
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.String
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:fqName visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-fqName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='public final fun <get-fqName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-fqName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:test1Invokator visibility:private modality:FINAL [val]
-          FIELD PROPERTY_BACKING_FIELD name:test1Invokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]
+          FIELD PROPERTY_BACKING_FIELD name:test1Invokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
             EXPRESSION_BODY
-              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
-                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Any?, kotlin.Any?> origin=LAMBDA
-                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (service:<root>.BoxService, parameters:kotlin.Array<out kotlin.Any?>) returnType:kotlin.Any? [suspend]
-                    VALUE_PARAMETER name:service index:0 type:<root>.BoxService
-                    VALUE_PARAMETER name:parameters index:1 type:kotlin.Array<out kotlin.Any?>
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
                     BLOCK_BODY
-                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, parameters: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.test1Invokator'
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.test1Invokator'
                         CALL 'public abstract fun test1 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                          $this: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.test1Invokator.<anonymous>' type=<root>.BoxService origin=null
-                          testData: TYPE_OP type=<root>.TestData origin=CAST typeOperand=<root>.TestData
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.test1Invokator.<anonymous>' type=<root>.BoxService origin=null
+                          ARG testData: TYPE_OP type=<root>.TestData origin=CAST typeOperand=<root>.TestData
                             CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
-                              $this: GET_VAR 'parameters: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.test1Invokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
-                              index: CONST Int type=kotlin.Int value=0
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test1Invokator> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
+                              ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.test1Invokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                              ARG index: CONST Int type=kotlin.Int value=0
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test1Invokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:test1Invokator visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='private final fun <get-test1Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
-                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test1Invokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
+              RETURN type=kotlin.Nothing from='private final fun <get-test1Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test1Invokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-test1Invokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:test2Invokator visibility:private modality:FINAL [val]
-          FIELD PROPERTY_BACKING_FIELD name:test2Invokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]
+          FIELD PROPERTY_BACKING_FIELD name:test2Invokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
             EXPRESSION_BODY
-              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
-                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Any?, kotlin.Any?> origin=LAMBDA
-                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (service:<root>.BoxService, parameters:kotlin.Array<out kotlin.Any?>) returnType:kotlin.Any? [suspend]
-                    VALUE_PARAMETER name:service index:0 type:<root>.BoxService
-                    VALUE_PARAMETER name:parameters index:1 type:kotlin.Array<out kotlin.Any?>
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
                     BLOCK_BODY
-                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, parameters: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.test2Invokator'
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.test2Invokator'
                         CALL 'public abstract fun test2 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                          $this: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.test2Invokator.<anonymous>' type=<root>.BoxService origin=null
-                          testData: TYPE_OP type=<root>.TestData origin=CAST typeOperand=<root>.TestData
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.test2Invokator.<anonymous>' type=<root>.BoxService origin=null
+                          ARG testData: TYPE_OP type=<root>.TestData origin=CAST typeOperand=<root>.TestData
                             CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
-                              $this: GET_VAR 'parameters: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.test2Invokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
-                              index: CONST Int type=kotlin.Int value=0
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test2Invokator> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
+                              ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.test2Invokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                              ARG index: CONST Int type=kotlin.Int value=0
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-test2Invokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:test2Invokator visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='private final fun <get-test2Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
-                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test2Invokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
+              RETURN type=kotlin.Nothing from='private final fun <get-test2Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test2Invokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-test2Invokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:callableMap visibility:private modality:FINAL [val]
           FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
             EXPRESSION_BODY
               CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                <K>: kotlin.String
-                <V>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
-                  CALL 'public final fun to <A, B> (that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                    <A>: kotlin.String
-                    <B>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                    $receiver: CONST String type=kotlin.String value="test1"
-                    that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<T of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>, isNonSuspendFunction: kotlin.Boolean) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
-                      <T>: <root>.BoxService
-                      name: CONST String type=kotlin.String value="test1"
-                      returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                        kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                          <T>: kotlin.String
-                        annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                          <T>: <none>
-                      invokator: CALL 'private final fun <get-test1Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=GET_PROPERTY
-                        $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                      parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
-                        <T>: kotlinx.rpc.descriptor.RpcParameter
-                        elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
-                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
-                            name: CONST String type=kotlin.String value="testData"
-                            type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                              kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                                <T>: <root>.TestData
-                              annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                                <T>: <none>
-                            annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                              <T>: <none>
-                      isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
-                  CALL 'public final fun to <A, B> (that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                    <A>: kotlin.String
-                    <B>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                    $receiver: CONST String type=kotlin.String value="test2"
-                    that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<T of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>, isNonSuspendFunction: kotlin.Boolean) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
-                      <T>: <root>.BoxService
-                      name: CONST String type=kotlin.String value="test2"
-                      returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                        kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                          <T>: kotlin.String
-                        annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                          <T>: <none>
-                      invokator: CALL 'private final fun <get-test2Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=GET_PROPERTY
-                        $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                      parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
-                        <T>: kotlinx.rpc.descriptor.RpcParameter
-                        elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
-                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
-                            name: CONST String type=kotlin.String value="testData"
-                            type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                              kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                                <T>: <root>.TestData
-                              annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                                <T>: <none>
-                            annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                              <T>: <none>
-                      isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                TYPE_ARG K: kotlin.String
+                TYPE_ARG V: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="test1"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="test1"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-test1Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="testData"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: <root>.TestData
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="test2"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="test2"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-test2Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="testData"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: <root>.TestData
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:callableMap visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callableMap>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        CONSTRUCTOR visibility:private <> () returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
+        CONSTRUCTOR visibility:private returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
           BLOCK_BODY
             DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
             INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=kotlin.Unit
-        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
           overridden:
             public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-          VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun hashCode (): kotlin.Int declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun toString (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN name:createInstance visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, serviceId:kotlin.Long, client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService
+        FUN name:createInstance visibility:public modality:OPEN returnType:<root>.BoxService
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:serviceId index:1 type:kotlin.Long
+          VALUE_PARAMETER kind:Regular name:client index:2 type:kotlinx.rpc.RpcClient
           overridden:
-            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): T of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:serviceId index:0 type:kotlin.Long
-          VALUE_PARAMETER name:client index:1 type:kotlinx.rpc.RpcClient
+            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): Service of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion'
               CONSTRUCTOR_CALL 'public constructor <init> (__rpc_stub_id: kotlin.Long, __rpc_client: kotlinx.rpc.RpcClient) declared in <root>.BoxService.$rpcServiceStub' type=<root>.BoxService.$rpcServiceStub origin=null
-                __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
-                __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
-        FUN name:getCallable visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, name:kotlin.String) returnType:kotlinx.rpc.descriptor.RpcCallable?
+                ARG __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
+                ARG __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
+        FUN name:getCallable visibility:public modality:FINAL returnType:kotlinx.rpc.descriptor.RpcCallable?
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
           overridden:
-            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:name index:0 type:kotlin.String
+            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
+            RETURN type=kotlin.Nothing from='public final fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
               CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlinx.rpc.descriptor.RpcCallable? origin=GET_ARRAY_ELEMENT
-                $this: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
-      CONSTRUCTOR visibility:public <> (__rpc_stub_id:kotlin.Long, __rpc_client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService.$rpcServiceStub [primary]
-        VALUE_PARAMETER name:__rpc_stub_id index:0 type:kotlin.Long
-        VALUE_PARAMETER name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
+                ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                ARG key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
+        PROPERTY name:callables visibility:public modality:FINAL [val]
+          overridden:
+            public abstract callables: kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FUN name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-callables> (): kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                CALL 'public abstract fun <get-values> (): kotlin.collections.Collection<V of kotlin.collections.Map> declared in kotlin.collections.Map' type=kotlin.collections.Collection<V of kotlin.collections.Map> origin=GET_PROPERTY
+                  ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                    ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callables>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.BoxService.$rpcServiceStub [primary]
+        VALUE_PARAMETER kind:Regular name:__rpc_stub_id index:0 type:kotlin.Long
+        VALUE_PARAMETER kind:Regular name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
         BLOCK_BODY
           DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
           INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]' type=kotlin.Unit
-      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
         overridden:
           public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun hashCode (): kotlin.Int declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun toString (): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN name:test1 visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub, testData:<root>.TestData) returnType:kotlin.String [suspend]
+      FUN name:test1 visibility:public modality:OPEN returnType:kotlin.String [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:testData index:1 type:<root>.TestData
         overridden:
           public abstract fun test1 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
-        VALUE_PARAMETER name:testData index:0 type:<root>.TestData
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public open fun test1 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService.$rpcServiceStub'
             CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.String origin=null
-              <T>: kotlin.String
-              $this: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
-                $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test1' type=<root>.BoxService.$rpcServiceStub origin=null
-              call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, parameters: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
-                descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
-                callableName: CONST String type=kotlin.String value="test1"
-                parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
-                  <T>: kotlin.Any?
-                  elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+              TYPE_ARG T: kotlin.String
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test1' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="test1"
+                ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                  ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
                     GET_VAR 'testData: <root>.TestData declared in <root>.BoxService.$rpcServiceStub.test1' type=<root>.TestData origin=null
-                serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test1' type=<root>.BoxService.$rpcServiceStub origin=null
-      FUN name:test2 visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub, testData:<root>.TestData) returnType:kotlin.String [suspend]
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test1' type=<root>.BoxService.$rpcServiceStub origin=null
+      FUN name:test2 visibility:public modality:OPEN returnType:kotlin.String [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:testData index:1 type:<root>.TestData
         overridden:
           public abstract fun test2 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
-        VALUE_PARAMETER name:testData index:0 type:<root>.TestData
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public open fun test2 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService.$rpcServiceStub'
             CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.String origin=null
-              <T>: kotlin.String
-              $this: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
-                $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test2' type=<root>.BoxService.$rpcServiceStub origin=null
-              call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, parameters: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
-                descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
-                callableName: CONST String type=kotlin.String value="test2"
-                parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
-                  <T>: kotlin.Any?
-                  elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+              TYPE_ARG T: kotlin.String
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test2' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="test2"
+                ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                  ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
                     GET_VAR 'testData: <root>.TestData declared in <root>.BoxService.$rpcServiceStub.test2' type=<root>.TestData origin=null
-                serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test2' type=<root>.BoxService.$rpcServiceStub origin=null
-    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.test2' type=<root>.BoxService.$rpcServiceStub origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN name:test1 visibility:public modality:ABSTRACT <> ($this:<root>.BoxService, testData:<root>.TestData) returnType:kotlin.String [suspend]
-      $this: VALUE_PARAMETER name:<this> type:<root>.BoxService
-      VALUE_PARAMETER name:testData index:0 type:<root>.TestData
-    FUN name:test2 visibility:public modality:ABSTRACT <> ($this:<root>.BoxService, testData:<root>.TestData) returnType:kotlin.String [suspend]
-      $this: VALUE_PARAMETER name:<this> type:<root>.BoxService
-      VALUE_PARAMETER name:testData index:0 type:<root>.TestData
-  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    FUN name:test1 visibility:public modality:ABSTRACT returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:testData index:1 type:<root>.TestData
+    FUN name:test2 visibility:public modality:ABSTRACT returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:testData index:1 type:<root>.TestData
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
         CALL 'public final fun runBlocking <T> (context: kotlin.coroutines.CoroutineContext, block: @[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, T of kotlinx.coroutines.runBlocking>): T of kotlinx.coroutines.runBlocking declared in kotlinx.coroutines' type=kotlin.String origin=null
-          <T>: kotlin.String
-          block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
-            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:kotlinx.coroutines.CoroutineScope) returnType:kotlin.String [suspend]
-              $receiver: VALUE_PARAMETER name:$this$runBlocking type:kotlinx.coroutines.CoroutineScope
+          TYPE_ARG T: kotlin.String
+          ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String [suspend]
+              VALUE_PARAMETER kind:ExtensionReceiver name:$this$runBlocking index:0 type:kotlinx.coroutines.CoroutineScope
               BLOCK_BODY
                 VAR name:test1 type:kotlin.String [val]
                   CALL 'public abstract fun test1 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                    $this: CALL 'public final fun withService <T> (): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
-                      <T>: <root>.BoxService
-                      $receiver: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
-                    testData: CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.String) declared in <root>.TestData' type=<root>.TestData origin=null
-                      value: CONST String type=kotlin.String value="value"
+                    ARG <this>: CALL 'public final fun withService <T> (<this>: kotlinx.rpc.RpcClient): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
+                      TYPE_ARG T: <root>.BoxService
+                      ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
+                    ARG testData: CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.String) declared in <root>.TestData' type=<root>.TestData origin=null
+                      ARG value: CONST String type=kotlin.String value="value"
                 VAR name:test2 type:kotlin.String [val]
                   CALL 'public abstract fun test2 (testData: <root>.TestData): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                    $this: CALL 'public final fun withService <T> (): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
-                      <T>: <root>.BoxService
-                      $receiver: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
-                    testData: CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.String) declared in <root>.TestData' type=<root>.TestData origin=null
-                      value: CONST String type=kotlin.String value="value"
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.box'
+                    ARG <this>: CALL 'public final fun withService <T> (<this>: kotlinx.rpc.RpcClient): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
+                      TYPE_ARG T: <root>.BoxService
+                      ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
+                    ARG testData: CONSTRUCTOR_CALL 'public constructor <init> (value: kotlin.String) declared in <root>.TestData' type=<root>.TestData origin=null
+                      ARG value: CONST String type=kotlin.String value="value"
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
                   WHEN type=kotlin.String origin=IF
                     BRANCH
                       if: WHEN type=kotlin.Boolean origin=ANDAND
                         BRANCH
                           if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                            arg0: GET_VAR 'val test1: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
-                            arg1: CONST String type=kotlin.String value="call_42"
+                            ARG arg0: GET_VAR 'val test1: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+                            ARG arg1: CONST String type=kotlin.String value="call_42"
                           then: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                            arg0: GET_VAR 'val test2: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
-                            arg1: CONST String type=kotlin.String value="call_42"
+                            ARG arg0: GET_VAR 'val test2: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+                            ARG arg1: CONST String type=kotlin.String value="call_42"
                         BRANCH
                           if: CONST Boolean type=kotlin.Boolean value=true
                           then: CONST Boolean type=kotlin.Boolean value=false

--- a/tests/compiler-plugin-tests/src/testData/box/flowParameter.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/flowParameter.fir.ir.txt
@@ -2,16 +2,16 @@ FILE fqName:<root> fileName:/flowParameter.kt
   CLASS INTERFACE name:BoxService modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
     annotations:
       Rpc
-    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService
     CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]
-      $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub
       PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
         FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_stub_id: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlin.Long origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlin.Long
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL returnType:kotlin.Long
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]' type=kotlin.Long origin=null
@@ -20,216 +20,242 @@ FILE fqName:<root> fileName:/flowParameter.kt
         FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlinx.rpc.RpcClient origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlinx.rpc.RpcClient
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL returnType:kotlinx.rpc.RpcClient
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]' type=kotlinx.rpc.RpcClient origin=null
                 receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_client>' type=<root>.BoxService.$rpcServiceStub origin=null
       CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]
-        $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        PROPERTY name:simpleName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract simpleName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:simpleName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-simpleName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-simpleName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:fqName visibility:public modality:FINAL [val]
           overridden:
             public abstract fqName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]
             EXPRESSION_BODY
               CONST String type=kotlin.String value="BoxService"
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.String
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:fqName visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-fqName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='public final fun <get-fqName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-fqName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:streamInvokator visibility:private modality:FINAL [val]
-          FIELD PROPERTY_BACKING_FIELD name:streamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]
+          FIELD PROPERTY_BACKING_FIELD name:streamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
             EXPRESSION_BODY
-              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
-                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Any?, kotlin.Any?> origin=LAMBDA
-                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (service:<root>.BoxService, parameters:kotlin.Array<out kotlin.Any?>) returnType:kotlin.Any? [suspend]
-                    VALUE_PARAMETER name:service index:0 type:<root>.BoxService
-                    VALUE_PARAMETER name:parameters index:1 type:kotlin.Array<out kotlin.Any?>
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
                     BLOCK_BODY
-                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, parameters: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.streamInvokator'
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.streamInvokator'
                         CALL 'public abstract fun stream (flow: kotlinx.coroutines.flow.Flow<kotlin.String>): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                          $this: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.streamInvokator.<anonymous>' type=<root>.BoxService origin=null
-                          flow: TYPE_OP type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=CAST typeOperand=kotlinx.coroutines.flow.Flow<kotlin.String>
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.streamInvokator.<anonymous>' type=<root>.BoxService origin=null
+                          ARG flow: TYPE_OP type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=CAST typeOperand=kotlinx.coroutines.flow.Flow<kotlin.String>
                             CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
-                              $this: GET_VAR 'parameters: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.streamInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
-                              index: CONST Int type=kotlin.Int value=0
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-streamInvokator> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
+                              ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.streamInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                              ARG index: CONST Int type=kotlin.Int value=0
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-streamInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:streamInvokator visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='private final fun <get-streamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
-                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:streamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
+              RETURN type=kotlin.Nothing from='private final fun <get-streamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:streamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-streamInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:callableMap visibility:private modality:FINAL [val]
           FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
             EXPRESSION_BODY
               CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                <K>: kotlin.String
-                <V>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
-                  CALL 'public final fun to <A, B> (that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                    <A>: kotlin.String
-                    <B>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                    $receiver: CONST String type=kotlin.String value="stream"
-                    that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<T of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>, isNonSuspendFunction: kotlin.Boolean) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
-                      <T>: <root>.BoxService
-                      name: CONST String type=kotlin.String value="stream"
-                      returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                        kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                          <T>: kotlin.String
-                        annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                          <T>: <none>
-                      invokator: CALL 'private final fun <get-streamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=GET_PROPERTY
-                        $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                      parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
-                        <T>: kotlinx.rpc.descriptor.RpcParameter
-                        elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
-                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
-                            name: CONST String type=kotlin.String value="flow"
-                            type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                              kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                                <T>: kotlinx.coroutines.flow.Flow<kotlin.String>
-                              annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                                <T>: <none>
-                            annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                              <T>: <none>
-                      isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                TYPE_ARG K: kotlin.String
+                TYPE_ARG V: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="stream"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="stream"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-streamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="flow"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlinx.coroutines.flow.Flow<kotlin.String>
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:callableMap visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callableMap>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        CONSTRUCTOR visibility:private <> () returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
+        CONSTRUCTOR visibility:private returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
           BLOCK_BODY
             DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
             INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=kotlin.Unit
-        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
           overridden:
             public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-          VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun hashCode (): kotlin.Int declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun toString (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN name:createInstance visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, serviceId:kotlin.Long, client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService
+        FUN name:createInstance visibility:public modality:OPEN returnType:<root>.BoxService
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:serviceId index:1 type:kotlin.Long
+          VALUE_PARAMETER kind:Regular name:client index:2 type:kotlinx.rpc.RpcClient
           overridden:
-            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): T of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:serviceId index:0 type:kotlin.Long
-          VALUE_PARAMETER name:client index:1 type:kotlinx.rpc.RpcClient
+            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): Service of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion'
               CONSTRUCTOR_CALL 'public constructor <init> (__rpc_stub_id: kotlin.Long, __rpc_client: kotlinx.rpc.RpcClient) declared in <root>.BoxService.$rpcServiceStub' type=<root>.BoxService.$rpcServiceStub origin=null
-                __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
-                __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
-        FUN name:getCallable visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, name:kotlin.String) returnType:kotlinx.rpc.descriptor.RpcCallable?
+                ARG __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
+                ARG __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
+        FUN name:getCallable visibility:public modality:FINAL returnType:kotlinx.rpc.descriptor.RpcCallable?
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
           overridden:
-            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:name index:0 type:kotlin.String
+            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
+            RETURN type=kotlin.Nothing from='public final fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
               CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlinx.rpc.descriptor.RpcCallable? origin=GET_ARRAY_ELEMENT
-                $this: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
-      CONSTRUCTOR visibility:public <> (__rpc_stub_id:kotlin.Long, __rpc_client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService.$rpcServiceStub [primary]
-        VALUE_PARAMETER name:__rpc_stub_id index:0 type:kotlin.Long
-        VALUE_PARAMETER name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
+                ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                ARG key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
+        PROPERTY name:callables visibility:public modality:FINAL [val]
+          overridden:
+            public abstract callables: kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FUN name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-callables> (): kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                CALL 'public abstract fun <get-values> (): kotlin.collections.Collection<V of kotlin.collections.Map> declared in kotlin.collections.Map' type=kotlin.collections.Collection<V of kotlin.collections.Map> origin=GET_PROPERTY
+                  ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                    ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callables>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.BoxService.$rpcServiceStub [primary]
+        VALUE_PARAMETER kind:Regular name:__rpc_stub_id index:0 type:kotlin.Long
+        VALUE_PARAMETER kind:Regular name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
         BLOCK_BODY
           DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
           INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]' type=kotlin.Unit
-      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
         overridden:
           public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun hashCode (): kotlin.Int declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun toString (): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN name:stream visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub, flow:kotlinx.coroutines.flow.Flow<kotlin.String>) returnType:kotlin.String [suspend]
+      FUN name:stream visibility:public modality:OPEN returnType:kotlin.String [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:flow index:1 type:kotlinx.coroutines.flow.Flow<kotlin.String>
         overridden:
           public abstract fun stream (flow: kotlinx.coroutines.flow.Flow<kotlin.String>): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
-        VALUE_PARAMETER name:flow index:0 type:kotlinx.coroutines.flow.Flow<kotlin.String>
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public open fun stream (flow: kotlinx.coroutines.flow.Flow<kotlin.String>): kotlin.String declared in <root>.BoxService.$rpcServiceStub'
             CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.String origin=null
-              <T>: kotlin.String
-              $this: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
-                $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.stream' type=<root>.BoxService.$rpcServiceStub origin=null
-              call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, parameters: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
-                descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
-                callableName: CONST String type=kotlin.String value="stream"
-                parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
-                  <T>: kotlin.Any?
-                  elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+              TYPE_ARG T: kotlin.String
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.stream' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="stream"
+                ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                  ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
                     GET_VAR 'flow: kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxService.$rpcServiceStub.stream' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
-                serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.stream' type=<root>.BoxService.$rpcServiceStub origin=null
-    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.stream' type=<root>.BoxService.$rpcServiceStub origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN name:stream visibility:public modality:ABSTRACT <> ($this:<root>.BoxService, flow:kotlinx.coroutines.flow.Flow<kotlin.String>) returnType:kotlin.String [suspend]
-      $this: VALUE_PARAMETER name:<this> type:<root>.BoxService
-      VALUE_PARAMETER name:flow index:0 type:kotlinx.coroutines.flow.Flow<kotlin.String>
-  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    FUN name:stream visibility:public modality:ABSTRACT returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:flow index:1 type:kotlinx.coroutines.flow.Flow<kotlin.String>
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
         CALL 'public final fun runBlocking <T> (context: kotlin.coroutines.CoroutineContext, block: @[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, T of kotlinx.coroutines.runBlocking>): T of kotlinx.coroutines.runBlocking declared in kotlinx.coroutines' type=kotlin.String origin=null
-          <T>: kotlin.String
-          block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
-            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:kotlinx.coroutines.CoroutineScope) returnType:kotlin.String [suspend]
-              $receiver: VALUE_PARAMETER name:$this$runBlocking type:kotlinx.coroutines.CoroutineScope
+          TYPE_ARG T: kotlin.String
+          ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String [suspend]
+              VALUE_PARAMETER kind:ExtensionReceiver name:$this$runBlocking index:0 type:kotlinx.coroutines.CoroutineScope
               BLOCK_BODY
                 VAR name:result type:kotlin.String [val]
                   CALL 'public abstract fun stream (flow: kotlinx.coroutines.flow.Flow<kotlin.String>): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                    $this: CALL 'public final fun withService <T> (): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
-                      <T>: <root>.BoxService
-                      $receiver: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
-                    flow: CALL 'public final fun flow <T> (block: @[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.flow.FlowCollector<T of kotlinx.coroutines.flow.flow>, kotlin.Unit>): kotlinx.coroutines.flow.Flow<T of kotlinx.coroutines.flow.flow> declared in kotlinx.coroutines.flow' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
-                      <T>: kotlin.String
-                      block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.flow.FlowCollector<kotlin.String>, kotlin.Unit> origin=LAMBDA
-                        FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:kotlinx.coroutines.flow.FlowCollector<kotlin.String>) returnType:kotlin.Unit [suspend]
-                          $receiver: VALUE_PARAMETER name:$this$flow type:kotlinx.coroutines.flow.FlowCollector<kotlin.String>
+                    ARG <this>: CALL 'public final fun withService <T> (<this>: kotlinx.rpc.RpcClient): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
+                      TYPE_ARG T: <root>.BoxService
+                      ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
+                    ARG flow: CALL 'public final fun flow <T> (block: @[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.flow.FlowCollector<T of kotlinx.coroutines.flow.flow>, kotlin.Unit>): kotlinx.coroutines.flow.Flow<T of kotlinx.coroutines.flow.flow> declared in kotlinx.coroutines.flow' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
+                      TYPE_ARG T: kotlin.String
+                      ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.flow.FlowCollector<kotlin.String>, kotlin.Unit> origin=LAMBDA
+                        FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Unit [suspend]
+                          VALUE_PARAMETER kind:ExtensionReceiver name:$this$flow index:0 type:kotlinx.coroutines.flow.FlowCollector<kotlin.String>
                           BLOCK_BODY
-                            RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Unit declared in <root>.box.<anonymous>'
+                            RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$flow: kotlinx.coroutines.flow.FlowCollector<kotlin.String>): kotlin.Unit declared in <root>.box.<anonymous>'
                               GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Unit modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.box'
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
                   WHEN type=kotlin.String origin=IF
                     BRANCH
                       if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                        arg0: GET_VAR 'val result: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
-                        arg1: CONST String type=kotlin.String value="call_42"
+                        ARG arg0: GET_VAR 'val result: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+                        ARG arg1: CONST String type=kotlin.String value="call_42"
                       then: CONST String type=kotlin.String value="OK"
                     BRANCH
                       if: CONST Boolean type=kotlin.Boolean value=true

--- a/tests/compiler-plugin-tests/src/testData/box/multiModule.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/multiModule.fir.ir.txt
@@ -3,16 +3,16 @@ FILE fqName:<root> fileName:/module_lib_multiModule.kt
   CLASS INTERFACE name:BoxService modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
     annotations:
       Rpc
-    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService
     CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]
-      $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub
       PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
         FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_stub_id: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlin.Long origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlin.Long
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL returnType:kotlin.Long
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]' type=kotlin.Long origin=null
@@ -21,192 +21,217 @@ FILE fqName:<root> fileName:/module_lib_multiModule.kt
         FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlinx.rpc.RpcClient origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlinx.rpc.RpcClient
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL returnType:kotlinx.rpc.RpcClient
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]' type=kotlinx.rpc.RpcClient origin=null
                 receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_client>' type=<root>.BoxService.$rpcServiceStub origin=null
       CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]
-        $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        PROPERTY name:simpleName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract simpleName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:simpleName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-simpleName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-simpleName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:fqName visibility:public modality:FINAL [val]
           overridden:
             public abstract fqName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]
             EXPRESSION_BODY
               CONST String type=kotlin.String value="BoxService"
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.String
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:fqName visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-fqName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='public final fun <get-fqName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-fqName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:simpleInvokator visibility:private modality:FINAL [val]
-          FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]
+          FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
             EXPRESSION_BODY
-              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
-                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Any?, kotlin.Any?> origin=LAMBDA
-                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (service:<root>.BoxService, parameters:kotlin.Array<out kotlin.Any?>) returnType:kotlin.Any? [suspend]
-                    VALUE_PARAMETER name:service index:0 type:<root>.BoxService
-                    VALUE_PARAMETER name:parameters index:1 type:kotlin.Array<out kotlin.Any?>
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
                     BLOCK_BODY
-                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, parameters: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator'
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator'
                         CALL 'public abstract fun simple (): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                          $this: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator.<anonymous>' type=<root>.BoxService origin=null
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleInvokator> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator.<anonymous>' type=<root>.BoxService origin=null
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:simpleInvokator visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
-                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
+              RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:callableMap visibility:private modality:FINAL [val]
           FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
             EXPRESSION_BODY
               CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                <K>: kotlin.String
-                <V>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
-                  CALL 'public final fun to <A, B> (that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                    <A>: kotlin.String
-                    <B>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                    $receiver: CONST String type=kotlin.String value="simple"
-                    that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<T of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>, isNonSuspendFunction: kotlin.Boolean) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
-                      <T>: <root>.BoxService
-                      name: CONST String type=kotlin.String value="simple"
-                      returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                        kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                          <T>: kotlin.String
-                        annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                          <T>: <none>
-                      invokator: CALL 'private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=GET_PROPERTY
-                        $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                      parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
-                        <T>: kotlinx.rpc.descriptor.RpcParameter
-                      isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                TYPE_ARG K: kotlin.String
+                TYPE_ARG V: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="simple"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="simple"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:callableMap visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callableMap>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        CONSTRUCTOR visibility:private <> () returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
+        CONSTRUCTOR visibility:private returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
           BLOCK_BODY
             DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
             INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=kotlin.Unit
-        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
           overridden:
             public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-          VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun hashCode (): kotlin.Int declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun toString (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN name:createInstance visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, serviceId:kotlin.Long, client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService
+        FUN name:createInstance visibility:public modality:OPEN returnType:<root>.BoxService
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:serviceId index:1 type:kotlin.Long
+          VALUE_PARAMETER kind:Regular name:client index:2 type:kotlinx.rpc.RpcClient
           overridden:
-            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): T of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:serviceId index:0 type:kotlin.Long
-          VALUE_PARAMETER name:client index:1 type:kotlinx.rpc.RpcClient
+            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): Service of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion'
               CONSTRUCTOR_CALL 'public constructor <init> (__rpc_stub_id: kotlin.Long, __rpc_client: kotlinx.rpc.RpcClient) declared in <root>.BoxService.$rpcServiceStub' type=<root>.BoxService.$rpcServiceStub origin=null
-                __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
-                __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
-        FUN name:getCallable visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, name:kotlin.String) returnType:kotlinx.rpc.descriptor.RpcCallable?
+                ARG __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
+                ARG __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
+        FUN name:getCallable visibility:public modality:FINAL returnType:kotlinx.rpc.descriptor.RpcCallable?
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
           overridden:
-            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:name index:0 type:kotlin.String
+            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
+            RETURN type=kotlin.Nothing from='public final fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
               CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlinx.rpc.descriptor.RpcCallable? origin=GET_ARRAY_ELEMENT
-                $this: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
-      CONSTRUCTOR visibility:public <> (__rpc_stub_id:kotlin.Long, __rpc_client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService.$rpcServiceStub [primary]
-        VALUE_PARAMETER name:__rpc_stub_id index:0 type:kotlin.Long
-        VALUE_PARAMETER name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
+                ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                ARG key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
+        PROPERTY name:callables visibility:public modality:FINAL [val]
+          overridden:
+            public abstract callables: kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FUN name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-callables> (): kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                CALL 'public abstract fun <get-values> (): kotlin.collections.Collection<V of kotlin.collections.Map> declared in kotlin.collections.Map' type=kotlin.collections.Collection<V of kotlin.collections.Map> origin=GET_PROPERTY
+                  ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                    ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callables>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.BoxService.$rpcServiceStub [primary]
+        VALUE_PARAMETER kind:Regular name:__rpc_stub_id index:0 type:kotlin.Long
+        VALUE_PARAMETER kind:Regular name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
         BLOCK_BODY
           DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
           INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]' type=kotlin.Unit
-      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
         overridden:
           public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun hashCode (): kotlin.Int declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun toString (): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN name:simple visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlin.String [suspend]
+      FUN name:simple visibility:public modality:OPEN returnType:kotlin.String [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
         overridden:
           public abstract fun simple (): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public open fun simple (): kotlin.String declared in <root>.BoxService.$rpcServiceStub'
             CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.String origin=null
-              <T>: kotlin.String
-              $this: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
-                $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
-              call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, parameters: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
-                descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
-                callableName: CONST String type=kotlin.String value="simple"
-                parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
-                  <T>: kotlin.Any?
-                serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
-    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+              TYPE_ARG T: kotlin.String
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="simple"
+                ARG arguments: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN name:simple visibility:public modality:ABSTRACT <> ($this:<root>.BoxService) returnType:kotlin.String [suspend]
-      $this: VALUE_PARAMETER name:<this> type:<root>.BoxService
+    FUN name:simple visibility:public modality:ABSTRACT returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
 Module: main
 FILE fqName:<root> fileName:/module_main_multiModule.kt
-  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
         CALL 'public final fun runBlocking <T> (context: kotlin.coroutines.CoroutineContext, block: @[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, T of kotlinx.coroutines.runBlocking>): T of kotlinx.coroutines.runBlocking declared in kotlinx.coroutines' type=kotlin.String origin=null
-          <T>: kotlin.String
-          block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
-            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:kotlinx.coroutines.CoroutineScope) returnType:kotlin.String [suspend]
-              $receiver: VALUE_PARAMETER name:$this$runBlocking type:kotlinx.coroutines.CoroutineScope
+          TYPE_ARG T: kotlin.String
+          ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String [suspend]
+              VALUE_PARAMETER kind:ExtensionReceiver name:$this$runBlocking index:0 type:kotlinx.coroutines.CoroutineScope
               BLOCK_BODY
                 VAR name:result type:kotlin.String [val]
                   CALL 'public abstract fun simple (): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                    $this: CALL 'public final fun withService <T> (): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
-                      <T>: <root>.BoxService
-                      $receiver: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.box'
+                    ARG <this>: CALL 'public final fun withService <T> (<this>: kotlinx.rpc.RpcClient): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
+                      TYPE_ARG T: <root>.BoxService
+                      ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
                   WHEN type=kotlin.String origin=IF
                     BRANCH
                       if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                        arg0: GET_VAR 'val result: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
-                        arg1: CONST String type=kotlin.String value="call_42"
+                        ARG arg0: GET_VAR 'val result: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+                        ARG arg1: CONST String type=kotlin.String value="call_42"
                       then: CONST String type=kotlin.String value="OK"
                     BRANCH
                       if: CONST Boolean type=kotlin.Boolean value=true

--- a/tests/compiler-plugin-tests/src/testData/box/simple.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/simple.fir.ir.txt
@@ -2,16 +2,16 @@ FILE fqName:<root> fileName:/simple.kt
   CLASS INTERFACE name:BoxService modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
     annotations:
       Rpc
-    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService
     CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]
-      $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub
       PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
         FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_stub_id: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlin.Long origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlin.Long
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL returnType:kotlin.Long
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]' type=kotlin.Long origin=null
@@ -20,190 +20,215 @@ FILE fqName:<root> fileName:/simple.kt
         FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]
           EXPRESSION_BODY
             GET_VAR '__rpc_client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlinx.rpc.RpcClient origin=INITIALIZE_PROPERTY_FROM_PARAMETER
-        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlinx.rpc.RpcClient
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL returnType:kotlinx.rpc.RpcClient
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
           correspondingProperty: PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub'
               GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]' type=kotlinx.rpc.RpcClient origin=null
                 receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_client>' type=<root>.BoxService.$rpcServiceStub origin=null
       CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]
-        $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        PROPERTY name:simpleName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract simpleName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:simpleName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-simpleName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-simpleName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:fqName visibility:public modality:FINAL [val]
           overridden:
             public abstract fqName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]
             EXPRESSION_BODY
               CONST String type=kotlin.String value="BoxService"
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.String
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:fqName visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-fqName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='public final fun <get-fqName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-fqName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:simpleInvokator visibility:private modality:FINAL [val]
-          FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]
+          FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
             EXPRESSION_BODY
-              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
-                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Any?, kotlin.Any?> origin=LAMBDA
-                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> (service:<root>.BoxService, parameters:kotlin.Array<out kotlin.Any?>) returnType:kotlin.Any? [suspend]
-                    VALUE_PARAMETER name:service index:0 type:<root>.BoxService
-                    VALUE_PARAMETER name:parameters index:1 type:kotlin.Array<out kotlin.Any?>
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
                     BLOCK_BODY
-                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, parameters: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator'
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator'
                         CALL 'public abstract fun simple (): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                          $this: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator.<anonymous>' type=<root>.BoxService origin=null
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleInvokator> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService>
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator.<anonymous>' type=<root>.BoxService origin=null
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:simpleInvokator visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
-              RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
-                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
+              RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
         PROPERTY name:callableMap visibility:private modality:FINAL [val]
           FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
             EXPRESSION_BODY
               CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                <K>: kotlin.String
-                <V>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
-                  CALL 'public final fun to <A, B> (that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
-                    <A>: kotlin.String
-                    <B>: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
-                    $receiver: CONST String type=kotlin.String value="simple"
-                    that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<T of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>, isNonSuspendFunction: kotlin.Boolean) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
-                      <T>: <root>.BoxService
-                      name: CONST String type=kotlin.String value="simple"
-                      returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
-                        kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
-                          <T>: kotlin.String
-                        annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
-                          <T>: <none>
-                      invokator: CALL 'private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=GET_PROPERTY
-                        $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                      parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
-                        <T>: kotlinx.rpc.descriptor.RpcParameter
-                      isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
-          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL <> ($this:<root>.BoxService.$rpcServiceStub.Companion) returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                TYPE_ARG K: kotlin.String
+                TYPE_ARG V: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="simple"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="simple"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
             correspondingProperty: PROPERTY name:callableMap visibility:private modality:FINAL [val]
-            $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
             BLOCK_BODY
               RETURN type=kotlin.Nothing from='private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callableMap>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        CONSTRUCTOR visibility:private <> () returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
+        CONSTRUCTOR visibility:private returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
           BLOCK_BODY
             DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
             INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=kotlin.Unit
-        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
           overridden:
             public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-          VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun hashCode (): kotlin.Int declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
           overridden:
             public open fun toString (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        FUN name:createInstance visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, serviceId:kotlin.Long, client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService
+        FUN name:createInstance visibility:public modality:OPEN returnType:<root>.BoxService
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:serviceId index:1 type:kotlin.Long
+          VALUE_PARAMETER kind:Regular name:client index:2 type:kotlinx.rpc.RpcClient
           overridden:
-            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): T of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:serviceId index:0 type:kotlin.Long
-          VALUE_PARAMETER name:client index:1 type:kotlinx.rpc.RpcClient
+            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): Service of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
             RETURN type=kotlin.Nothing from='public open fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion'
               CONSTRUCTOR_CALL 'public constructor <init> (__rpc_stub_id: kotlin.Long, __rpc_client: kotlinx.rpc.RpcClient) declared in <root>.BoxService.$rpcServiceStub' type=<root>.BoxService.$rpcServiceStub origin=null
-                __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
-                __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
-        FUN name:getCallable visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub.Companion, name:kotlin.String) returnType:kotlinx.rpc.descriptor.RpcCallable?
+                ARG __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
+                ARG __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
+        FUN name:getCallable visibility:public modality:FINAL returnType:kotlinx.rpc.descriptor.RpcCallable?
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
           overridden:
-            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
-          $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
-          VALUE_PARAMETER name:name index:0 type:kotlin.String
+            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           BLOCK_BODY
-            RETURN type=kotlin.Nothing from='public open fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
+            RETURN type=kotlin.Nothing from='public final fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
               CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlinx.rpc.descriptor.RpcCallable? origin=GET_ARRAY_ELEMENT
-                $this: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-                key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
-      CONSTRUCTOR visibility:public <> (__rpc_stub_id:kotlin.Long, __rpc_client:kotlinx.rpc.RpcClient) returnType:<root>.BoxService.$rpcServiceStub [primary]
-        VALUE_PARAMETER name:__rpc_stub_id index:0 type:kotlin.Long
-        VALUE_PARAMETER name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
+                ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                ARG key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
+        PROPERTY name:callables visibility:public modality:FINAL [val]
+          overridden:
+            public abstract callables: kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FUN name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-callables> (): kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                CALL 'public abstract fun <get-values> (): kotlin.collections.Collection<V of kotlin.collections.Map> declared in kotlin.collections.Map' type=kotlin.collections.Collection<V of kotlin.collections.Map> origin=GET_PROPERTY
+                  ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                    ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callables>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.BoxService.$rpcServiceStub [primary]
+        VALUE_PARAMETER kind:Regular name:__rpc_stub_id index:0 type:kotlin.Long
+        VALUE_PARAMETER kind:Regular name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
         BLOCK_BODY
           DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
           INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]' type=kotlin.Unit
-      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
         overridden:
           public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-        VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun hashCode (): kotlin.Int declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
         overridden:
           public open fun toString (): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      FUN name:simple visibility:public modality:OPEN <> ($this:<root>.BoxService.$rpcServiceStub) returnType:kotlin.String [suspend]
+      FUN name:simple visibility:public modality:OPEN returnType:kotlin.String [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
         overridden:
           public abstract fun simple (): kotlin.String declared in <root>.BoxService
-        $this: VALUE_PARAMETER name:<this> type:<root>.BoxService.$rpcServiceStub
         BLOCK_BODY
           RETURN type=kotlin.Nothing from='public open fun simple (): kotlin.String declared in <root>.BoxService.$rpcServiceStub'
             CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.String origin=null
-              <T>: kotlin.String
-              $this: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
-                $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
-              call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, parameters: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
-                descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
-                callableName: CONST String type=kotlin.String value="simple"
-                parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
-                  <T>: kotlin.Any?
-                serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
-                  $this: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
-    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+              TYPE_ARG T: kotlin.String
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="simple"
+                ARG arguments: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
       overridden:
         public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
-    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun hashCode (): kotlin.Int declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
       overridden:
         public open fun toString (): kotlin.String declared in kotlin.Any
-      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
-    FUN name:simple visibility:public modality:ABSTRACT <> ($this:<root>.BoxService) returnType:kotlin.String [suspend]
-      $this: VALUE_PARAMETER name:<this> type:<root>.BoxService
-  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    FUN name:simple visibility:public modality:ABSTRACT returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
     BLOCK_BODY
       RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
         CALL 'public final fun runBlocking <T> (context: kotlin.coroutines.CoroutineContext, block: @[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, T of kotlinx.coroutines.runBlocking>): T of kotlinx.coroutines.runBlocking declared in kotlinx.coroutines' type=kotlin.String origin=null
-          <T>: kotlin.String
-          block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
-            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:kotlinx.coroutines.CoroutineScope) returnType:kotlin.String [suspend]
-              $receiver: VALUE_PARAMETER name:$this$runBlocking type:kotlinx.coroutines.CoroutineScope
+          TYPE_ARG T: kotlin.String
+          ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String [suspend]
+              VALUE_PARAMETER kind:ExtensionReceiver name:$this$runBlocking index:0 type:kotlinx.coroutines.CoroutineScope
               BLOCK_BODY
                 VAR name:result type:kotlin.String [val]
                   CALL 'public abstract fun simple (): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
-                    $this: CALL 'public final fun withService <T> (): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
-                      <T>: <root>.BoxService
-                      $receiver: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
-                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.String declared in <root>.box'
+                    ARG <this>: CALL 'public final fun withService <T> (<this>: kotlinx.rpc.RpcClient): T of kotlinx.rpc.withService declared in kotlinx.rpc' type=<root>.BoxService origin=null
+                      TYPE_ARG T: <root>.BoxService
+                      ARG <this>: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:TestRpcClient modality:FINAL visibility:public superTypes:[kotlinx.rpc.RpcClient]' type=kotlinx.rpc.codegen.test.TestRpcClient
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
                   WHEN type=kotlin.String origin=IF
                     BRANCH
                       if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
-                        arg0: GET_VAR 'val result: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
-                        arg1: CONST String type=kotlin.String value="call_42"
+                        ARG arg0: GET_VAR 'val result: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+                        ARG arg1: CONST String type=kotlin.String value="call_42"
                       then: CONST String type=kotlin.String value="OK"
                     BRANCH
                       if: CONST Boolean type=kotlin.Boolean value=true


### PR DESCRIPTION
**Subsystem**
Compiler Plugin, gRPC

**Problem Description**
We have all platform bindings for the gRPC, but no service generation

**Solution**
Add service generations and a `MessageCodec` locator:
- Use `MessageCodecResolver` in `GrpcClient`/`GrpcServer`
- Or annotate your message with `WithCodec` annotation (default for protobuf messages)

And we now have **fully working gRPC** services with arbitrary serilization.

For next PRs:
- FIR checkers
- Method metadata
