### PR TITLE
Expose RpcServiceDescriptor.callableMap

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/IrUtils.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/IrUtils.kt
@@ -11,7 +11,9 @@ import org.jetbrains.kotlin.ir.builders.declarations.buildField
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrExpressionBody
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrClassifierSymbol
+import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.IrTypeArgument
 import org.jetbrains.kotlin.ir.types.IrTypeProjection
@@ -19,8 +21,8 @@ import org.jetbrains.kotlin.ir.types.SimpleTypeNullability
 import org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl
 import org.jetbrains.kotlin.ir.types.impl.makeTypeProjection
 import org.jetbrains.kotlin.ir.util.dump
+import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.types.Variance
-import java.util.*
 
 fun IrClassifierSymbol.typeWith(type: IrType, variance: Variance): IrType {
     return IrSimpleTypeImpl(
@@ -31,9 +33,10 @@ fun IrClassifierSymbol.typeWith(type: IrType, variance: Variance): IrType {
     )
 }
 
-val IrProperty.getterOrFail: IrSimpleFunction get () {
-    return getter ?: error("'getter' should be present, but was null: ${dump()}")
-}
+val IrProperty.getterOrFail: IrSimpleFunction
+    get() {
+        return getter ?: error("'getter' should be present, but was null: ${dump()}")
+    }
 
 fun IrProperty.addDefaultGetter(
     parentClass: IrClass,
@@ -95,3 +98,6 @@ fun <T> List<T>.compactIfPossible(): List<T> =
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER") // TODO(KTIJ-26314): Remove this suppression
 fun IrFactory.createExpressionBody(expression: IrExpression): IrExpressionBody =
     createExpressionBody(expression.startOffset, expression.endOffset, expression)
+
+fun IrClassSymbol.findPropertyByName(name: String): IrPropertySymbol? =
+    owner.properties.singleOrNull { it.name.asString() == name }?.symbol

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -55,6 +55,7 @@ public abstract interface class kotlinx/rpc/descriptor/RpcParameter {
 public abstract interface class kotlinx/rpc/descriptor/RpcServiceDescriptor {
 	public abstract fun createInstance (JLkotlinx/rpc/RpcClient;)Ljava/lang/Object;
 	public abstract fun getCallable (Ljava/lang/String;)Lkotlinx/rpc/descriptor/RpcCallable;
+	public abstract fun getCallableMap ()Ljava/util/Map;
 	public abstract fun getFqName ()Ljava/lang/String;
 }
 

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -28,6 +28,8 @@ abstract interface <#A: kotlin/Any> kotlinx.rpc.descriptor/RpcCallable { // kotl
 }
 
 abstract interface <#A: kotlin/Any> kotlinx.rpc.descriptor/RpcServiceDescriptor { // kotlinx.rpc.descriptor/RpcServiceDescriptor|null[0]
+    abstract val callableMap // kotlinx.rpc.descriptor/RpcServiceDescriptor.callableMap|{}callableMap[0]
+        abstract fun <get-callableMap>(): kotlin.collections/Map<kotlin/String, kotlinx.rpc.descriptor/RpcCallable<#A>> // kotlinx.rpc.descriptor/RpcServiceDescriptor.callableMap.<get-callableMap>|<get-callableMap>(){}[0]
     abstract val fqName // kotlinx.rpc.descriptor/RpcServiceDescriptor.fqName|{}fqName[0]
         abstract fun <get-fqName>(): kotlin/String // kotlinx.rpc.descriptor/RpcServiceDescriptor.fqName.<get-fqName>|<get-fqName>(){}[0]
 

--- a/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
@@ -44,6 +44,8 @@ public interface RpcServiceDescriptor<@Rpc T : Any> {
 
     public fun getCallable(name: String): RpcCallable<T>?
 
+    public val callableMap: Map<String, RpcCallable<T>>
+
     public fun createInstance(serviceId: Long, client: RpcClient): T
 }
 

--- a/tests/compiler-plugin-tests/build.gradle.kts
+++ b/tests/compiler-plugin-tests/build.gradle.kts
@@ -2,7 +2,7 @@
  * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
  */
 
-import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.dsl.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -110,6 +110,12 @@ tasks.test {
     dependsOn(project(":core").tasks.getByName("jvmJar"))
     dependsOn(project(":utils").tasks.getByName("jvmJar"))
     dependsOn(project(":krpc:krpc-core").tasks.getByName("jvmJar"))
+    dependsOn("generateTests")
+
+    inputs.dir("src/testData")
+        .ignoreEmptyDirectories()
+        .normalizeLineEndings()
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 
     useJUnitPlatform()
 

--- a/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
+++ b/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
@@ -3,9 +3,9 @@
 package kotlinx.rpc.codegen.test.runners;
 
 import com.intellij.testFramework.TestDataPath;
-import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.jetbrains.kotlin.test.TargetBackend;
 import org.jetbrains.kotlin.test.TestMetadata;
+import org.jetbrains.kotlin.test.util.KtTestUtil;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -38,6 +38,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
   public void testMultiModule() {
     runTest("src/testData/box/multiModule.kt");
   }
+
+    @Test
+    @TestMetadata("serviceDescriptor.kt")
+    public void testServiceDescriptor() {
+        runTest("src/testData/box/serviceDescriptor.kt");
+    }
 
   @Test
   @TestMetadata("simple.kt")

--- a/tests/compiler-plugin-tests/src/testData/box/serviceDescriptor.fir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/serviceDescriptor.fir.txt
@@ -1,0 +1,27 @@
+FILE: serviceDescriptor.kt
+    @R|kotlinx/rpc/annotations/Rpc|() public abstract interface BoxService : R|kotlin/Any| {
+        public abstract suspend fun simple(): R|kotlin/String|
+
+        public final class $rpcServiceStub : R|kotlin/Any| {
+            public final companion object Companion : R|kotlin/Any| {
+            }
+
+        }
+
+    }
+    @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlinx/rpc/internal/utils/ExperimentalRpcApi|))) public final fun box(): R|kotlin/String| {
+        ^box R|kotlinx/coroutines/runBlocking|<R|kotlin/String|>(<L> = runBlocking@fun R|kotlinx/coroutines/CoroutineScope|.<anonymous>(): R|kotlin/String| <inline=NoInline, kind=EXACTLY_ONCE>  {
+            lval descriptor: R|kotlinx/rpc/descriptor/RpcServiceDescriptor<BoxService>| = R|kotlinx/rpc/descriptor/serviceDescriptorOf|<R|BoxService|>()
+            lval result: R|kotlin/String?| = R|<local>/descriptor|.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcServiceDescriptor.callableMap: R|kotlin/collections/Map<kotlin/String, kotlinx/rpc/descriptor/RpcCallable<BoxService>>|>|.R|SubstitutionOverride<kotlin/collections/Map.get: R|kotlinx/rpc/descriptor/RpcCallable<BoxService>?|>|(String(simple))?.{ $subj$.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcCallable.name: R|kotlin/String|>| }
+            ^ when () {
+                ==(R|<local>/result|, String(simple)) ->  {
+                    String(OK)
+                }
+                else ->  {
+                    <strcat>(String(Fail: ), R|<local>/result|)
+                }
+            }
+
+        }
+        )
+    }

