### PR TITLE
Fix diagnostic rendering for compiler plugins checkers

### DIFF
--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirRpcExtensionRegistrar.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirRpcExtensionRegistrar.kt
@@ -5,6 +5,7 @@
 package kotlinx.rpc.codegen
 
 import kotlinx.rpc.codegen.checkers.FirSerializablePropertiesProvider
+import kotlinx.rpc.codegen.checkers.diagnostics.registerDiagnosticRendererFactories
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CompilerConfiguration
@@ -20,5 +21,7 @@ class FirRpcExtensionRegistrar(private val configuration: CompilerConfiguration)
         +GFactory { FirRpcServiceGenerator(it, logger) }
         +CFactory { FirRpcAdditionalCheckers(it, configuration) }
         +SCFactory { FirSerializablePropertiesProvider(it) }
+
+        registerDiagnosticRendererFactories()
     }
 }

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
@@ -15,9 +15,7 @@ import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 
 // ###########################################################################
 // ###                     BIG WARNING, LISTEN CLOSELY!                    ###

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
@@ -96,7 +96,6 @@ object RpcStrictModeDiagnosticRendererFactory : BaseDiagnosticRendererFactory() 
     }
 
     private fun message(entityName: String): String {
-        return "$entityName is prohibited in @Rpc services in strict mode. " +
-                "Support will be removed completely in the 0.8.0 release."
+        return "$entityName is prohibited in @Rpc services. "
     }
 }

--- a/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/diagnostics/RpcKtDiagnosticsContainer.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/diagnostics/RpcKtDiagnosticsContainer.kt
@@ -4,6 +4,12 @@
 
 package kotlinx.rpc.codegen.checkers.diagnostics
 
+//##csm RpcKtDiagnosticsContainer.kt-imports
+//##csm specific=[2.0.0...2.2.10]
+import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
+//##csm /specific
+//##csm /RpcKtDiagnosticsContainer.kt-imports
+
 //##csm RpcKtDiagnosticsContainer
 //##csm specific=[2.0.0...2.2.10]
 abstract class RpcKtDiagnosticsContainer : RpcKtDiagnosticsContainerCore
@@ -19,3 +25,13 @@ abstract class RpcKtDiagnosticsContainer : KtDiagnosticsContainer(), RpcKtDiagno
 }
 //##csm /default
 //##csm /RpcKtDiagnosticsContainer
+
+// Automatically done for later versions
+fun registerDiagnosticRendererFactories() {
+//##csm registerDiagnosticRendererFactories
+//##csm specific=[2.0.0...2.2.10]
+    RootDiagnosticRendererFactory.registerFactory(FirRpcDiagnostics.getRendererFactoryVs())
+    RootDiagnosticRendererFactory.registerFactory(FirRpcStrictModeDiagnostics.getRendererFactoryVs())
+//##csm /specific
+//##csm /registerDiagnosticRendererFactories
+}


### PR DESCRIPTION
**Subsystem**
Compiler Plugin

**Problem Description**
One of the previous refactoring broke rendering for diagnostics

