### PR TITLE
fix wrong unchecked null cast (potential NPE)

### DIFF
--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestService.kt
@@ -64,6 +64,7 @@ interface KrpcTestService {
     suspend fun nullableReturn(returnNull: Boolean): TestClass?
     suspend fun variance(arg2: TestList<in TestClass>, arg3: TestList2<TestClass>): TestList<out TestClass>?
     suspend fun collectOnce(flow: Flow<String>)
+    suspend fun returnTestClassThatThrowsWhileDeserialization(value: Int): TestClassThatThrowsWhileDeserialization
 
     suspend fun nonSerializableClass(localDate: LocalDate): LocalDate
     suspend fun nonSerializableClassWithSerializer(

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTestServiceBackend.kt
@@ -98,6 +98,10 @@ class KrpcTestServiceBackend : KrpcTestService {
         return arg1
     }
 
+    override suspend fun returnTestClassThatThrowsWhileDeserialization(value: Int): TestClassThatThrowsWhileDeserialization {
+        return TestClassThatThrowsWhileDeserialization(value)
+    }
+
     override suspend fun nullableParam(arg1: String?): String {
         return arg1 ?: "null"
     }

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
@@ -20,6 +20,7 @@ import kotlinx.rpc.krpc.server.KrpcServer
 import kotlinx.rpc.registerService
 import kotlinx.rpc.withService
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -459,6 +460,16 @@ abstract class KrpcTransportTestBase {
     @Test
     fun testUnitFlow() = runTest {
         assertEquals(Unit, client.unitFlow().toList().single())
+    }
+
+    @Test
+    fun testPR445() = runTest {
+        assertFailsWith<SerializationException> {
+            val result = client.returnTestClassThatThrowsWhileDeserialization(42)
+            @Suppress("SENSELESS_COMPARISON")
+            if (result == null)
+                println("result must not be null")
+        }
     }
 }
 

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
@@ -467,8 +467,9 @@ abstract class KrpcTransportTestBase {
         assertFailsWith<SerializationException> {
             val result = client.returnTestClassThatThrowsWhileDeserialization(42)
             @Suppress("SENSELESS_COMPARISON")
-            if (result == null)
-                println("result must not be null")
+            if (result == null) {
+                assertNotNull(result, "result must not be null")
+            }
         }
     }
 }

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/TestClass.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/TestClass.kt
@@ -4,13 +4,39 @@
 
 package kotlinx.rpc.krpc.test
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 @Suppress("EqualsOrHashCode", "detekt.EqualsWithHashCodeExist")
 @Serializable
 open class TestClass(val value: Int = 0) {
     override fun equals(other: Any?): Boolean {
         if (other !is TestClass) return false
+        return value == other.value
+    }
+}
+
+@Suppress("EqualsOrHashCode", "detekt.EqualsWithHashCodeExist")
+@Serializable(with = TestClassThatThrowsWhileDeserialization.Serializer::class)
+class TestClassThatThrowsWhileDeserialization(val value: Int = 0) {
+    object Serializer : KSerializer<TestClassThatThrowsWhileDeserialization> {
+        override val descriptor = Int.serializer().descriptor
+
+        override fun serialize(encoder: Encoder, value: TestClassThatThrowsWhileDeserialization) {
+            encoder.encodeInt(value.value)
+        }
+
+        override fun deserialize(decoder: Decoder): TestClassThatThrowsWhileDeserialization {
+            throw SerializationException("Its TestClassThatThrowsWhileDeserialization")
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is TestClassThatThrowsWhileDeserialization) return false
         return value == other.value
     }
 }


### PR DESCRIPTION
**Problem Description**

I encountered an issue where an RPC service returned null even though the RPC function never actually returns null

After investigation, it turned out that the error occurred during the deserialization of the server's response. However, kotlinx-rpc silently ignored the deserialization exception and performed an unchecked cast of null to the RPC function's return type T

This happens inside the KrpcClient class in the handleServerStreamingMessage function:

```Kotlin
is KrpcCallMessage.CallSuccess, is KrpcCallMessage.StreamMessage -> {
    val value = runCatching {
        val serializerResult = serialFormat.serializersModule
            .buildContextual(callable.returnType)
        decodeMessageData(serialFormat, serializerResult, message)
    }
    @Suppress("UNCHECKED_CAST")
    channel.send(value.getOrNull() as T) // Thats not ok
}
```

When deserialization fails, getOrNull() returns null, which is then unchecked-cast to T. This may propagate unexpected null values


**Expected behaviour**

If deserialization fails, the error should be propagated back to the remote function call site, instead of sending a null value through the channel

Replacing getOrNull() with getOrThrow() would throw the exception immediately inside the library's internals, but this would not deliver it to the location where the developer actually invokes the remote function.
Therefore, I switched from Channel<T> to Channel<Result<T>>, allowing the deserialization error to be captured and then rethrown at the correct call site

This is my first attempt at contributing, please don’t hit me 🙃