### PR TITLE
Grpc services followup

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcIrContext.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcIrContext.kt
@@ -255,8 +255,8 @@ internal class RpcIrContext(
             grpcServiceDescriptor.namedFunction("delegate")
         }
 
-        val grpcMessageCodecResolverResolve by lazy {
-            grpcMessageCodecResolver.namedFunction("resolve")
+        val grpcMessageCodecResolverResolveOrNull by lazy {
+            grpcMessageCodecResolver.namedFunction("resolveOrNull")
         }
 
         private fun IrClassSymbol.namedFunction(name: String): IrSimpleFunction {

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -1155,11 +1155,11 @@ internal class RpcStubGenerator(
             "Only methods are allowed here"
         }
 
-        check(callable.arguments.size == 1) {
-            "Only single argument methods are allowed here"
+        check(callable.arguments.size <= 1) {
+            "Only single or none argument methods are allowed here"
         }
 
-        val requestParameterType = callable.arguments[0].type
+        val requestParameterType = callable.arguments.getOrNull(0)?.type ?: ctx.irBuiltIns.unitType
         val responseParameterType = callable.function.returnType
 
         val requestType: IrType = requestParameterType.unwrapFlow()

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -1262,7 +1262,7 @@ internal class RpcStubGenerator(
                     startOffset = UNDEFINED_OFFSET,
                     endOffset = UNDEFINED_OFFSET,
                     type = ctx.grpcMessageCodec.typeWith(type),
-                    symbol = ctx.functions.grpcMessageCodecResolverResolve.symbol,
+                    symbol = ctx.functions.grpcMessageCodecResolverResolveOrNull.symbol,
                     typeArgumentsCount = 0,
                     valueArgumentsCount = 1,
                 )

--- a/compiler-plugin/compiler-plugin-common/src/main/kotlin/kotlinx/rpc/codegen/common/Names.kt
+++ b/compiler-plugin/compiler-plugin-common/src/main/kotlin/kotlinx/rpc/codegen/common/Names.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.name.Name
 object RpcClassId {
     val rpcAnnotation = ClassId(FqName("kotlinx.rpc.annotations"), Name.identifier("Rpc"))
     val grpcAnnotation = ClassId(FqName("kotlinx.rpc.grpc.annotations"), Name.identifier("Grpc"))
+    val withCodecAnnotation = ClassId(FqName("kotlinx.rpc.grpc.codec"), Name.identifier("WithCodec"))
     val checkedTypeAnnotation = ClassId(FqName("kotlinx.rpc.annotations"), Name.identifier("CheckedTypeAnnotation"))
 
     val serializableAnnotation = ClassId(FqName("kotlinx.serialization"), Name.identifier("Serializable"))
@@ -19,6 +20,8 @@ object RpcClassId {
     val flow = ClassId(FqName("kotlinx.coroutines.flow"), Name.identifier("Flow"))
     val sharedFlow = ClassId(FqName("kotlinx.coroutines.flow"), Name.identifier("SharedFlow"))
     val stateFlow = ClassId(FqName("kotlinx.coroutines.flow"), Name.identifier("StateFlow"))
+
+    val messageCodec = ClassId(FqName("kotlinx.rpc.grpc.codec"), Name.identifier("MessageCodec"))
 }
 
 object RpcNames {

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirRpcAdditionalCheckers.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirRpcAdditionalCheckers.kt
@@ -23,6 +23,8 @@ class FirRpcAdditionalCheckers(
 ) : FirAdditionalCheckersExtension(session) {
     override fun FirDeclarationPredicateRegistrar.registerPredicates() {
         register(FirRpcPredicates.rpc)
+        register(FirRpcPredicates.grpc)
+        register(FirRpcPredicates.withCodec)
         register(FirRpcPredicates.checkedAnnotationMeta)
     }
 

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirRpcPredicates.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirRpcPredicates.kt
@@ -12,6 +12,14 @@ object FirRpcPredicates {
         metaAnnotated(RpcClassId.rpcAnnotation.asSingleFqName(), includeItself = true) // @Rpc
     }
 
+    internal val grpc = DeclarationPredicate.create {
+        metaAnnotated(RpcClassId.grpcAnnotation.asSingleFqName(), includeItself = true)
+    }
+
+    internal val withCodec = DeclarationPredicate.create {
+        annotated(RpcClassId.withCodecAnnotation.asSingleFqName())
+    }
+
     internal val checkedAnnotationMeta = DeclarationPredicate.create {
         metaAnnotated(RpcClassId.checkedTypeAnnotation.asSingleFqName(), includeItself = false)
     }

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirGrpcServiceDeclarationChecker.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirGrpcServiceDeclarationChecker.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.codegen.checkers
+
+import kotlinx.rpc.codegen.FirRpcPredicates
+import kotlinx.rpc.codegen.checkers.diagnostics.FirGrpcDiagnostics
+import kotlinx.rpc.codegen.checkers.util.functionParametersRecursionCheck
+import kotlinx.rpc.codegen.common.RpcClassId
+import kotlinx.rpc.codegen.vsApi
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.types.isMarkedNullable
+
+object FirGrpcServiceDeclarationChecker {
+    fun check(
+        declaration: FirRegularClass,
+        context: CheckerContext,
+        reporter: DiagnosticReporter,
+    ) {
+        if (!context.session.predicateBasedProvider.matches(FirRpcPredicates.grpc, declaration)) {
+            return
+        }
+
+        vsApi {
+            declaration
+                .declarationsVS(context.session)
+                .filterIsInstance<FirNamedFunctionSymbol>()
+        }.onEach { function ->
+            if (function.valueParameterSymbols.size > 1) {
+                reporter.reportOn(
+                    source = function.source,
+                    factory = FirGrpcDiagnostics.MULTIPLE_PARAMETERS_IN_GRPC_SERVICE,
+                    context = context,
+                )
+            }
+
+            if (function.valueParameterSymbols.size == 1) {
+                val parameterSymbol = function.valueParameterSymbols[0]
+                if (parameterSymbol.resolvedReturnType.isMarkedNullable) {
+                    reporter.reportOn(
+                        source = parameterSymbol.source,
+                        factory = FirGrpcDiagnostics.NULLABLE_PARAMETER_IN_GRPC_SERVICE,
+                        context = context,
+                    )
+                }
+
+                functionParametersRecursionCheck(
+                    function = function,
+                    context = context,
+                ) { source, symbol, parents ->
+                    if (symbol.classId == RpcClassId.flow && parents.isNotEmpty()) {
+                        reporter.reportOn(
+                            source = source,
+                            factory = FirGrpcDiagnostics.NON_TOP_LEVEL_CLIENT_STREAMING_IN_RPC_SERVICE,
+                            context = context,
+                        )
+                    }
+                }
+            }
+
+            if (function.resolvedReturnType.isMarkedNullable) {
+                reporter.reportOn(
+                    source = function.resolvedReturnTypeRef.source,
+                    factory = FirGrpcDiagnostics.NULLABLE_RETURN_TYPE_IN_GRPC_SERVICE,
+                    context = context,
+                )
+            }
+        }
+    }
+}

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirRpcCheckers.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirRpcCheckers.kt
@@ -18,6 +18,8 @@ class FirRpcDeclarationCheckers(ctx: FirCheckersContext) : DeclarationCheckers()
         FirRpcAnnotationCheckerVS(),
         FirRpcStrictModeClassCheckerVS(),
         FirRpcServiceDeclarationCheckerVS(ctx),
+        FirGrpcServiceDeclarationCheckerVS(),
+        FirWithCodecDeclarationCheckerVS(),
     )
 
     override val classCheckers: Set<FirClassChecker> = setOf(

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirRpcStrictModeClassChecker.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirRpcStrictModeClassChecker.kt
@@ -6,6 +6,7 @@ package kotlinx.rpc.codegen.checkers
 
 import kotlinx.rpc.codegen.FirRpcPredicates
 import kotlinx.rpc.codegen.checkers.diagnostics.FirRpcStrictModeDiagnostics
+import kotlinx.rpc.codegen.checkers.util.functionParametersRecursionCheck
 import kotlinx.rpc.codegen.common.RpcClassId
 import kotlinx.rpc.codegen.vsApi
 import org.jetbrains.kotlin.KtSourceElement
@@ -13,19 +14,11 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactory0
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
-import org.jetbrains.kotlin.fir.analysis.checkers.extractArgumentsTypeRefAndSource
-import org.jetbrains.kotlin.fir.analysis.checkers.toClassLikeSymbol
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.utils.isSuspend
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
-import org.jetbrains.kotlin.fir.scopes.impl.toConeType
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
-import org.jetbrains.kotlin.fir.types.FirTypeRef
-import org.jetbrains.kotlin.utils.memoryOptimizedMap
-import org.jetbrains.kotlin.utils.memoryOptimizedPlus
 
 object FirRpcStrictModeClassChecker {
     fun check(
@@ -37,7 +30,6 @@ object FirRpcStrictModeClassChecker {
             return
         }
 
-        val serializablePropertiesProvider = context.session.serializablePropertiesProvider
         vsApi { declaration.declarationsVS(context.session) }.forEach { declaration ->
             when (declaration) {
                 is FirPropertySymbol -> {
@@ -45,116 +37,44 @@ object FirRpcStrictModeClassChecker {
                 }
 
                 is FirNamedFunctionSymbol -> {
-                    checkFunction(declaration, context, reporter, serializablePropertiesProvider)
+                    fun reportOn(element: KtSourceElement?, checker: FirRpcStrictModeDiagnostics.() -> KtDiagnosticFactory0) {
+                        reporter.reportOn(element, FirRpcStrictModeDiagnostics.checker(), context)
+                    }
+
+                    val returnClassSymbol = vsApi {
+                        declaration.resolvedReturnTypeRef.coneTypeVS.toClassSymbolVS(context.session)
+                    }
+
+                    if (returnClassSymbol?.classId == RpcClassId.flow && declaration.isSuspend) {
+                        reportOn(declaration.source) { SUSPENDING_SERVER_STREAMING_IN_RPC_SERVICE }
+                    }
+
+                    functionParametersRecursionCheck(
+                        function = declaration,
+                        context = context,
+                    ) { source, symbol, parents ->
+                        when (symbol.classId) {
+                            RpcClassId.stateFlow -> {
+                                reportOn(source) { STATE_FLOW_IN_RPC_SERVICE }
+                            }
+
+                            RpcClassId.sharedFlow -> {
+                                reportOn(source) { SHARED_FLOW_IN_RPC_SERVICE }
+                            }
+
+                            RpcClassId.flow -> {
+                                if (parents.any { it.classId == RpcClassId.flow }) {
+                                    reportOn(source) { NESTED_STREAMING_IN_RPC_SERVICE }
+                                } else if (parents.isNotEmpty() && parents[0] == returnClassSymbol) {
+                                    reportOn(source) { NON_TOP_LEVEL_SERVER_STREAMING_IN_RPC_SERVICE }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 else -> {}
             }
         }
-    }
-
-    private fun checkFunction(
-        function: FirNamedFunctionSymbol,
-        context: CheckerContext,
-        reporter: DiagnosticReporter,
-        serializablePropertiesProvider: FirSerializablePropertiesProvider,
-    ) {
-        fun reportOn(element: KtSourceElement?, checker: FirRpcStrictModeDiagnostics.() -> KtDiagnosticFactory0?) {
-            reporter.reportOn(element, FirRpcStrictModeDiagnostics.checker() ?: return, context)
-        }
-
-        val returnClassSymbol = vsApi {
-            function.resolvedReturnTypeRef.coneTypeVS.toClassSymbolVS(context.session)
-        }
-
-        val types = function.valueParameterSymbols.memoryOptimizedMap { parameter ->
-            parameter.source to vsApi {
-                parameter.resolvedReturnTypeRef
-            }
-        } memoryOptimizedPlus (function.resolvedReturnTypeRef.source to function.resolvedReturnTypeRef)
-
-        types.forEach { (source, symbol) ->
-            checkSerializableTypes(
-                context = context,
-                typeRef = symbol,
-                serializablePropertiesProvider = serializablePropertiesProvider,
-            ) { symbol, parents ->
-                when (symbol.classId) {
-                    RpcClassId.stateFlow -> {
-                        reportOn(source) { STATE_FLOW_IN_RPC_SERVICE }
-                    }
-
-                    RpcClassId.sharedFlow -> {
-                        reportOn(source) { SHARED_FLOW_IN_RPC_SERVICE }
-                    }
-
-                    RpcClassId.flow -> {
-                        if (parents.any { it.classId == RpcClassId.flow }) {
-                            reportOn(source) { NESTED_STREAMING_IN_RPC_SERVICE }
-                        } else if (parents.isNotEmpty() && parents[0] == returnClassSymbol) {
-                            reportOn(source) { NON_TOP_LEVEL_SERVER_STREAMING_IN_RPC_SERVICE }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (returnClassSymbol?.classId == RpcClassId.flow && function.isSuspend) {
-            reportOn(function.source) { SUSPENDING_SERVER_STREAMING_IN_RPC_SERVICE }
-        }
-    }
-
-    private fun checkSerializableTypes(
-        context: CheckerContext,
-        typeRef: FirTypeRef,
-        serializablePropertiesProvider: FirSerializablePropertiesProvider,
-        parentContext: List<FirClassLikeSymbol<*>> = emptyList(),
-        checker: (FirClassLikeSymbol<*>, List<FirClassLikeSymbol<*>>) -> Unit,
-    ) {
-        val symbol = typeRef.toClassLikeSymbol(context.session) ?: return
-
-        checker(symbol, parentContext)
-
-        if (symbol !is FirClassSymbol<*>) {
-            return
-        }
-
-        val nextContext = parentContext memoryOptimizedPlus symbol
-
-        if (symbol in parentContext && symbol.typeParameterSymbols.isEmpty()) {
-            return
-        }
-
-        val typeParameters = extractArgumentsTypeRefAndSource(typeRef)
-            .orEmpty()
-            .withIndex()
-            .associate { (i, refSource) ->
-                symbol.typeParameterSymbols[i].toConeType() to refSource.typeRef
-            }
-
-        val flowProps: List<FirTypeRef> = if (symbol.classId == RpcClassId.flow) {
-            listOf(typeParameters.values.toList()[0]!!)
-        } else {
-            emptyList()
-        }
-
-        serializablePropertiesProvider.getSerializablePropertiesForClass(symbol)
-            .mapNotNull { property ->
-                val resolvedTypeRef = property.resolvedReturnTypeRef
-                if (resolvedTypeRef.toClassLikeSymbol(context.session) != null) {
-                    resolvedTypeRef
-                } else {
-                    typeParameters[property.resolvedReturnType]
-                }
-            }.memoryOptimizedPlus(flowProps)
-            .forEach { symbol ->
-                checkSerializableTypes(
-                    context = context,
-                    typeRef = symbol,
-                    serializablePropertiesProvider = serializablePropertiesProvider,
-                    parentContext = nextContext,
-                    checker = checker,
-                )
-            }
     }
 }

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirWithCodecDeclarationChecker.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirWithCodecDeclarationChecker.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.codegen.checkers
+
+import kotlinx.rpc.codegen.FirRpcPredicates
+import kotlinx.rpc.codegen.FirVersionSpecificApiImpl.toClassSymbolVS
+import kotlinx.rpc.codegen.checkers.diagnostics.FirGrpcDiagnostics
+import kotlinx.rpc.codegen.common.RpcClassId
+import kotlinx.rpc.codegen.vsApi
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.diagnostics.reportOn
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.findArgumentByName
+import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
+import org.jetbrains.kotlin.fir.declarations.getKClassArgument
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.resolve.defaultType
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.classId
+import org.jetbrains.kotlin.fir.types.type
+import org.jetbrains.kotlin.name.Name
+
+object FirWithCodecDeclarationChecker {
+    fun check(
+        declaration: FirRegularClass,
+        context: CheckerContext,
+        reporter: DiagnosticReporter,
+    ) {
+        if (!context.session.predicateBasedProvider.matches(FirRpcPredicates.withCodec, declaration)) {
+            return
+        }
+
+        val withCodec = declaration.getAnnotationByClassId(RpcClassId.withCodecAnnotation, context.session)
+            ?: error(
+                "Unexpected unresolved @WithCodec annotation type " +
+                        "for declaration: ${declaration.symbol.classId.asSingleFqName()}"
+            )
+
+        val kClassValue = withCodec.getKClassArgument(CODEC_ARGUMENT_NAME, context.session)
+            ?: error(
+                "Unexpected unresolved 'codec' argument for @WithCodec annotation " +
+                        "for declaration: ${declaration.symbol.classId.asSingleFqName()}"
+            )
+
+        val codecClassSymbol = vsApi { kClassValue.toClassSymbolVS(context.session) }
+            ?: error(
+                "'codec' argument type for @WithCodec annotation is not a class " +
+                        "for declaration: ${declaration.symbol.classId.asSingleFqName()}"
+            )
+
+        val codecTargetClass = codecClassSymbol.findMessageCodecSuperType(context.session)
+            .typeArguments.first().type
+
+        if (codecTargetClass?.classId != declaration.symbol.classId) {
+            reporter.reportOn(
+                source = withCodec.findArgumentByName(CODEC_ARGUMENT_NAME)?.source,
+                factory = FirGrpcDiagnostics.CODEC_TYPE_MISMATCH,
+                a = declaration.symbol.defaultType(),
+                b = kClassValue,
+                context = context,
+            )
+        }
+
+        if (codecClassSymbol.classKind != ClassKind.OBJECT) {
+            reporter.reportOn(
+                source = withCodec.findArgumentByName(CODEC_ARGUMENT_NAME)?.source,
+                factory = FirGrpcDiagnostics.NOT_AN_OBJECT_REFERENCE_IN_WITH_CODEC_ANNOTATION,
+                context = context,
+            )
+        }
+    }
+
+    private fun FirClassSymbol<*>.findMessageCodecSuperType(session: FirSession): ConeKotlinType = vsApi {
+        return resolvedSuperTypes.find {
+            it.classId == RpcClassId.messageCodec
+        } ?: resolvedSuperTypes.firstNotNullOf {
+            it.toClassSymbolVS(session)?.findMessageCodecSuperType(session)
+        }
+    }
+
+    private val CODEC_ARGUMENT_NAME = Name.identifier("codec")
+}

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.diagnostics.error2
 import org.jetbrains.kotlin.diagnostics.error3
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
 import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
+import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtAnnotated
@@ -48,5 +49,18 @@ object FirRpcStrictModeDiagnostics : RpcKtDiagnosticsContainer() {
 
     override fun getRendererFactoryVs(): BaseDiagnosticRendererFactory {
         return RpcStrictModeDiagnosticRendererFactory
+    }
+}
+
+object FirGrpcDiagnostics : RpcKtDiagnosticsContainer() {
+    val NULLABLE_PARAMETER_IN_GRPC_SERVICE by error0<KtElement>()
+    val NULLABLE_RETURN_TYPE_IN_GRPC_SERVICE by error0<KtElement>()
+    val NON_TOP_LEVEL_CLIENT_STREAMING_IN_RPC_SERVICE by error0<KtElement>()
+    val MULTIPLE_PARAMETERS_IN_GRPC_SERVICE by error0<KtElement>()
+    val NOT_AN_OBJECT_REFERENCE_IN_WITH_CODEC_ANNOTATION by error0<KtElement>()
+    val CODEC_TYPE_MISMATCH by error2<KtElement, ConeClassLikeType, ConeKotlinType>()
+
+    override fun getRendererFactoryVs(): BaseDiagnosticRendererFactory {
+        return GrpcDiagnosticRendererFactory
     }
 }

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
@@ -100,3 +100,39 @@ object RpcStrictModeDiagnosticRendererFactory : BaseDiagnosticRendererFactory() 
                 "Support will be removed completely in the 0.8.0 release."
     }
 }
+
+object GrpcDiagnosticRendererFactory : BaseDiagnosticRendererFactory() {
+    override val MAP by RpcKtDiagnosticFactoryToRendererMap("Grpc") { map ->
+        map.put(
+            factory = FirGrpcDiagnostics.NULLABLE_PARAMETER_IN_GRPC_SERVICE,
+            message = "Nullable type is not allowed in @Grpc service function parameters.",
+        )
+
+        map.put(
+            factory = FirGrpcDiagnostics.NULLABLE_RETURN_TYPE_IN_GRPC_SERVICE,
+            message = "Nullable type is not allowed in @Grpc service function return types.",
+        )
+
+        map.put(
+            factory = FirGrpcDiagnostics.NON_TOP_LEVEL_CLIENT_STREAMING_IN_RPC_SERVICE,
+            message = "Non top-level client-side streaming is not allowed in @Grpc services.",
+        )
+
+        map.put(
+            factory = FirGrpcDiagnostics.MULTIPLE_PARAMETERS_IN_GRPC_SERVICE,
+            message = "Multiple parameters are not allowed in @Grpc service functions.",
+        )
+
+        map.put(
+            factory = FirGrpcDiagnostics.NOT_AN_OBJECT_REFERENCE_IN_WITH_CODEC_ANNOTATION,
+            message = "'codec' parameter must reference an object, not a class or an interface.",
+        )
+
+        map.put(
+            factory = FirGrpcDiagnostics.CODEC_TYPE_MISMATCH,
+            message = "Codec type mismatch. Expected {0}, got {1}.",
+            rendererA = FirDiagnosticRenderers.RENDER_TYPE,
+            rendererB = FirDiagnosticRenderers.RENDER_TYPE,
+        )
+    }
+}

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/util/functionParametersRecursionCheck.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/util/functionParametersRecursionCheck.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.codegen.checkers.util
+
+import kotlinx.rpc.codegen.checkers.FirSerializablePropertiesProvider
+import kotlinx.rpc.codegen.checkers.serializablePropertiesProvider
+import kotlinx.rpc.codegen.common.RpcClassId
+import kotlinx.rpc.codegen.vsApi
+import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.extractArgumentsTypeRefAndSource
+import org.jetbrains.kotlin.fir.analysis.checkers.toClassLikeSymbol
+import org.jetbrains.kotlin.fir.scopes.impl.toConeType
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.types.FirTypeRef
+import org.jetbrains.kotlin.utils.memoryOptimizedMap
+import org.jetbrains.kotlin.utils.memoryOptimizedPlus
+import kotlin.collections.get
+import kotlin.collections.orEmpty
+import kotlin.collections.withIndex
+
+internal fun functionParametersRecursionCheck(
+    function: FirNamedFunctionSymbol,
+    context: CheckerContext,
+    checker: (KtSourceElement?, FirClassLikeSymbol<*>, List<FirClassLikeSymbol<*>>) -> Unit,
+) {
+    val types = function.valueParameterSymbols.memoryOptimizedMap { parameter ->
+        parameter.source to vsApi {
+            parameter.resolvedReturnTypeRef
+        }
+    } memoryOptimizedPlus (function.resolvedReturnTypeRef.source to function.resolvedReturnTypeRef)
+
+    types.forEach { (source, symbol) ->
+        checkSerializableTypes(
+            context = context,
+            typeRef = symbol,
+            serializablePropertiesProvider = context.session.serializablePropertiesProvider,
+            checker = { classSymbol, parentContext -> checker(source, classSymbol, parentContext) },
+        )
+    }
+}
+
+private fun checkSerializableTypes(
+    context: CheckerContext,
+    typeRef: FirTypeRef,
+    serializablePropertiesProvider: FirSerializablePropertiesProvider,
+    parentContext: List<FirClassLikeSymbol<*>> = emptyList(),
+    checker: (FirClassLikeSymbol<*>, List<FirClassLikeSymbol<*>>) -> Unit,
+) {
+    val symbol = typeRef.toClassLikeSymbol(context.session) ?: return
+
+    checker(symbol, parentContext)
+
+    if (symbol !is FirClassSymbol<*>) {
+        return
+    }
+
+    val nextContext = parentContext memoryOptimizedPlus symbol
+
+    if (symbol in parentContext && symbol.typeParameterSymbols.isEmpty()) {
+        return
+    }
+
+    val typeParameters = extractArgumentsTypeRefAndSource(typeRef)
+        .orEmpty()
+        .withIndex()
+        .associate { (i, refSource) ->
+            symbol.typeParameterSymbols[i].toConeType() to refSource.typeRef
+        }
+
+    val flowProps: List<FirTypeRef> = if (symbol.classId == RpcClassId.flow) {
+        listOf(typeParameters.values.toList()[0]!!)
+    } else {
+        emptyList()
+    }
+
+    serializablePropertiesProvider.getSerializablePropertiesForClass(symbol)
+        .mapNotNull { property ->
+            val resolvedTypeRef = property.resolvedReturnTypeRef
+            if (resolvedTypeRef.toClassLikeSymbol(context.session) != null) {
+                resolvedTypeRef
+            } else {
+                typeParameters[property.resolvedReturnType]
+            }
+        }.memoryOptimizedPlus(flowProps)
+        .forEach { symbol ->
+            checkSerializableTypes(
+                context = context,
+                typeRef = symbol,
+                serializablePropertiesProvider = serializablePropertiesProvider,
+                parentContext = nextContext,
+                checker = checker,
+            )
+        }
+}

--- a/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/FirRpcCheckersVS.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/FirRpcCheckersVS.kt
@@ -140,3 +140,35 @@ class FirRpcStrictModeClassCheckerVS : FirRegularClassChecker(MppCheckerKind.Com
     //##csm /default
     //##csm /FirRpcStrictModeClassCheckerVS_context
 }
+
+class FirGrpcServiceDeclarationCheckerVS : FirRegularClassChecker(MppCheckerKind.Common) {
+    //##csm FirGrpcServiceDeclarationCheckerVS_context
+    //##csm specific=[2.0.0...2.1.21, 2.2.0-ij251-*]
+    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
+        FirGrpcServiceDeclarationChecker.check(declaration, context, reporter)
+    }
+    //##csm /specific
+    //##csm default
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirRegularClass) {
+        FirGrpcServiceDeclarationChecker.check(declaration, context, reporter)
+    }
+    //##csm /default
+    //##csm /FirGrpcServiceDeclarationCheckerVS_context
+}
+
+class FirWithCodecDeclarationCheckerVS : FirRegularClassChecker(MppCheckerKind.Common) {
+    //##csm FirWithCodecDeclarationChecker_context
+    //##csm specific=[2.0.0...2.1.21, 2.2.0-ij251-*]
+    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
+        FirWithCodecDeclarationChecker.check(declaration, context, reporter)
+    }
+    //##csm /specific
+    //##csm default
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirRegularClass) {
+        FirWithCodecDeclarationChecker.check(declaration, context, reporter)
+    }
+    //##csm /default
+    //##csm /FirWithCodecDeclarationChecker_context
+}

--- a/grpc/grpc-codec-kotlinx-serialization/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/kotlinx/serialization/KotlinxSerializationCodecResolver.kt
+++ b/grpc/grpc-codec-kotlinx-serialization/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/kotlinx/serialization/KotlinxSerializationCodecResolver.kt
@@ -17,12 +17,13 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialFormat
 import kotlinx.serialization.StringFormat
 import kotlinx.serialization.serializer
+import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KType
 
 @ExperimentalRpcApi
 public class KotlinxSerializationCodecResolver(private val serialFormat: SerialFormat) : MessageCodecResolver {
-    override fun resolve(kType: KType): MessageCodec<*> {
-        val serializer = serialFormat.serializersModule.serializer(kType)
+    override fun resolveOrNull(kType: KType): MessageCodec<*>? {
+        val serializer = serialFormat.serializersModule.serializerOrNull(kType) ?: return null
 
         return KotlinxSerializationCodec(serializer, serialFormat)
     }

--- a/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/WithCodec.kt
+++ b/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/WithCodec.kt
@@ -8,4 +8,5 @@ import kotlinx.rpc.internal.utils.ExperimentalRpcApi
 import kotlin.reflect.KClass
 
 @ExperimentalRpcApi
+@Target(AnnotationTarget.CLASS)
 public annotation class WithCodec(val codec: KClass<out MessageCodec<*>>)

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcClient.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcClient.kt
@@ -9,6 +9,8 @@ import kotlinx.rpc.RpcCall
 import kotlinx.rpc.RpcClient
 import kotlinx.rpc.grpc.codec.EmptyMessageCodecResolver
 import kotlinx.rpc.grpc.codec.MessageCodecResolver
+import kotlinx.rpc.grpc.codec.ThrowingMessageCodecResolver
+import kotlinx.rpc.grpc.codec.plus
 import kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate
 import kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor
 import kotlinx.rpc.grpc.internal.*
@@ -24,9 +26,10 @@ private typealias RequestClient = Any
  */
 public class GrpcClient internal constructor(
     private val channel: ManagedChannel,
-    private val messageCodecResolver: MessageCodecResolver = EmptyMessageCodecResolver,
+    messageCodecResolver: MessageCodecResolver = EmptyMessageCodecResolver,
 ) : RpcClient {
     private val delegates = RpcInternalConcurrentHashMap<String, GrpcServiceDelegate>()
+    private val messageCodecResolver = messageCodecResolver + ThrowingMessageCodecResolver
 
     public fun shutdown() {
         delegates.clear()

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcClient.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcClient.kt
@@ -93,7 +93,9 @@ public class GrpcClient internal constructor(
     }
 
     private inline fun <T, R> withGrpcCall(call: RpcCall, body: (MethodDescriptor<RequestClient, T>, Any) -> R): R {
-        require(call.arguments.size == 1) { "Call parameter size should be 1, but ${call.arguments.size}" }
+        require(call.arguments.size <= 1) {
+            "Call parameter size must be 0 or 1, but ${call.arguments.size}"
+        }
 
         val delegate = delegates.computeIfAbsent(call.descriptor.fqName) {
             val grpc = call.descriptor as? GrpcServiceDescriptor<*>
@@ -107,8 +109,7 @@ public class GrpcClient internal constructor(
                 as? MethodDescriptor<RequestClient, T>
             ?: error("Expected a gRPC method descriptor")
 
-        val request = call.arguments[0]
-            ?: error("Expected a single argument for a gRPC call")
+        val request = call.arguments.getOrNull(0) ?: Unit
 
         return body(methodDescriptor, request)
     }

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcServer.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcServer.kt
@@ -112,26 +112,26 @@ public class GrpcServer internal constructor(
     ): ServerMethodDefinition<RequestServer, ResponseServer> {
         return when (descriptor.type) {
             MethodType.UNARY -> {
-                internalScope.unaryServerMethodDefinition(descriptor) { request ->
+                internalScope.unaryServerMethodDefinition(descriptor, returnType.kType) { request ->
                     unaryInvokator.call(service, arrayOf(request)) as ResponseServer
                 }
             }
 
             MethodType.CLIENT_STREAMING -> {
-                internalScope.clientStreamingServerMethodDefinition(descriptor) { requests ->
+                internalScope.clientStreamingServerMethodDefinition(descriptor, returnType.kType) { requests ->
                     unaryInvokator.call(service, arrayOf(requests)) as ResponseServer
                 }
             }
 
             MethodType.SERVER_STREAMING -> {
-                internalScope.serverStreamingServerMethodDefinition(descriptor) { request ->
+                internalScope.serverStreamingServerMethodDefinition(descriptor, returnType.kType) { request ->
                     @Suppress("UNCHECKED_CAST")
                     flowInvokator.call(service, arrayOf(request)) as Flow<ResponseServer>
                 }
             }
 
             MethodType.BIDI_STREAMING -> {
-                internalScope.bidiStreamingServerMethodDefinition(descriptor) { requests ->
+                internalScope.bidiStreamingServerMethodDefinition(descriptor, returnType.kType) { requests ->
                     @Suppress("UNCHECKED_CAST")
                     flowInvokator.call(service, arrayOf(requests)) as Flow<ResponseServer>
                 }

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcServer.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/GrpcServer.kt
@@ -18,6 +18,8 @@ import kotlinx.rpc.descriptor.unaryInvokator
 import kotlinx.rpc.grpc.annotations.Grpc
 import kotlinx.rpc.grpc.codec.EmptyMessageCodecResolver
 import kotlinx.rpc.grpc.codec.MessageCodecResolver
+import kotlinx.rpc.grpc.codec.ThrowingMessageCodecResolver
+import kotlinx.rpc.grpc.codec.plus
 import kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor
 import kotlinx.rpc.grpc.internal.MethodDescriptor
 import kotlinx.rpc.grpc.internal.MethodType
@@ -46,12 +48,14 @@ private typealias ResponseServer = Any
  */
 public class GrpcServer internal constructor(
     override val port: Int = 8080,
-    private val messageCodecResolver: MessageCodecResolver = EmptyMessageCodecResolver,
+    messageCodecResolver: MessageCodecResolver = EmptyMessageCodecResolver,
     parentContext: CoroutineContext = EmptyCoroutineContext,
     configure: ServerBuilder<*>.() -> Unit,
 ) : RpcServer, Server {
     private val internalContext = SupervisorJob(parentContext.job)
     private val internalScope = CoroutineScope(parentContext + internalContext)
+
+    private val messageCodecResolver = messageCodecResolver + ThrowingMessageCodecResolver
 
     private var isBuilt = false
     private lateinit var internalServer: Server

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/RawClientServerTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/RawClientServerTest.kt
@@ -29,6 +29,7 @@ import kotlinx.rpc.grpc.internal.serverStreamingServerMethodDefinition
 import kotlinx.rpc.grpc.internal.serviceDescriptor
 import kotlinx.rpc.grpc.internal.unaryRpc
 import kotlinx.rpc.grpc.internal.unaryServerMethodDefinition
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -40,7 +41,7 @@ class RawClientServerTest {
         methodName = "unary",
         type = MethodType.UNARY,
         methodDefinition = { descriptor ->
-            unaryServerMethodDefinition(descriptor) { it + it }
+            unaryServerMethodDefinition(descriptor, typeOf<String>()) { it + it }
         },
     ) { channel, descriptor ->
         val response = unaryRpc(channel, descriptor, "Hello")
@@ -53,7 +54,7 @@ class RawClientServerTest {
         methodName = "serverStreaming",
         type = MethodType.SERVER_STREAMING,
         methodDefinition = { descriptor ->
-            serverStreamingServerMethodDefinition(descriptor) {
+            serverStreamingServerMethodDefinition(descriptor, typeOf<String>()) {
                 flowOf(it, it)
             }
         }
@@ -68,7 +69,7 @@ class RawClientServerTest {
         methodName = "clientStreaming",
         type = MethodType.CLIENT_STREAMING,
         methodDefinition = { descriptor ->
-            clientStreamingServerMethodDefinition(descriptor) {
+            clientStreamingServerMethodDefinition(descriptor, typeOf<String>()) {
                 it.toList().joinToString(separator = "")
             }
         }
@@ -83,7 +84,7 @@ class RawClientServerTest {
         methodName = "bidirectionalStreaming",
         type = MethodType.BIDI_STREAMING,
         methodDefinition = { descriptor ->
-            bidiStreamingServerMethodDefinition(descriptor) {
+            bidiStreamingServerMethodDefinition(descriptor, typeOf<String>()) {
                 it.map { str -> str + str }
             }
         }

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/BaseGrpcServiceTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/BaseGrpcServiceTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.service
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.rpc.grpc.GrpcClient
+import kotlinx.rpc.grpc.GrpcServer
+import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.rpc.grpc.codec.MessageCodecResolver
+import kotlinx.rpc.withService
+import kotlin.reflect.KClass
+
+abstract class BaseGrpcServiceTest {
+    protected inline fun <@Grpc reified Service : Any> runServiceTest(
+        resolver: MessageCodecResolver,
+        impl: Service,
+        noinline block: suspend (Service) -> Unit,
+    ) {
+        runServiceTest(Service::class, resolver, impl, block)
+    }
+
+    protected fun <@Grpc Service : Any> runServiceTest(
+        kClass: KClass<Service>,
+        resolver: MessageCodecResolver,
+        impl: Service,
+        block: suspend (Service) -> Unit,
+    ) = runTest {
+        val server = GrpcServer(
+            port = PORT,
+            messageCodecResolver = resolver,
+            parentContext = coroutineContext,
+            builder = {
+                registerService(kClass) { impl }
+            }
+        )
+
+        server.start()
+
+        val client = GrpcClient("localhost", PORT, messageCodecResolver = resolver) {
+            usePlaintext()
+        }
+
+        val service = client.withService(kClass)
+
+        block(service)
+
+        client.shutdown()
+        client.awaitTermination()
+        server.shutdown()
+        server.awaitTermination()
+    }
+
+    companion object {
+        const val PORT = 8082
+    }
+}
+
+suspend fun doWork(): String {
+    delay(1)
+    return "qwerty"
+}

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/CustomResolverGrpcServiceTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/CustomResolverGrpcServiceTest.kt
@@ -131,7 +131,7 @@ class CustomResolverGrpcServiceTest : BaseGrpcServiceTest() {
             when (kType.classifier) {
                 Unit::class -> unitCodec
                 String::class -> stringCodec
-                else -> error("Unsupported type: $kType")
+                else -> null
             }
         }
 

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/CustomResolverGrpcServiceTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/CustomResolverGrpcServiceTest.kt
@@ -6,7 +6,6 @@ package kotlinx.rpc.grpc.service
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.io.Buffer
@@ -40,7 +39,7 @@ interface GrpcService {
 
     suspend fun message(value: Message): Message
 
-    suspend fun krpc173(unit: Unit)
+    suspend fun krpc173()
 
     suspend fun clientStreaming(flow: Flow<String>): String
 
@@ -58,7 +57,7 @@ class GrpcServiceImpl : GrpcService {
         return Message("${value.value} ${value.value}")
     }
 
-    override suspend fun krpc173(unit: Unit) {
+    override suspend fun krpc173() {
         doWork()
     }
 
@@ -97,7 +96,7 @@ class CustomResolverGrpcServiceTest : BaseGrpcServiceTest() {
         resolver = simpleResolver,
         impl = GrpcServiceImpl(),
     ) { service ->
-        assertEquals(Unit, service.krpc173(Unit))
+        assertEquals(Unit, service.krpc173())
     }
 
     @Test
@@ -148,11 +147,11 @@ class CustomResolverGrpcServiceTest : BaseGrpcServiceTest() {
 
         val unitCodec = object : MessageCodec<Unit> {
             override fun encode(value: Unit): Source {
-                return Buffer().apply { writeString("Unit") }
+                return Buffer()
             }
 
             override fun decode(stream: Source) {
-                assertEquals("Unit", stream.readString())
+                check(stream.exhausted())
             }
         }
     }

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/SerializationGrpcServiceTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/SerializationGrpcServiceTest.kt
@@ -25,7 +25,7 @@ interface GrpcServiceSerializable {
 
     suspend fun serialization(value: SerializableMessage): SerializableMessage
 
-    suspend fun krpc173(unit: Unit)
+    suspend fun krpc173()
 
     suspend fun clientStreaming(flow: Flow<String>): String
 
@@ -43,7 +43,7 @@ class GrpcServiceSerializableImpl : GrpcServiceSerializable {
         return SerializableMessage("${value.value} ${value.value}")
     }
 
-    override suspend fun krpc173(unit: Unit) {
+    override suspend fun krpc173() {
         doWork()
     }
 
@@ -76,7 +76,7 @@ class SerializationGrpcServiceTest : BaseGrpcServiceTest() {
         resolver = Json.asCodecResolver(),
         impl = GrpcServiceSerializableImpl(),
     ) { service ->
-        assertEquals(Unit, service.krpc173(Unit))
+        assertEquals(Unit, service.krpc173())
     }
 
     @Test

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/SerializationGrpcServiceTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/service/SerializationGrpcServiceTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.service
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.rpc.grpc.codec.kotlinx.serialization.asCodecResolver
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+@Serializable
+class SerializableMessage(val value: String)
+
+@Grpc
+interface GrpcServiceSerializable {
+    suspend fun plainString(value: String): String
+
+    suspend fun serialization(value: SerializableMessage): SerializableMessage
+
+    suspend fun krpc173(unit: Unit)
+
+    suspend fun clientStreaming(flow: Flow<String>): String
+
+    fun serverStreaming(value: String): Flow<String>
+
+    fun bidiStreaming(flow: Flow<String>): Flow<String>
+}
+
+class GrpcServiceSerializableImpl : GrpcServiceSerializable {
+    override suspend fun plainString(value: String): String {
+        return "$value $value"
+    }
+
+    override suspend fun serialization(value: SerializableMessage): SerializableMessage {
+        return SerializableMessage("${value.value} ${value.value}")
+    }
+
+    override suspend fun krpc173(unit: Unit) {
+        doWork()
+    }
+
+    override suspend fun clientStreaming(flow: Flow<String>): String {
+        return flow.toList().joinToString(" ")
+    }
+
+    override fun serverStreaming(value: String): Flow<String> {
+        return flowOf(value, value)
+    }
+
+    override fun bidiStreaming(flow: Flow<String>): Flow<String> {
+        return flow.map { "$it $it" }
+    }
+}
+
+class SerializationGrpcServiceTest : BaseGrpcServiceTest() {
+    @Test
+    fun testSerializationCodec() = runServiceTest<GrpcServiceSerializable>(
+        resolver = Json.asCodecResolver(),
+        impl = GrpcServiceSerializableImpl(),
+    ) { service ->
+        assertEquals("test test", service.plainString("test"))
+
+        assertEquals("test test", service.serialization(SerializableMessage("test")).value)
+    }
+
+    @Test
+    fun krpc173() = runServiceTest<GrpcServiceSerializable>(
+        resolver = Json.asCodecResolver(),
+        impl = GrpcServiceSerializableImpl(),
+    ) { service ->
+        assertEquals(Unit, service.krpc173(Unit))
+    }
+
+    @Test
+    fun clientStreaming() = runServiceTest<GrpcService>(
+        resolver = Json.asCodecResolver(),
+        impl = GrpcServiceImpl(),
+    ) { service ->
+        assertEquals("test test", service.clientStreaming(flowOf("test", "test")))
+    }
+
+    @Test
+    fun serverStreaming() = runServiceTest<GrpcService>(
+        resolver = Json.asCodecResolver(),
+        impl = GrpcServiceImpl(),
+    ) { service ->
+        assertEquals(listOf("test", "test"), service.serverStreaming("test").toList())
+    }
+
+    @Test
+    fun bidiStreaming() = runServiceTest<GrpcService>(
+        resolver = Json.asCodecResolver(),
+        impl = GrpcServiceImpl(),
+    ) { service ->
+        assertContentEquals(
+            expected = listOf("test test", "test test"),
+            actual = service.bidiStreaming(flowOf("test", "test")).toList(),
+        )
+    }
+}

--- a/krpc/krpc-server/src/commonMain/kotlin/kotlinx/rpc/krpc/server/internal/KrpcServerService.kt
+++ b/krpc/krpc-server/src/commonMain/kotlin/kotlinx/rpc/krpc/server/internal/KrpcServerService.kt
@@ -155,7 +155,7 @@ internal class KrpcServerService<@Rpc T : Any>(
                     is RpcInvokator.UnaryResponse -> {
                         val value = invokator.call(service, data).let { interceptedValue ->
                             // KRPC-173
-                            if (callable.returnType.kType == typeOf<Unit>()) {
+                            if (callable.returnType.kType == unitKType) {
                                 Unit
                             } else {
                                 interceptedValue
@@ -378,3 +378,5 @@ internal class RpcRequest(val handlerJob: Job, val streamContext: ServerStreamCo
         streamContext.removeCall(callId, cause)
     }
 }
+
+private  val unitKType = typeOf<Unit>()

--- a/tests/compiler-plugin-tests/build.gradle.kts
+++ b/tests/compiler-plugin-tests/build.gradle.kts
@@ -100,6 +100,9 @@ dependencies {
     testImplementation(libs.junit5.platform.suite.api)
 
     testDataClasspath(projects.utils)
+    testDataClasspath(projects.grpc.grpcCodec)
+    testDataClasspath(projects.grpc.grpcCore)
+    testDataClasspath(libs.kotlinx.io.core)
     testDataClasspath(libs.coroutines.core)
 }
 

--- a/tests/compiler-plugin-tests/build.gradle.kts
+++ b/tests/compiler-plugin-tests/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     testPriorityRuntimeClasspath(libs.intellij.util) { isTransitive = false }
 
     implementation(projects.core)
+    implementation(projects.grpc.grpcCore)
 
     testRuntimeOnly(libs.kotlin.test)
     testRuntimeOnly(libs.kotlin.script.runtime)

--- a/tests/compiler-plugin-tests/src/main/kotlin/kotlinx/rpc/codegen/test/Grpc.kt
+++ b/tests/compiler-plugin-tests/src/main/kotlin/kotlinx/rpc/codegen/test/Grpc.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.codegen.test
+
+import io.grpc.MethodDescriptor
+import kotlinx.io.Source
+import kotlinx.rpc.descriptor.serviceDescriptorOf
+import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.rpc.grpc.codec.MessageCodec
+import kotlinx.rpc.grpc.codec.MessageCodecResolver
+import kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate
+import kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor
+import kotlin.reflect.KType
+
+/**
+ * To check in methods:
+ * ```
+ * bareMethodName
+ * type
+ * serviceName
+ * isSafe
+ * isIdempotent
+ * isSampledToLocalTracing
+ * ```
+ *
+ * Types:
+ * ```
+ * MethodDescriptor.MethodType.UNARY
+ * MethodDescriptor.MethodType.SERVER_STREAMING
+ * MethodDescriptor.MethodType.CLIENT_STREAMING
+ * MethodDescriptor.MethodType.BIDI_STREAMING
+ * ```
+ */
+@Suppress("unused")
+inline fun <@Grpc reified T : Any> grpcDelegate(): GrpcServiceDelegate {
+    val descriptor = serviceDescriptorOf<T>() as GrpcServiceDescriptor
+    val delegate = descriptor.delegate(SimpleResolver)
+
+    return delegate
+}
+
+fun MethodDescriptor<*, *>.checkMethod(
+    expectedMethodName: String,
+    expectedMethodType: MethodDescriptor.MethodType,
+    expectedServiceName: String,
+    expectedIsSafe: Boolean = true,
+    expectedIsIdempotent: Boolean = true,
+    expectedIsSampledToLocalTracing: Boolean = true,
+): String? {
+    return when {
+        bareMethodName != expectedMethodName -> "wrong bareMethodName: $bareMethodName"
+        type != expectedMethodType -> "wrong type: $type"
+        serviceName != expectedServiceName -> "wrong service name: $fullMethodName"
+        isSafe != expectedIsSafe -> "wrong isSafe: $isSafe"
+        isIdempotent != expectedIsIdempotent -> "wrong isIdempotent: $isIdempotent"
+        isSampledToLocalTracing != expectedIsSampledToLocalTracing -> "wrong isSampledToLocalTracing: $isSampledToLocalTracing"
+        else -> null
+    }
+}
+
+object SimpleResolver : MessageCodecResolver {
+    override fun resolveOrNull(kType: KType): MessageCodec<*>? {
+        return when (kType.classifier) {
+            String::class -> StringCodec
+            Unit::class -> UnitCodec
+            Message::class -> MessageClassCodec
+            else -> null
+        }
+    }
+}
+
+object StringCodec : MessageCodec<String> {
+    override fun encode(value: String): Source {
+        TODO("Not yet implemented")
+    }
+
+    override fun decode(stream: Source): String {
+        TODO("Not yet implemented")
+    }
+}
+
+object UnitCodec : MessageCodec<String> {
+    override fun encode(value: String): Source {
+        TODO("Not yet implemented")
+    }
+
+    override fun decode(stream: Source): String {
+        TODO("Not yet implemented")
+    }
+}
+
+@Suppress("unused")
+class Message(val a: Int, val b: String)
+
+object MessageClassCodec : MessageCodec<Message> {
+    override fun encode(value: Message): Source {
+        TODO("Not yet implemented")
+    }
+
+    override fun decode(stream: Source): Message {
+        TODO("Not yet implemented")
+    }
+}

--- a/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
+++ b/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
@@ -1,5 +1,9 @@
 
 
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.rpc.codegen.test.runners;
 
 import com.intellij.testFramework.TestDataPath;
@@ -31,6 +35,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
   @TestMetadata("flowParameter.kt")
   public void testFlowParameter() {
     runTest("src/testData/box/flowParameter.kt");
+  }
+
+  @Test
+  @TestMetadata("grpc.kt")
+  public void testGrpc() {
+    runTest("src/testData/box/grpc.kt");
   }
 
   @Test

--- a/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/DiagnosticTestGenerated.java
+++ b/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/DiagnosticTestGenerated.java
@@ -1,5 +1,9 @@
 
 
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
 package kotlinx.rpc.codegen.test.runners;
 
 import com.intellij.testFramework.TestDataPath;
@@ -28,6 +32,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
   }
 
   @Test
+  @TestMetadata("grpc.kt")
+  public void testGrpc() {
+    runTest("src/testData/diagnostics/grpc.kt");
+  }
+
+  @Test
   @TestMetadata("rpcChecked.kt")
   public void testRpcChecked() {
     runTest("src/testData/diagnostics/rpcChecked.kt");
@@ -43,5 +53,11 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
   @TestMetadata("strictMode.kt")
   public void testStrictMode() {
     runTest("src/testData/diagnostics/strictMode.kt");
+  }
+
+  @Test
+  @TestMetadata("withCodec.kt")
+  public void testWithCodec() {
+    runTest("src/testData/diagnostics/withCodec.kt");
   }
 }

--- a/tests/compiler-plugin-tests/src/testData/box/grpc.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/grpc.fir.ir.txt
@@ -1,0 +1,964 @@
+FILE fqName:<root> fileName:/grpc.kt
+  annotations:
+    OptIn(markerClass = [CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB ANNOTATION_CLASS name:ExperimentalRpcApi modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.reflect.KClass<kotlinx.rpc.internal.utils.ExperimentalRpcApi>, CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB ANNOTATION_CLASS name:InternalRpcApi modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.reflect.KClass<kotlinx.rpc.internal.utils.InternalRpcApi>] type=kotlin.Array<out kotlin.reflect.KClass<out kotlin.Annotation>> varargElementType=kotlin.reflect.KClass<out kotlin.Annotation>)
+  CLASS CLASS name:Custom modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      WithCodec(codec = CLASS_REFERENCE 'CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.grpc.codec.MessageCodec<<root>.Custom>]' type=kotlin.reflect.KClass<<root>.Custom.Companion>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Custom
+    PROPERTY name:content visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:content type:kotlin.String visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'content: kotlin.String declared in <root>.Custom.<init>' type=kotlin.String origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-content> visibility:public modality:FINAL returnType:kotlin.String
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Custom
+        correspondingProperty: PROPERTY name:content visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-content> (): kotlin.String declared in <root>.Custom'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:content type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+              receiver: GET_VAR '<this>: <root>.Custom declared in <root>.Custom.<get-content>' type=<root>.Custom origin=null
+    CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.grpc.codec.MessageCodec<<root>.Custom>]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.Custom.Companion
+      CONSTRUCTOR visibility:private returnType:<root>.Custom.Companion [primary]
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.grpc.codec.MessageCodec<<root>.Custom>]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlinx.rpc.grpc.codec.MessageCodec
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in kotlinx.rpc.grpc.codec.MessageCodec
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in kotlinx.rpc.grpc.codec.MessageCodec
+      FUN name:decode visibility:public modality:OPEN returnType:<root>.Custom
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Custom.Companion
+        VALUE_PARAMETER kind:Regular name:stream index:1 type:kotlinx.io.Source
+        overridden:
+          public abstract fun decode (stream: kotlinx.io.Source): T of kotlinx.rpc.grpc.codec.MessageCodec declared in kotlinx.rpc.grpc.codec.MessageCodec
+        BLOCK_BODY
+          CALL 'public final fun TODO (reason: kotlin.String): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+            ARG reason: CONST String type=kotlin.String value="Not yet implemented"
+      FUN name:encode visibility:public modality:OPEN returnType:kotlinx.io.Source
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.Custom.Companion
+        VALUE_PARAMETER kind:Regular name:value index:1 type:<root>.Custom
+        overridden:
+          public abstract fun encode (value: T of kotlinx.rpc.grpc.codec.MessageCodec): kotlinx.io.Source declared in kotlinx.rpc.grpc.codec.MessageCodec
+        BLOCK_BODY
+          CALL 'public final fun TODO (reason: kotlin.String): kotlin.Nothing declared in kotlin' type=kotlin.Nothing origin=null
+            ARG reason: CONST String type=kotlin.String value="Not yet implemented"
+    CONSTRUCTOR visibility:public returnType:<root>.Custom [primary]
+      VALUE_PARAMETER kind:Regular name:content index:0 type:kotlin.String
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Custom modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  CLASS INTERFACE name:BoxService modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Grpc
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService
+    CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub
+      PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
+        FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]
+          EXPRESSION_BODY
+            GET_VAR '__rpc_stub_id: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlin.Long origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL returnType:kotlin.Long
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+          correspondingProperty: PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]' type=kotlin.Long origin=null
+                receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_stub_id>' type=<root>.BoxService.$rpcServiceStub origin=null
+      PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
+        FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]
+          EXPRESSION_BODY
+            GET_VAR '__rpc_client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlinx.rpc.RpcClient origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL returnType:kotlinx.rpc.RpcClient
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+          correspondingProperty: PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]' type=kotlinx.rpc.RpcClient origin=null
+                receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_client>' type=<root>.BoxService.$rpcServiceStub origin=null
+      CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        PROPERTY name:simpleName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract simpleName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:simpleName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-simpleName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-simpleName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:fqName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract fqName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:fqName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-fqName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-fqName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-fqName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:simpleInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator'
+                        CALL 'public abstract fun simple (value: kotlin.String): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator.<anonymous>' type=<root>.BoxService origin=null
+                          ARG value: TYPE_OP type=kotlin.String origin=CAST typeOperand=kotlin.String
+                            CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                              ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.simpleInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                              ARG index: CONST Int type=kotlin.Int value=0
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:simpleInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:unitInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:unitInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.unitInvokator'
+                        CALL 'public abstract fun unit (): kotlin.Unit declared in <root>.BoxService' type=kotlin.Unit origin=null
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.unitInvokator.<anonymous>' type=<root>.BoxService origin=null
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-unitInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:unitInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-unitInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:unitInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-unitInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:clientStreamInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:clientStreamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.clientStreamInvokator'
+                        CALL 'public abstract fun clientStream (flow: kotlinx.coroutines.flow.Flow<kotlin.String>): kotlin.Unit declared in <root>.BoxService' type=kotlin.Unit origin=null
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.clientStreamInvokator.<anonymous>' type=<root>.BoxService origin=null
+                          ARG flow: TYPE_OP type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=CAST typeOperand=kotlinx.coroutines.flow.Flow<kotlin.String>
+                            CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                              ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.clientStreamInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                              ARG index: CONST Int type=kotlin.Int value=0
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-clientStreamInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:clientStreamInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-clientStreamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:clientStreamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-clientStreamInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:serverStreamInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:serverStreamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.Function2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlinx.coroutines.flow.Flow<kotlin.Any?>> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlinx.coroutines.flow.Flow<kotlin.Any?>
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlinx.coroutines.flow.Flow<kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.serverStreamInvokator'
+                        CALL 'public abstract fun serverStream (): kotlinx.coroutines.flow.Flow<kotlin.Unit> declared in <root>.BoxService' type=kotlinx.coroutines.flow.Flow<kotlin.Unit> origin=null
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.serverStreamInvokator.<anonymous>' type=<root>.BoxService origin=null
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-serverStreamInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:serverStreamInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-serverStreamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:serverStreamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-serverStreamInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:bidiStreamInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:bidiStreamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.Function2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlinx.coroutines.flow.Flow<kotlin.Any?>> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlinx.coroutines.flow.Flow<kotlin.Any?>
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlinx.coroutines.flow.Flow<kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.bidiStreamInvokator'
+                        CALL 'public abstract fun bidiStream (flow: kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>): kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> declared in <root>.BoxService' type=kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> origin=null
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.bidiStreamInvokator.<anonymous>' type=<root>.BoxService origin=null
+                          ARG flow: TYPE_OP type=kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> origin=CAST typeOperand=kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>
+                            CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                              ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.bidiStreamInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                              ARG index: CONST Int type=kotlin.Int value=0
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-bidiStreamInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:bidiStreamInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-bidiStreamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:bidiStreamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-bidiStreamInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:customInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:customInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.customInvokator'
+                        CALL 'public abstract fun custom (): <root>.Custom declared in <root>.BoxService' type=<root>.Custom origin=null
+                          ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.customInvokator.<anonymous>' type=<root>.BoxService origin=null
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-customInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:customInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-customInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:customInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-customInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:callableMap visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
+            EXPRESSION_BODY
+              CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                TYPE_ARG K: kotlin.String
+                TYPE_ARG V: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="simple"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="simple"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="value"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlin.String
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="unit"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="unit"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-unitInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="clientStream"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="clientStream"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-clientStreamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="flow"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlinx.coroutines.flow.Flow<kotlin.String>
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="serverStream"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="serverStream"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-serverStreamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="bidiStream"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="bidiStream"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlinx.rpc.codegen.test.Message
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-bidiStreamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="flow"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="custom"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="custom"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: <root>.Custom
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-customInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callableMap> visibility:private modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:callableMap visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:callableMap type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callableMap>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        CONSTRUCTOR visibility:private returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
+          BLOCK_BODY
+            DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+            INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]' type=kotlin.Unit
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+          overridden:
+            public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun hashCode (): kotlin.Int declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun toString (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+        FUN name:createInstance visibility:public modality:OPEN returnType:<root>.BoxService
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:serviceId index:1 type:kotlin.Long
+          VALUE_PARAMETER kind:Regular name:client index:2 type:kotlinx.rpc.RpcClient
+          overridden:
+            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): Service of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public open fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion'
+              CONSTRUCTOR_CALL 'public constructor <init> (__rpc_stub_id: kotlin.Long, __rpc_client: kotlinx.rpc.RpcClient) declared in <root>.BoxService.$rpcServiceStub' type=<root>.BoxService.$rpcServiceStub origin=null
+                ARG __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
+                ARG __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
+        FUN name:delegate visibility:public modality:FINAL returnType:kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:resolver index:1 type:kotlinx.rpc.grpc.codec.MessageCodecResolver
+          overridden:
+            public abstract fun delegate (resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver): kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor
+          BLOCK_BODY
+            VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.collections.Map<kotlin.String, io.grpc.MethodDescriptor<*, *>> [val]
+              CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                TYPE_ARG K: kotlin.String
+                TYPE_ARG V: io.grpc.MethodDescriptor<*, *>
+                ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>>> varargElementType=kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>>
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: io.grpc.MethodDescriptor<*, *>
+                    ARG <this>: CONST String type=kotlin.String value="simple"
+                    ARG that: CALL 'public final fun methodDescriptor <Request, Response> (fullMethodName: kotlin.String, requestCodec: kotlinx.rpc.grpc.codec.MessageCodec<Request of kotlinx.rpc.grpc.internal.methodDescriptor>, responseCodec: kotlinx.rpc.grpc.codec.MessageCodec<Response of kotlinx.rpc.grpc.internal.methodDescriptor>, type: kotlinx.rpc.grpc.internal.MethodType, schemaDescriptor: kotlin.Any?, idempotent: kotlin.Boolean, safe: kotlin.Boolean, sampledToLocalTracing: kotlin.Boolean): io.grpc.MethodDescriptor<Request of kotlinx.rpc.grpc.internal.methodDescriptor, Response of kotlinx.rpc.grpc.internal.methodDescriptor> declared in kotlinx.rpc.grpc.internal' type=io.grpc.MethodDescriptor<kotlin.String, kotlin.String> origin=null
+                      TYPE_ARG Request: kotlin.String
+                      TYPE_ARG Response: kotlin.String
+                      ARG fullMethodName: CONST String type=kotlin.String value="BoxService/simple"
+                      ARG requestCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.String> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                      ARG responseCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.String> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                      ARG type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:UNARY' type=kotlinx.rpc.grpc.internal.MethodType
+                      ARG schemaDescriptor: CONST Null type=kotlin.Any? value=null
+                      ARG idempotent: CONST Boolean type=kotlin.Boolean value=true
+                      ARG safe: CONST Boolean type=kotlin.Boolean value=true
+                      ARG sampledToLocalTracing: CONST Boolean type=kotlin.Boolean value=true
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: io.grpc.MethodDescriptor<*, *>
+                    ARG <this>: CONST String type=kotlin.String value="unit"
+                    ARG that: CALL 'public final fun methodDescriptor <Request, Response> (fullMethodName: kotlin.String, requestCodec: kotlinx.rpc.grpc.codec.MessageCodec<Request of kotlinx.rpc.grpc.internal.methodDescriptor>, responseCodec: kotlinx.rpc.grpc.codec.MessageCodec<Response of kotlinx.rpc.grpc.internal.methodDescriptor>, type: kotlinx.rpc.grpc.internal.MethodType, schemaDescriptor: kotlin.Any?, idempotent: kotlin.Boolean, safe: kotlin.Boolean, sampledToLocalTracing: kotlin.Boolean): io.grpc.MethodDescriptor<Request of kotlinx.rpc.grpc.internal.methodDescriptor, Response of kotlinx.rpc.grpc.internal.methodDescriptor> declared in kotlinx.rpc.grpc.internal' type=io.grpc.MethodDescriptor<kotlin.Unit, kotlin.Unit> origin=null
+                      TYPE_ARG Request: kotlin.Unit
+                      TYPE_ARG Response: kotlin.Unit
+                      ARG fullMethodName: CONST String type=kotlin.String value="BoxService/unit"
+                      ARG requestCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.Unit> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                      ARG responseCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.Unit> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                      ARG type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:UNARY' type=kotlinx.rpc.grpc.internal.MethodType
+                      ARG schemaDescriptor: CONST Null type=kotlin.Any? value=null
+                      ARG idempotent: CONST Boolean type=kotlin.Boolean value=true
+                      ARG safe: CONST Boolean type=kotlin.Boolean value=true
+                      ARG sampledToLocalTracing: CONST Boolean type=kotlin.Boolean value=true
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: io.grpc.MethodDescriptor<*, *>
+                    ARG <this>: CONST String type=kotlin.String value="clientStream"
+                    ARG that: CALL 'public final fun methodDescriptor <Request, Response> (fullMethodName: kotlin.String, requestCodec: kotlinx.rpc.grpc.codec.MessageCodec<Request of kotlinx.rpc.grpc.internal.methodDescriptor>, responseCodec: kotlinx.rpc.grpc.codec.MessageCodec<Response of kotlinx.rpc.grpc.internal.methodDescriptor>, type: kotlinx.rpc.grpc.internal.MethodType, schemaDescriptor: kotlin.Any?, idempotent: kotlin.Boolean, safe: kotlin.Boolean, sampledToLocalTracing: kotlin.Boolean): io.grpc.MethodDescriptor<Request of kotlinx.rpc.grpc.internal.methodDescriptor, Response of kotlinx.rpc.grpc.internal.methodDescriptor> declared in kotlinx.rpc.grpc.internal' type=io.grpc.MethodDescriptor<kotlin.String, kotlin.Unit> origin=null
+                      TYPE_ARG Request: kotlin.String
+                      TYPE_ARG Response: kotlin.Unit
+                      ARG fullMethodName: CONST String type=kotlin.String value="BoxService/clientStream"
+                      ARG requestCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.String> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                      ARG responseCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.Unit> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                      ARG type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:CLIENT_STREAMING' type=kotlinx.rpc.grpc.internal.MethodType
+                      ARG schemaDescriptor: CONST Null type=kotlin.Any? value=null
+                      ARG idempotent: CONST Boolean type=kotlin.Boolean value=true
+                      ARG safe: CONST Boolean type=kotlin.Boolean value=true
+                      ARG sampledToLocalTracing: CONST Boolean type=kotlin.Boolean value=true
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: io.grpc.MethodDescriptor<*, *>
+                    ARG <this>: CONST String type=kotlin.String value="serverStream"
+                    ARG that: CALL 'public final fun methodDescriptor <Request, Response> (fullMethodName: kotlin.String, requestCodec: kotlinx.rpc.grpc.codec.MessageCodec<Request of kotlinx.rpc.grpc.internal.methodDescriptor>, responseCodec: kotlinx.rpc.grpc.codec.MessageCodec<Response of kotlinx.rpc.grpc.internal.methodDescriptor>, type: kotlinx.rpc.grpc.internal.MethodType, schemaDescriptor: kotlin.Any?, idempotent: kotlin.Boolean, safe: kotlin.Boolean, sampledToLocalTracing: kotlin.Boolean): io.grpc.MethodDescriptor<Request of kotlinx.rpc.grpc.internal.methodDescriptor, Response of kotlinx.rpc.grpc.internal.methodDescriptor> declared in kotlinx.rpc.grpc.internal' type=io.grpc.MethodDescriptor<kotlin.Unit, kotlin.Unit> origin=null
+                      TYPE_ARG Request: kotlin.Unit
+                      TYPE_ARG Response: kotlin.Unit
+                      ARG fullMethodName: CONST String type=kotlin.String value="BoxService/serverStream"
+                      ARG requestCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.Unit> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                      ARG responseCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.Unit> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                      ARG type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:SERVER_STREAMING' type=kotlinx.rpc.grpc.internal.MethodType
+                      ARG schemaDescriptor: CONST Null type=kotlin.Any? value=null
+                      ARG idempotent: CONST Boolean type=kotlin.Boolean value=true
+                      ARG safe: CONST Boolean type=kotlin.Boolean value=true
+                      ARG sampledToLocalTracing: CONST Boolean type=kotlin.Boolean value=true
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: io.grpc.MethodDescriptor<*, *>
+                    ARG <this>: CONST String type=kotlin.String value="bidiStream"
+                    ARG that: CALL 'public final fun methodDescriptor <Request, Response> (fullMethodName: kotlin.String, requestCodec: kotlinx.rpc.grpc.codec.MessageCodec<Request of kotlinx.rpc.grpc.internal.methodDescriptor>, responseCodec: kotlinx.rpc.grpc.codec.MessageCodec<Response of kotlinx.rpc.grpc.internal.methodDescriptor>, type: kotlinx.rpc.grpc.internal.MethodType, schemaDescriptor: kotlin.Any?, idempotent: kotlin.Boolean, safe: kotlin.Boolean, sampledToLocalTracing: kotlin.Boolean): io.grpc.MethodDescriptor<Request of kotlinx.rpc.grpc.internal.methodDescriptor, Response of kotlinx.rpc.grpc.internal.methodDescriptor> declared in kotlinx.rpc.grpc.internal' type=io.grpc.MethodDescriptor<kotlinx.rpc.codegen.test.Message, kotlinx.rpc.codegen.test.Message> origin=null
+                      TYPE_ARG Request: kotlinx.rpc.codegen.test.Message
+                      TYPE_ARG Response: kotlinx.rpc.codegen.test.Message
+                      ARG fullMethodName: CONST String type=kotlin.String value="BoxService/bidiStream"
+                      ARG requestCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlinx.rpc.codegen.test.Message> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlinx.rpc.codegen.test.Message
+                      ARG responseCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlinx.rpc.codegen.test.Message> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlinx.rpc.codegen.test.Message
+                      ARG type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:BIDI_STREAMING' type=kotlinx.rpc.grpc.internal.MethodType
+                      ARG schemaDescriptor: CONST Null type=kotlin.Any? value=null
+                      ARG idempotent: CONST Boolean type=kotlin.Boolean value=true
+                      ARG safe: CONST Boolean type=kotlin.Boolean value=true
+                      ARG sampledToLocalTracing: CONST Boolean type=kotlin.Boolean value=true
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: io.grpc.MethodDescriptor<*, *>
+                    ARG <this>: CONST String type=kotlin.String value="custom"
+                    ARG that: CALL 'public final fun methodDescriptor <Request, Response> (fullMethodName: kotlin.String, requestCodec: kotlinx.rpc.grpc.codec.MessageCodec<Request of kotlinx.rpc.grpc.internal.methodDescriptor>, responseCodec: kotlinx.rpc.grpc.codec.MessageCodec<Response of kotlinx.rpc.grpc.internal.methodDescriptor>, type: kotlinx.rpc.grpc.internal.MethodType, schemaDescriptor: kotlin.Any?, idempotent: kotlin.Boolean, safe: kotlin.Boolean, sampledToLocalTracing: kotlin.Boolean): io.grpc.MethodDescriptor<Request of kotlinx.rpc.grpc.internal.methodDescriptor, Response of kotlinx.rpc.grpc.internal.methodDescriptor> declared in kotlinx.rpc.grpc.internal' type=io.grpc.MethodDescriptor<kotlin.Unit, <root>.Custom> origin=null
+                      TYPE_ARG Request: kotlin.Unit
+                      TYPE_ARG Response: <root>.Custom
+                      ARG fullMethodName: CONST String type=kotlin.String value="BoxService/custom"
+                      ARG requestCodec: CALL 'public abstract fun resolveOrNull (kType: kotlin.reflect.KType): kotlinx.rpc.grpc.codec.MessageCodec<*>? declared in kotlinx.rpc.grpc.codec.MessageCodecResolver' type=kotlinx.rpc.grpc.codec.MessageCodec<kotlin.Unit> origin=null
+                        ARG <this>: GET_VAR 'resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlinx.rpc.grpc.codec.MessageCodecResolver origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.Unit
+                      ARG responseCodec: GET_OBJECT 'CLASS OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.grpc.codec.MessageCodec<<root>.Custom>]' type=<root>.Custom.Companion
+                      ARG type: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:UNARY' type=kotlinx.rpc.grpc.internal.MethodType
+                      ARG schemaDescriptor: CONST Null type=kotlin.Any? value=null
+                      ARG idempotent: CONST Boolean type=kotlin.Boolean value=true
+                      ARG safe: CONST Boolean type=kotlin.Boolean value=true
+                      ARG sampledToLocalTracing: CONST Boolean type=kotlin.Boolean value=true
+            VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:io.grpc.ServiceDescriptor [val]
+              CALL 'public final fun serviceDescriptor (name: kotlin.String, methods: kotlin.collections.Collection<io.grpc.MethodDescriptor<*, *>>, schemaDescriptor: kotlin.Any?): io.grpc.ServiceDescriptor declared in kotlinx.rpc.grpc.internal' type=io.grpc.ServiceDescriptor origin=null
+                ARG name: CONST String type=kotlin.String value="BoxService"
+                ARG methods: CALL 'public abstract fun <get-values> (): kotlin.collections.Collection<V of kotlin.collections.Map> declared in kotlin.collections.Map' type=kotlin.collections.Collection<V of kotlin.collections.Map> origin=GET_PROPERTY
+                  ARG <this>: GET_VAR 'val tmp_0: kotlin.collections.Map<kotlin.String, io.grpc.MethodDescriptor<*, *>> declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlin.collections.Map<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                ARG schemaDescriptor: CONST Null type=kotlin.Any? value=null
+            RETURN type=kotlin.Nothing from='public final fun delegate (resolver: kotlinx.rpc.grpc.codec.MessageCodecResolver): kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.BoxService.$rpcServiceStub.Companion'
+              CONSTRUCTOR_CALL 'public constructor <init> (methodDescriptorMap: kotlin.collections.Map<kotlin.String, io.grpc.MethodDescriptor<*, *>>, serviceDescriptor: io.grpc.ServiceDescriptor) declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+                ARG methodDescriptorMap: GET_VAR 'val tmp_0: kotlin.collections.Map<kotlin.String, io.grpc.MethodDescriptor<*, *>> declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=kotlin.collections.Map<kotlin.String, io.grpc.MethodDescriptor<*, *>> origin=null
+                ARG serviceDescriptor: GET_VAR 'val tmp_1: io.grpc.ServiceDescriptor declared in <root>.BoxService.$rpcServiceStub.Companion.delegate' type=io.grpc.ServiceDescriptor origin=null
+        FUN name:getCallable visibility:public modality:FINAL returnType:kotlinx.rpc.descriptor.RpcCallable?
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+          overridden:
+            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public final fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
+              CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlinx.rpc.descriptor.RpcCallable? origin=GET_ARRAY_ELEMENT
+                ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                ARG key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
+        PROPERTY name:callables visibility:public modality:FINAL [val]
+          overridden:
+            public abstract callables: kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FUN name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-callables> (): kotlin.collections.Collection<kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                CALL 'public abstract fun <get-values> (): kotlin.collections.Collection<V of kotlin.collections.Map> declared in kotlin.collections.Map' type=kotlin.collections.Collection<V of kotlin.collections.Map> origin=GET_PROPERTY
+                  ARG <this>: CALL 'private final fun <get-callableMap> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                    ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callables>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.BoxService.$rpcServiceStub [primary]
+        VALUE_PARAMETER kind:Regular name:__rpc_stub_id index:0 type:kotlin.Long
+        VALUE_PARAMETER kind:Regular name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BoxService
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in <root>.BoxService
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in <root>.BoxService
+      FUN name:bidiStream visibility:public modality:OPEN returnType:kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:flow index:1 type:kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>
+        overridden:
+          public abstract fun bidiStream (flow: kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>): kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> declared in <root>.BoxService
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun bidiStream (flow: kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>): kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> declared in <root>.BoxService.$rpcServiceStub'
+            CALL 'public abstract fun callServerStreaming <T> (call: kotlinx.rpc.RpcCall): kotlinx.coroutines.flow.Flow<T of kotlinx.rpc.RpcClient.callServerStreaming> declared in kotlinx.rpc.RpcClient' type=kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> origin=null
+              TYPE_ARG T: kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.bidiStream' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="bidiStream"
+                ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                  ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+                    GET_VAR 'flow: kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> declared in <root>.BoxService.$rpcServiceStub.bidiStream' type=kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message> origin=null
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.bidiStream' type=<root>.BoxService.$rpcServiceStub origin=null
+      FUN name:clientStream visibility:public modality:OPEN returnType:kotlin.Unit [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:flow index:1 type:kotlinx.coroutines.flow.Flow<kotlin.String>
+        overridden:
+          public abstract fun clientStream (flow: kotlinx.coroutines.flow.Flow<kotlin.String>): kotlin.Unit declared in <root>.BoxService
+        BLOCK_BODY
+          CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.Unit origin=null
+            TYPE_ARG T: kotlin.Unit
+            ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.clientStream' type=<root>.BoxService.$rpcServiceStub origin=null
+            ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+              ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+              ARG callableName: CONST String type=kotlin.String value="clientStream"
+              ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                TYPE_ARG T: kotlin.Any?
+                ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+                  GET_VAR 'flow: kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxService.$rpcServiceStub.clientStream' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
+              ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.clientStream' type=<root>.BoxService.$rpcServiceStub origin=null
+      FUN name:custom visibility:public modality:OPEN returnType:<root>.Custom [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        overridden:
+          public abstract fun custom (): <root>.Custom declared in <root>.BoxService
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun custom (): <root>.Custom declared in <root>.BoxService.$rpcServiceStub'
+            CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=<root>.Custom origin=null
+              TYPE_ARG T: <root>.Custom
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.custom' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="custom"
+                ARG arguments: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.custom' type=<root>.BoxService.$rpcServiceStub origin=null
+      FUN name:serverStream visibility:public modality:OPEN returnType:kotlinx.coroutines.flow.Flow<kotlin.Unit>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        overridden:
+          public abstract fun serverStream (): kotlinx.coroutines.flow.Flow<kotlin.Unit> declared in <root>.BoxService
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun serverStream (): kotlinx.coroutines.flow.Flow<kotlin.Unit> declared in <root>.BoxService.$rpcServiceStub'
+            CALL 'public abstract fun callServerStreaming <T> (call: kotlinx.rpc.RpcCall): kotlinx.coroutines.flow.Flow<T of kotlinx.rpc.RpcClient.callServerStreaming> declared in kotlinx.rpc.RpcClient' type=kotlinx.coroutines.flow.Flow<kotlin.Unit> origin=null
+              TYPE_ARG T: kotlinx.coroutines.flow.Flow<kotlin.Unit>
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.serverStream' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="serverStream"
+                ARG arguments: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.serverStream' type=<root>.BoxService.$rpcServiceStub origin=null
+      FUN name:simple visibility:public modality:OPEN returnType:kotlin.String [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.String
+        overridden:
+          public abstract fun simple (value: kotlin.String): kotlin.String declared in <root>.BoxService
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun simple (value: kotlin.String): kotlin.String declared in <root>.BoxService.$rpcServiceStub'
+            CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.String origin=null
+              TYPE_ARG T: kotlin.String
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="simple"
+                ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                  ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+                    GET_VAR 'value: kotlin.String declared in <root>.BoxService.$rpcServiceStub.simple' type=kotlin.String origin=null
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.simple' type=<root>.BoxService.$rpcServiceStub origin=null
+      FUN name:unit visibility:public modality:OPEN returnType:kotlin.Unit [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        overridden:
+          public abstract fun unit (): kotlin.Unit declared in <root>.BoxService
+        BLOCK_BODY
+          CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.Unit origin=null
+            TYPE_ARG T: kotlin.Unit
+            ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+              ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.unit' type=<root>.BoxService.$rpcServiceStub origin=null
+            ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+              ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>; kotlinx.rpc.grpc.descriptor.GrpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+              ARG callableName: CONST String type=kotlin.String value="unit"
+              ARG arguments: CALL 'public final fun emptyArray <T> (): kotlin.Array<T of kotlin.emptyArray> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                TYPE_ARG T: kotlin.Any?
+              ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.unit' type=<root>.BoxService.$rpcServiceStub origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:bidiStream visibility:public modality:ABSTRACT returnType:kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:flow index:1 type:kotlinx.coroutines.flow.Flow<kotlinx.rpc.codegen.test.Message>
+    FUN name:clientStream visibility:public modality:ABSTRACT returnType:kotlin.Unit [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:flow index:1 type:kotlinx.coroutines.flow.Flow<kotlin.String>
+    FUN name:custom visibility:public modality:ABSTRACT returnType:<root>.Custom [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+    FUN name:serverStream visibility:public modality:ABSTRACT returnType:kotlinx.coroutines.flow.Flow<kotlin.Unit>
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+    FUN name:simple visibility:public modality:ABSTRACT returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:value index:1 type:kotlin.String
+    FUN name:unit visibility:public modality:ABSTRACT returnType:kotlin.Unit [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:delegate type:kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate [val]
+        CALL 'public final fun grpcDelegate <T> (): kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in kotlinx.rpc.codegen.test' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+          TYPE_ARG T: <root>.BoxService
+      WHEN type=kotlin.Unit origin=IF
+        BRANCH
+          if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+            ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+              ARG arg0: CALL 'public open fun getName (): @[FlexibleNullability] kotlin.String? declared in io.grpc.ServiceDescriptor' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY
+                ARG <this>: CALL 'public final fun <get-serviceDescriptor> (): io.grpc.ServiceDescriptor declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.ServiceDescriptor origin=GET_PROPERTY
+                  ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+              ARG arg1: CONST String type=kotlin.String value="BoxService"
+          then: BLOCK type=kotlin.Unit origin=null
+            RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+              STRING_CONCATENATION type=kotlin.String
+                CONST String type=kotlin.String value="Fail: Wrong service name: "
+                CALL 'public open fun getName (): @[FlexibleNullability] kotlin.String? declared in io.grpc.ServiceDescriptor' type=@[FlexibleNullability] kotlin.String? origin=GET_PROPERTY
+                  ARG <this>: CALL 'public final fun <get-serviceDescriptor> (): io.grpc.ServiceDescriptor declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.ServiceDescriptor origin=GET_PROPERTY
+                    ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        BLOCK type=kotlin.Nothing? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.String? [val]
+            CALL 'public final fun checkMethod (<this>: io.grpc.MethodDescriptor<*, *>, expectedMethodName: kotlin.String, expectedMethodType: io.grpc.MethodDescriptor.MethodType, expectedServiceName: kotlin.String, expectedIsSafe: kotlin.Boolean, expectedIsIdempotent: kotlin.Boolean, expectedIsSampledToLocalTracing: kotlin.Boolean): kotlin.String? declared in kotlinx.rpc.codegen.test' type=kotlin.String? origin=null
+              ARG <this>: CALL 'public final fun CHECK_NOT_NULL <T0> (arg0: T0 of kotlin.internal.ir.CHECK_NOT_NULL?): {T0 of kotlin.internal.ir.CHECK_NOT_NULL & Any} declared in kotlin.internal.ir' type=io.grpc.MethodDescriptor<*, *> origin=EXCLEXCL
+                TYPE_ARG T0: io.grpc.MethodDescriptor<*, *>
+                ARG arg0: CALL 'public final fun getMethodDescriptor (methodName: kotlin.String): io.grpc.MethodDescriptor<*, *>? declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.MethodDescriptor<*, *>? origin=null
+                  ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+                  ARG methodName: CONST String type=kotlin.String value="simple"
+              ARG expectedMethodName: CONST String type=kotlin.String value="simple"
+              ARG expectedMethodType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_JAVA_DECLARATION_STUB name:UNARY' type=io.grpc.MethodDescriptor.MethodType
+              ARG expectedServiceName: CONST String type=kotlin.String value="BoxService"
+          WHEN type=kotlin.Nothing? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                ARG arg0: GET_VAR 'val tmp_2: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun let <T, R> (<this>: T of kotlin.let, block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=kotlin.Nothing origin=null
+                TYPE_ARG T: kotlin.String
+                TYPE_ARG R: kotlin.Nothing
+                ARG <this>: GET_VAR 'val tmp_2: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG block: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.Nothing> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Nothing
+                    VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+                        STRING_CONCATENATION type=kotlin.String
+                          CONST String type=kotlin.String value="Fail: "
+                          GET_VAR 'it: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        BLOCK type=kotlin.Nothing? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlin.String? [val]
+            CALL 'public final fun checkMethod (<this>: io.grpc.MethodDescriptor<*, *>, expectedMethodName: kotlin.String, expectedMethodType: io.grpc.MethodDescriptor.MethodType, expectedServiceName: kotlin.String, expectedIsSafe: kotlin.Boolean, expectedIsIdempotent: kotlin.Boolean, expectedIsSampledToLocalTracing: kotlin.Boolean): kotlin.String? declared in kotlinx.rpc.codegen.test' type=kotlin.String? origin=null
+              ARG <this>: CALL 'public final fun CHECK_NOT_NULL <T0> (arg0: T0 of kotlin.internal.ir.CHECK_NOT_NULL?): {T0 of kotlin.internal.ir.CHECK_NOT_NULL & Any} declared in kotlin.internal.ir' type=io.grpc.MethodDescriptor<*, *> origin=EXCLEXCL
+                TYPE_ARG T0: io.grpc.MethodDescriptor<*, *>
+                ARG arg0: CALL 'public final fun getMethodDescriptor (methodName: kotlin.String): io.grpc.MethodDescriptor<*, *>? declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.MethodDescriptor<*, *>? origin=null
+                  ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+                  ARG methodName: CONST String type=kotlin.String value="unit"
+              ARG expectedMethodName: CONST String type=kotlin.String value="unit"
+              ARG expectedMethodType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_JAVA_DECLARATION_STUB name:UNARY' type=io.grpc.MethodDescriptor.MethodType
+              ARG expectedServiceName: CONST String type=kotlin.String value="BoxService"
+          WHEN type=kotlin.Nothing? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                ARG arg0: GET_VAR 'val tmp_3: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun let <T, R> (<this>: T of kotlin.let, block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=kotlin.Nothing origin=null
+                TYPE_ARG T: kotlin.String
+                TYPE_ARG R: kotlin.Nothing
+                ARG <this>: GET_VAR 'val tmp_3: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG block: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.Nothing> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Nothing
+                    VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+                        STRING_CONCATENATION type=kotlin.String
+                          CONST String type=kotlin.String value="Fail: "
+                          GET_VAR 'it: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        BLOCK type=kotlin.Nothing? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlin.String? [val]
+            CALL 'public final fun checkMethod (<this>: io.grpc.MethodDescriptor<*, *>, expectedMethodName: kotlin.String, expectedMethodType: io.grpc.MethodDescriptor.MethodType, expectedServiceName: kotlin.String, expectedIsSafe: kotlin.Boolean, expectedIsIdempotent: kotlin.Boolean, expectedIsSampledToLocalTracing: kotlin.Boolean): kotlin.String? declared in kotlinx.rpc.codegen.test' type=kotlin.String? origin=null
+              ARG <this>: CALL 'public final fun CHECK_NOT_NULL <T0> (arg0: T0 of kotlin.internal.ir.CHECK_NOT_NULL?): {T0 of kotlin.internal.ir.CHECK_NOT_NULL & Any} declared in kotlin.internal.ir' type=io.grpc.MethodDescriptor<*, *> origin=EXCLEXCL
+                TYPE_ARG T0: io.grpc.MethodDescriptor<*, *>
+                ARG arg0: CALL 'public final fun getMethodDescriptor (methodName: kotlin.String): io.grpc.MethodDescriptor<*, *>? declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.MethodDescriptor<*, *>? origin=null
+                  ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+                  ARG methodName: CONST String type=kotlin.String value="custom"
+              ARG expectedMethodName: CONST String type=kotlin.String value="custom"
+              ARG expectedMethodType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_JAVA_DECLARATION_STUB name:UNARY' type=io.grpc.MethodDescriptor.MethodType
+              ARG expectedServiceName: CONST String type=kotlin.String value="BoxService"
+          WHEN type=kotlin.Nothing? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                ARG arg0: GET_VAR 'val tmp_4: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun let <T, R> (<this>: T of kotlin.let, block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=kotlin.Nothing origin=null
+                TYPE_ARG T: kotlin.String
+                TYPE_ARG R: kotlin.Nothing
+                ARG <this>: GET_VAR 'val tmp_4: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG block: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.Nothing> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Nothing
+                    VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+                        STRING_CONCATENATION type=kotlin.String
+                          CONST String type=kotlin.String value="Fail: "
+                          GET_VAR 'it: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        BLOCK type=kotlin.Nothing? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_5 type:kotlin.String? [val]
+            CALL 'public final fun checkMethod (<this>: io.grpc.MethodDescriptor<*, *>, expectedMethodName: kotlin.String, expectedMethodType: io.grpc.MethodDescriptor.MethodType, expectedServiceName: kotlin.String, expectedIsSafe: kotlin.Boolean, expectedIsIdempotent: kotlin.Boolean, expectedIsSampledToLocalTracing: kotlin.Boolean): kotlin.String? declared in kotlinx.rpc.codegen.test' type=kotlin.String? origin=null
+              ARG <this>: CALL 'public final fun CHECK_NOT_NULL <T0> (arg0: T0 of kotlin.internal.ir.CHECK_NOT_NULL?): {T0 of kotlin.internal.ir.CHECK_NOT_NULL & Any} declared in kotlin.internal.ir' type=io.grpc.MethodDescriptor<*, *> origin=EXCLEXCL
+                TYPE_ARG T0: io.grpc.MethodDescriptor<*, *>
+                ARG arg0: CALL 'public final fun getMethodDescriptor (methodName: kotlin.String): io.grpc.MethodDescriptor<*, *>? declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.MethodDescriptor<*, *>? origin=null
+                  ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+                  ARG methodName: CONST String type=kotlin.String value="clientStream"
+              ARG expectedMethodName: CONST String type=kotlin.String value="clientStream"
+              ARG expectedMethodType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_JAVA_DECLARATION_STUB name:CLIENT_STREAMING' type=io.grpc.MethodDescriptor.MethodType
+              ARG expectedServiceName: CONST String type=kotlin.String value="BoxService"
+          WHEN type=kotlin.Nothing? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                ARG arg0: GET_VAR 'val tmp_5: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun let <T, R> (<this>: T of kotlin.let, block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=kotlin.Nothing origin=null
+                TYPE_ARG T: kotlin.String
+                TYPE_ARG R: kotlin.Nothing
+                ARG <this>: GET_VAR 'val tmp_5: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG block: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.Nothing> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Nothing
+                    VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+                        STRING_CONCATENATION type=kotlin.String
+                          CONST String type=kotlin.String value="Fail: "
+                          GET_VAR 'it: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        BLOCK type=kotlin.Nothing? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_6 type:kotlin.String? [val]
+            CALL 'public final fun checkMethod (<this>: io.grpc.MethodDescriptor<*, *>, expectedMethodName: kotlin.String, expectedMethodType: io.grpc.MethodDescriptor.MethodType, expectedServiceName: kotlin.String, expectedIsSafe: kotlin.Boolean, expectedIsIdempotent: kotlin.Boolean, expectedIsSampledToLocalTracing: kotlin.Boolean): kotlin.String? declared in kotlinx.rpc.codegen.test' type=kotlin.String? origin=null
+              ARG <this>: CALL 'public final fun CHECK_NOT_NULL <T0> (arg0: T0 of kotlin.internal.ir.CHECK_NOT_NULL?): {T0 of kotlin.internal.ir.CHECK_NOT_NULL & Any} declared in kotlin.internal.ir' type=io.grpc.MethodDescriptor<*, *> origin=EXCLEXCL
+                TYPE_ARG T0: io.grpc.MethodDescriptor<*, *>
+                ARG arg0: CALL 'public final fun getMethodDescriptor (methodName: kotlin.String): io.grpc.MethodDescriptor<*, *>? declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.MethodDescriptor<*, *>? origin=null
+                  ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+                  ARG methodName: CONST String type=kotlin.String value="serverStream"
+              ARG expectedMethodName: CONST String type=kotlin.String value="serverStream"
+              ARG expectedMethodType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_JAVA_DECLARATION_STUB name:SERVER_STREAMING' type=io.grpc.MethodDescriptor.MethodType
+              ARG expectedServiceName: CONST String type=kotlin.String value="BoxService"
+          WHEN type=kotlin.Nothing? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                ARG arg0: GET_VAR 'val tmp_6: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun let <T, R> (<this>: T of kotlin.let, block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=kotlin.Nothing origin=null
+                TYPE_ARG T: kotlin.String
+                TYPE_ARG R: kotlin.Nothing
+                ARG <this>: GET_VAR 'val tmp_6: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG block: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.Nothing> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Nothing
+                    VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+                        STRING_CONCATENATION type=kotlin.String
+                          CONST String type=kotlin.String value="Fail: "
+                          GET_VAR 'it: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+      TYPE_OP type=kotlin.Unit origin=IMPLICIT_COERCION_TO_UNIT typeOperand=kotlin.Unit
+        BLOCK type=kotlin.Nothing? origin=SAFE_CALL
+          VAR IR_TEMPORARY_VARIABLE name:tmp_7 type:kotlin.String? [val]
+            CALL 'public final fun checkMethod (<this>: io.grpc.MethodDescriptor<*, *>, expectedMethodName: kotlin.String, expectedMethodType: io.grpc.MethodDescriptor.MethodType, expectedServiceName: kotlin.String, expectedIsSafe: kotlin.Boolean, expectedIsIdempotent: kotlin.Boolean, expectedIsSampledToLocalTracing: kotlin.Boolean): kotlin.String? declared in kotlinx.rpc.codegen.test' type=kotlin.String? origin=null
+              ARG <this>: CALL 'public final fun CHECK_NOT_NULL <T0> (arg0: T0 of kotlin.internal.ir.CHECK_NOT_NULL?): {T0 of kotlin.internal.ir.CHECK_NOT_NULL & Any} declared in kotlin.internal.ir' type=io.grpc.MethodDescriptor<*, *> origin=EXCLEXCL
+                TYPE_ARG T0: io.grpc.MethodDescriptor<*, *>
+                ARG arg0: CALL 'public final fun getMethodDescriptor (methodName: kotlin.String): io.grpc.MethodDescriptor<*, *>? declared in kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate' type=io.grpc.MethodDescriptor<*, *>? origin=null
+                  ARG <this>: GET_VAR 'val delegate: kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate declared in <root>.box' type=kotlinx.rpc.grpc.descriptor.GrpcServiceDelegate origin=null
+                  ARG methodName: CONST String type=kotlin.String value="bidiStream"
+              ARG expectedMethodName: CONST String type=kotlin.String value="bidiStream"
+              ARG expectedMethodType: GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_JAVA_DECLARATION_STUB name:BIDI_STREAMING' type=io.grpc.MethodDescriptor.MethodType
+              ARG expectedServiceName: CONST String type=kotlin.String value="BoxService"
+          WHEN type=kotlin.Nothing? origin=null
+            BRANCH
+              if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                ARG arg0: GET_VAR 'val tmp_7: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG arg1: CONST Null type=kotlin.Nothing? value=null
+              then: CONST Null type=kotlin.Nothing? value=null
+            BRANCH
+              if: CONST Boolean type=kotlin.Boolean value=true
+              then: CALL 'public final fun let <T, R> (<this>: T of kotlin.let, block: kotlin.Function1<T of kotlin.let, R of kotlin.let>): R of kotlin.let declared in kotlin' type=kotlin.Nothing origin=null
+                TYPE_ARG T: kotlin.String
+                TYPE_ARG R: kotlin.Nothing
+                ARG <this>: GET_VAR 'val tmp_7: kotlin.String? declared in <root>.box' type=kotlin.String? origin=null
+                ARG block: FUN_EXPR type=kotlin.Function1<kotlin.String, kotlin.Nothing> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Nothing
+                    VALUE_PARAMETER kind:Regular name:it index:0 type:kotlin.String
+                    BLOCK_BODY
+                      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+                        STRING_CONCATENATION type=kotlin.String
+                          CONST String type=kotlin.String value="Fail: "
+                          GET_VAR 'it: kotlin.String declared in <root>.box.<anonymous>' type=kotlin.String origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CONST String type=kotlin.String value="OK"

--- a/tests/compiler-plugin-tests/src/testData/box/grpc.fir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/grpc.fir.txt
@@ -1,0 +1,80 @@
+FILE: grpc.kt
+    @FILE:R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlinx/rpc/internal/utils/ExperimentalRpcApi|), <getClass>(Q|kotlinx/rpc/internal/utils/InternalRpcApi|)))
+    @R|kotlinx/rpc/grpc/codec/WithCodec|(codec = <getClass>(Q|Custom.Companion|)) public final class Custom : R|kotlin/Any| {
+        public constructor(content: R|kotlin/String|): R|Custom| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val content: R|kotlin/String| = R|<local>/content|
+            public get(): R|kotlin/String|
+
+        public final companion object Companion : R|kotlinx/rpc/grpc/codec/MessageCodec<Custom>| {
+            private constructor(): R|Custom.Companion| {
+                super<R|kotlin/Any|>()
+            }
+
+            public open override fun encode(value: R|Custom|): R|kotlinx/io/Source| {
+                R|kotlin/TODO|(String(Not yet implemented))
+            }
+
+            public open override fun decode(stream: R|kotlinx/io/Source|): R|Custom| {
+                R|kotlin/TODO|(String(Not yet implemented))
+            }
+
+        }
+
+    }
+    @R|kotlinx/rpc/grpc/annotations/Grpc|() public abstract interface BoxService : R|kotlin/Any| {
+        public abstract suspend fun simple(value: R|kotlin/String|): R|kotlin/String|
+
+        public abstract suspend fun unit(): R|kotlin/Unit|
+
+        public abstract suspend fun clientStream(flow: R|kotlinx/coroutines/flow/Flow<kotlin/String>|): R|kotlin/Unit|
+
+        public abstract fun serverStream(): R|kotlinx/coroutines/flow/Flow<kotlin/Unit>|
+
+        public abstract fun bidiStream(flow: R|kotlinx/coroutines/flow/Flow<kotlinx/rpc/codegen/test/Message>|): R|kotlinx/coroutines/flow/Flow<kotlinx/rpc/codegen/test/Message>|
+
+        public abstract suspend fun custom(): R|Custom|
+
+        public final class $rpcServiceStub : R|kotlin/Any| {
+            public final companion object Companion : R|kotlin/Any| {
+            }
+
+        }
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval delegate: R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate| = R|kotlinx/rpc/codegen/test/grpcDelegate|<R|BoxService|>()
+        when () {
+            !=(R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.serviceDescriptor|.R|io/grpc/ServiceDescriptor.name|, String(BoxService)) ->  {
+                ^box <strcat>(String(Fail: Wrong service name: ), R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.serviceDescriptor|.R|io/grpc/ServiceDescriptor.name|)
+            }
+        }
+
+        R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.getMethodDescriptor|(String(simple))!!.R|kotlinx/rpc/codegen/test/checkMethod|(String(simple), Q|io/grpc/MethodDescriptor.MethodType|.R|io/grpc/MethodDescriptor.MethodType.UNARY|, String(BoxService))?.{ $subj$.R|kotlin/let|<R|kotlin/String|, R|kotlin/Nothing|>(<L> = let@fun <anonymous>(it: R|kotlin/String|): R|kotlin/Nothing| <inline=Inline, kind=EXACTLY_ONCE>  {
+            ^box <strcat>(String(Fail: ), R|<local>/it|)
+        }
+        ) }
+        R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.getMethodDescriptor|(String(unit))!!.R|kotlinx/rpc/codegen/test/checkMethod|(String(unit), Q|io/grpc/MethodDescriptor.MethodType|.R|io/grpc/MethodDescriptor.MethodType.UNARY|, String(BoxService))?.{ $subj$.R|kotlin/let|<R|kotlin/String|, R|kotlin/Nothing|>(<L> = let@fun <anonymous>(it: R|kotlin/String|): R|kotlin/Nothing| <inline=Inline, kind=EXACTLY_ONCE>  {
+            ^box <strcat>(String(Fail: ), R|<local>/it|)
+        }
+        ) }
+        R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.getMethodDescriptor|(String(custom))!!.R|kotlinx/rpc/codegen/test/checkMethod|(String(custom), Q|io/grpc/MethodDescriptor.MethodType|.R|io/grpc/MethodDescriptor.MethodType.UNARY|, String(BoxService))?.{ $subj$.R|kotlin/let|<R|kotlin/String|, R|kotlin/Nothing|>(<L> = let@fun <anonymous>(it: R|kotlin/String|): R|kotlin/Nothing| <inline=Inline, kind=EXACTLY_ONCE>  {
+            ^box <strcat>(String(Fail: ), R|<local>/it|)
+        }
+        ) }
+        R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.getMethodDescriptor|(String(clientStream))!!.R|kotlinx/rpc/codegen/test/checkMethod|(String(clientStream), Q|io/grpc/MethodDescriptor.MethodType|.R|io/grpc/MethodDescriptor.MethodType.CLIENT_STREAMING|, String(BoxService))?.{ $subj$.R|kotlin/let|<R|kotlin/String|, R|kotlin/Nothing|>(<L> = let@fun <anonymous>(it: R|kotlin/String|): R|kotlin/Nothing| <inline=Inline, kind=EXACTLY_ONCE>  {
+            ^box <strcat>(String(Fail: ), R|<local>/it|)
+        }
+        ) }
+        R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.getMethodDescriptor|(String(serverStream))!!.R|kotlinx/rpc/codegen/test/checkMethod|(String(serverStream), Q|io/grpc/MethodDescriptor.MethodType|.R|io/grpc/MethodDescriptor.MethodType.SERVER_STREAMING|, String(BoxService))?.{ $subj$.R|kotlin/let|<R|kotlin/String|, R|kotlin/Nothing|>(<L> = let@fun <anonymous>(it: R|kotlin/String|): R|kotlin/Nothing| <inline=Inline, kind=EXACTLY_ONCE>  {
+            ^box <strcat>(String(Fail: ), R|<local>/it|)
+        }
+        ) }
+        R|<local>/delegate|.R|kotlinx/rpc/grpc/descriptor/GrpcServiceDelegate.getMethodDescriptor|(String(bidiStream))!!.R|kotlinx/rpc/codegen/test/checkMethod|(String(bidiStream), Q|io/grpc/MethodDescriptor.MethodType|.R|io/grpc/MethodDescriptor.MethodType.BIDI_STREAMING|, String(BoxService))?.{ $subj$.R|kotlin/let|<R|kotlin/String|, R|kotlin/Nothing|>(<L> = let@fun <anonymous>(it: R|kotlin/String|): R|kotlin/Nothing| <inline=Inline, kind=EXACTLY_ONCE>  {
+            ^box <strcat>(String(Fail: ), R|<local>/it|)
+        }
+        ) }
+        ^box String(OK)
+    }

--- a/tests/compiler-plugin-tests/src/testData/box/grpc.kt
+++ b/tests/compiler-plugin-tests/src/testData/box/grpc.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// RUN_PIPELINE_TILL: BACKEND
+
+@file:OptIn(kotlinx.rpc.internal.utils.ExperimentalRpcApi::class, kotlinx.rpc.internal.utils.InternalRpcApi::class)
+
+import io.grpc.MethodDescriptor
+import kotlinx.io.Source
+import kotlinx.coroutines.flow.Flow
+import kotlinx.rpc.codegen.test.grpcDelegate
+import kotlinx.rpc.codegen.test.checkMethod
+import kotlinx.rpc.codegen.test.Message
+import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.rpc.grpc.codec.WithCodec
+import kotlinx.rpc.grpc.codec.MessageCodec
+
+@WithCodec(Custom.Companion::class)
+class Custom(val content: String) {
+    companion object : MessageCodec<Custom> {
+        override fun encode(value: Custom): Source {
+            TODO("Not yet implemented")
+        }
+
+        override fun decode(stream: Source): Custom {
+            TODO("Not yet implemented")
+        }
+    }
+}
+
+@Grpc
+interface BoxService {
+    suspend fun simple(value: String): String
+
+    suspend fun unit()
+
+    suspend fun clientStream(flow: Flow<String>)
+
+    fun serverStream(): Flow<Unit>
+
+    fun bidiStream(flow: Flow<Message>): Flow<Message>
+
+    suspend fun custom(): Custom
+}
+
+fun box(): String {
+    val delegate = grpcDelegate<BoxService>()
+
+    if (delegate.serviceDescriptor.name != "BoxService") {
+        return "Fail: Wrong service name: ${delegate.serviceDescriptor.name}"
+    }
+
+    delegate.getMethodDescriptor("simple")!!.checkMethod(
+        expectedMethodName = "simple",
+        expectedMethodType = MethodDescriptor.MethodType.UNARY,
+        expectedServiceName = "BoxService",
+    )?.let { return "Fail: $it"}
+
+    delegate.getMethodDescriptor("unit")!!.checkMethod(
+        expectedMethodName = "unit",
+        expectedMethodType = MethodDescriptor.MethodType.UNARY,
+        expectedServiceName = "BoxService",
+    )?.let { return "Fail: $it"}
+
+    delegate.getMethodDescriptor("custom")!!.checkMethod(
+        expectedMethodName = "custom",
+        expectedMethodType = MethodDescriptor.MethodType.UNARY,
+        expectedServiceName = "BoxService",
+    )?.let { return "Fail: $it"}
+
+    delegate.getMethodDescriptor("clientStream")!!.checkMethod(
+        expectedMethodName = "clientStream",
+        expectedMethodType = MethodDescriptor.MethodType.CLIENT_STREAMING,
+        expectedServiceName = "BoxService",
+    )?.let { return "Fail: $it"}
+
+    delegate.getMethodDescriptor("serverStream")!!.checkMethod(
+        expectedMethodName = "serverStream",
+        expectedMethodType = MethodDescriptor.MethodType.SERVER_STREAMING,
+        expectedServiceName = "BoxService",
+    )?.let { return "Fail: $it"}
+
+    delegate.getMethodDescriptor("bidiStream")!!.checkMethod(
+        expectedMethodName = "bidiStream",
+        expectedMethodType = MethodDescriptor.MethodType.BIDI_STREAMING,
+        expectedServiceName = "BoxService",
+    )?.let { return "Fail: $it"}
+
+    return "OK"
+}

--- a/tests/compiler-plugin-tests/src/testData/diagnostics/grpc.fir.txt
+++ b/tests/compiler-plugin-tests/src/testData/diagnostics/grpc.fir.txt
@@ -1,0 +1,36 @@
+FILE: module_main_grpc.kt
+    @R|kotlinx/rpc/grpc/annotations/Grpc|() public abstract interface MyService : R|kotlin/Any| {
+        public abstract suspend fun unary(value: R|kotlin/String|): R|kotlin/String|
+
+        public abstract suspend fun clientStreaming(flow: R|kotlinx/coroutines/flow/Flow<kotlin/String>|): R|kotlin/String|
+
+        public abstract fun serverStreaming(value: R|kotlin/String|): R|kotlinx/coroutines/flow/Flow<kotlin/String>|
+
+        public abstract fun bidiStreaming(flow: R|kotlinx/coroutines/flow/Flow<kotlin/String>|): R|kotlinx/coroutines/flow/Flow<kotlin/String>|
+
+        public abstract suspend fun zeroValues(): R|kotlin/Unit|
+
+        public abstract fun checkRegularDiagnosticsWork(): R|kotlin/Unit|
+
+        public abstract suspend fun multipleParams(param1: R|kotlin/String|, param2: R|kotlin/String|): R|kotlin/Unit|
+
+        public abstract suspend fun nullable(param1: R|kotlin/String?|): R|kotlin/String?|
+
+        public abstract suspend fun innerFlow(withFlow: R|WithFlow|): R|kotlin/Unit|
+
+        public final class $rpcServiceStub : R|kotlin/Any| {
+            public final companion object Companion : R|kotlin/Any| {
+            }
+
+        }
+
+    }
+    public final class WithFlow : R|kotlin/Any| {
+        public constructor(flow: R|kotlinx/coroutines/flow/Flow<kotlin/String>|): R|WithFlow| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val flow: R|kotlinx/coroutines/flow/Flow<kotlin/String>| = R|<local>/flow|
+            public get(): R|kotlinx/coroutines/flow/Flow<kotlin/String>|
+
+    }

--- a/tests/compiler-plugin-tests/src/testData/diagnostics/grpc.kt
+++ b/tests/compiler-plugin-tests/src/testData/diagnostics/grpc.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// RUN_PIPELINE_TILL: FRONTEND
+
+// MODULE: main
+
+import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.coroutines.flow.Flow
+
+@Grpc
+interface MyService {
+    suspend fun unary(value: String): String
+
+    suspend fun clientStreaming(flow: Flow<String>): String
+
+    fun serverStreaming(value: String): Flow<String>
+
+    fun bidiStreaming(flow: Flow<String>): Flow<String>
+
+    suspend fun zeroValues()
+
+    <!NON_SUSPENDING_REQUEST_WITHOUT_STREAMING_RETURN_TYPE!>fun checkRegularDiagnosticsWork()<!>
+
+    <!MULTIPLE_PARAMETERS_IN_GRPC_SERVICE!>suspend fun multipleParams(param1: String, param2: String)<!>
+
+    suspend fun nullable(<!NULLABLE_PARAMETER_IN_GRPC_SERVICE!>param1: String?<!>): <!NULLABLE_RETURN_TYPE_IN_GRPC_SERVICE!>String?<!>
+
+    suspend fun innerFlow(<!NON_TOP_LEVEL_CLIENT_STREAMING_IN_RPC_SERVICE!>withFlow: WithFlow<!>)
+}
+
+class WithFlow(val flow: Flow<String>)

--- a/tests/compiler-plugin-tests/src/testData/diagnostics/withCodec.fir.txt
+++ b/tests/compiler-plugin-tests/src/testData/diagnostics/withCodec.fir.txt
@@ -1,0 +1,88 @@
+FILE: module_main_withCodec.kt
+    @FILE:R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlinx/rpc/internal/utils/ExperimentalRpcApi|)))
+    @R|kotlinx/rpc/grpc/codec/WithCodec|(codec = <getClass>(Q|TestCodec|)) public open class Test : R|kotlin/Any| {
+        public constructor(): R|Test| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|kotlinx/rpc/grpc/codec/WithCodec|(codec = <getClass>(Q|TestCodec|)) public final class Test1 : R|kotlin/Any| {
+        public constructor(): R|Test1| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|kotlinx/rpc/grpc/codec/WithCodec|(codec = <getClass>(Q|TestCodec|)) public final class Test2 : R|Test| {
+        public constructor(): R|Test2| {
+            super<R|Test|>()
+        }
+
+    }
+    public final object TestCodec : R|kotlinx/rpc/grpc/codec/MessageCodec<Test>| {
+        private constructor(): R|TestCodec| {
+            super<R|kotlin/Any|>()
+        }
+
+        public open override fun encode(value: R|Test|): R|kotlinx/io/Source| {
+            R|kotlin/error|(String(Not implemented))
+        }
+
+        public open override fun decode(stream: R|kotlinx/io/Source|): R|Test| {
+            R|kotlin/error|(String(Not implemented))
+        }
+
+    }
+    @R|kotlinx/rpc/grpc/codec/WithCodec|(codec = <getClass>(Q|TestCodec3|)) public final class Test3 : R|kotlin/Any| {
+        public constructor(): R|Test3| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final class TestCodec3 : R|kotlinx/rpc/grpc/codec/MessageCodec<Test3>| {
+        public constructor(): R|TestCodec3| {
+            super<R|kotlin/Any|>()
+        }
+
+        public open override fun encode(value: R|Test3|): R|kotlinx/io/Source| {
+            R|kotlin/error|(String(Not implemented))
+        }
+
+        public open override fun decode(stream: R|kotlinx/io/Source|): R|Test3| {
+            R|kotlin/error|(String(Not implemented))
+        }
+
+    }
+    @R|kotlinx/rpc/grpc/codec/WithCodec|(codec = <getClass>(Q|TestCodec4|)) public final class Test4 : R|kotlin/Any| {
+        public constructor(): R|Test4| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final object TestCodec4 : R|ATestCodec4|, R|Whatever| {
+        private constructor(): R|TestCodec4| {
+            super<R|ATestCodec4|>()
+        }
+
+    }
+    public abstract interface Whatever : R|kotlin/Any| {
+    }
+    public abstract class ATestCodec4 : R|kotlinx/rpc/grpc/codec/MessageCodec<Test4>| {
+        public constructor(): R|ATestCodec4| {
+            super<R|kotlin/Any|>()
+        }
+
+        public open override fun encode(value: R|Test4|): R|kotlinx/io/Source| {
+            R|kotlin/error|(String(Not implemented))
+        }
+
+        public open override fun decode(stream: R|kotlinx/io/Source|): R|Test4| {
+            R|kotlin/error|(String(Not implemented))
+        }
+
+    }
+    @R|kotlinx/rpc/grpc/codec/WithCodec|(codec = <getClass>(Q|TestCodec4|)) public final class Test5 : R|kotlin/Any| {
+        public constructor(): R|Test5| {
+            super<R|kotlin/Any|>()
+        }
+
+    }

--- a/tests/compiler-plugin-tests/src/testData/diagnostics/withCodec.kt
+++ b/tests/compiler-plugin-tests/src/testData/diagnostics/withCodec.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// RUN_PIPELINE_TILL: FRONTEND
+
+// MODULE: main
+
+@file:OptIn(kotlinx.rpc.internal.utils.ExperimentalRpcApi::class)
+
+import kotlinx.rpc.grpc.codec.WithCodec
+import kotlinx.rpc.grpc.codec.MessageCodec
+import kotlinx.io.Source
+
+@WithCodec(TestCodec::class)
+open class Test
+
+@WithCodec(<!CODEC_TYPE_MISMATCH!>TestCodec::class<!>)
+class Test1
+
+@WithCodec(<!CODEC_TYPE_MISMATCH!>TestCodec::class<!>)
+class Test2 : Test()
+
+object TestCodec : MessageCodec<Test> {
+    override fun encode(value: Test): Source {
+        error("Not implemented")
+    }
+
+    override fun decode(stream: Source): Test {
+        error("Not implemented")
+    }
+}
+
+@WithCodec(<!NOT_AN_OBJECT_REFERENCE_IN_WITH_CODEC_ANNOTATION!>TestCodec3::class<!>)
+class Test3
+
+class TestCodec3 : MessageCodec<Test3> {
+    override fun encode(value: Test3): Source {
+        error("Not implemented")
+    }
+
+    override fun decode(stream: Source): Test3 {
+        error("Not implemented")
+    }
+}
+
+@WithCodec(TestCodec4::class)
+class Test4
+
+object TestCodec4 : ATestCodec4(), Whatever
+
+interface Whatever
+
+abstract class ATestCodec4 : MessageCodec<Test4> {
+    override fun encode(value: Test4): Source {
+        error("Not implemented")
+    }
+
+    override fun decode(stream: Source): Test4 {
+        error("Not implemented")
+    }
+}
+
+@WithCodec(<!CODEC_TYPE_MISMATCH!>TestCodec4::class<!>)
+class Test5


### PR DESCRIPTION
**Subsystem**
gRPC Services, Compiler Plugin

**Solutions**
- Compiler checkers for `@Grpc` and `@WithCodec` annotations
- Support for zero-parameters functions
- Stream tests
- Bug fixes
- `MessageCodecResolver` gained plus operator for combinations
- Compiler plugin tests