--- a/tests/compiler-plugin-tests/src/testData/box/serviceDescriptor.kt
+++ b/tests/compiler-plugin-tests/src/testData/box/serviceDescriptor.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// RUN_PIPELINE_TILL: BACKEND
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.rpc.descriptor.serviceDescriptorOf
+import kotlinx.rpc.annotations.Rpc
+import kotlinx.rpc.codegen.test.TestRpcClient
+import kotlinx.rpc.internal.utils.ExperimentalRpcApi
+
+@Rpc
+interface BoxService {
+    suspend fun simple(): String
+}
+
+@OptIn(ExperimentalRpcApi::class)
+fun box(): String = runBlocking {
+    val descriptor = serviceDescriptorOf<BoxService>()
+    val result = descriptor.callableMap["simple"]?.name
+
+    if (result == "simple") "OK" else "Fail: $result"
+}
+
+/* GENERATED_FIR_TAGS: functionDeclaration, interfaceDeclaration, suspend */


### PR DESCRIPTION
**Subsystem**
Descriptors.

**Problem Description**
See https://github.com/Kotlin/kotlinx-rpc/issues/496.  Despite generating a list of a descriptor's callables, it's never exposed. 

**Solution**
This PR makes the generated property public and adds a corresponding overridden property to the interface.

