### PR TITLE
Fix wording for the `perCallBufferSize` docs

### DIFF
--- a/docs/pages/kotlinx-rpc/topics/configuration.topic
+++ b/docs/pages/kotlinx-rpc/topics/configuration.topic
@@ -92,8 +92,8 @@
                 The default value is <code>Duration.INFINITE</code>.
             </li>
             <li>
-                <code>perCallBufferSize</code> - size of the buffer for one call.
-                Call can be a stream or a single message.
+                <code>perCallBufferSize</code> - size of the messages buffer for one call.
+                The buffer ignores the size in bytes and only counts the number of messages.
                 This effectively provides a backpressure mechanism.
                 If a peer is slow to process the message during a call,
                 the buffer will be filled up and

--- a/krpc/krpc-core/src/commonMain/kotlin/kotlinx/rpc/krpc/KrpcConfig.kt
+++ b/krpc/krpc-core/src/commonMain/kotlin/kotlinx/rpc/krpc/KrpcConfig.kt
@@ -79,10 +79,9 @@ public sealed class KrpcConfigBuilder protected constructor() {
         /**
          * A buffer size for a single call.
          *
-         * The default value is 1000,
-         * meaning that only after one message is handled - the next one will be sent.
+         * The default value is 1000 messages independent of their size in bytes.
          *
-         * This buffer also applies to how many messages are cached with [waitTimeout]
+         * This buffer also applies to how many messages are cached with [waitTimeout].
          */
         public var perCallBufferSize: Int = 1000
     }


### PR DESCRIPTION
**Subsystem**
Docs
