### PR TITLE
Add collect once check for client streams

### DIFF
--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
@@ -63,6 +63,7 @@ interface KrpcTestService {
     suspend fun nullableParam(arg1: String?): String
     suspend fun nullableReturn(returnNull: Boolean): TestClass?
     suspend fun variance(arg2: TestList<in TestClass>, arg3: TestList2<TestClass>): TestList<out TestClass>?
+    suspend fun collectOnce(flow: Flow<String>)
 
     suspend fun nonSerializableClass(localDate: LocalDate): LocalDate
     suspend fun nonSerializableClassWithSerializer(

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
 import kotlin.coroutines.resumeWithException
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class KrpcTestServiceBackend : KrpcTestService {
@@ -112,6 +113,11 @@ class KrpcTestServiceBackend : KrpcTestService {
         assertEquals(arg2.value, 42)
         assertEquals(arg3.value, 42)
         return TestList(3)
+    }
+
+    override suspend fun collectOnce(flow: Flow<String>) {
+        flow.toList()
+        assertFailsWith<IllegalStateException> { flow.toList() }
     }
 
     override suspend fun nonSerializableClass(localDate: LocalDate): LocalDate {

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
@@ -260,6 +260,11 @@ abstract class KrpcTransportTestBase {
     }
 
     @Test
+    fun collectOnce() = runTest {
+        client.collectOnce(flowOf("test1", "test2", "test3"))
+    }
+
+    @Test
     fun incomingStreamSyncCollect() = runTest {
         val result = client.incomingStreamSyncCollect(flowOf("test1", "test2", "test3"))
 


### PR DESCRIPTION
**Subsystem**
kRPC

**Problem Description**
Client flows have side effects and thus can't be collected more than once
