### PR TITLE
Bump compat-patrouille version

### DIFF
--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -28,7 +28,7 @@ detekt-gradle-plugin = "1.23.8"
 kover = "0.9.1"
 develocity = "3.19.2"
 common-custom-user-data = "2.3"
-compat-patrouille = "0.0.0"
+compat-patrouille = "0.0.1"
 
 [libraries]
 # kotlinx.rpc – references to the included builds


### PR DESCRIPTION
This is a PR on a [PR](https://github.com/Kotlin/kotlinx-rpc/pull/438).

Just confirming it's working with [latest version](https://github.com/GradleUp/compat-patrouille/releases/tag/v0.0.1). 

<img width="930" height="269" alt="Screenshot 2025-08-11 at 11 16 55" src="https://github.com/user-attachments/assets/0753e930-4acb-4f45-955d-36296a278059" />

Feel free to merge or discard this. 