### PR TITLE
Fix scope initialization on the kRPC Client

### DIFF
--- a/krpc/krpc-client/src/commonMain/kotlin/kotlinx/rpc/krpc/client/KrpcClient.kt
+++ b/krpc/krpc-client/src/commonMain/kotlin/kotlinx/rpc/krpc/client/KrpcClient.kt
@@ -217,6 +217,8 @@ public abstract class KrpcClient : RpcClient, KrpcEndpoint {
                 transport = initializeTransport()
                 isTransportReady = true
 
+                internalScope // access scope to initialize it
+
                 connector.subscribeToGenericMessages(::handleGenericMessage)
                 connector.subscribeToProtocolMessages(::handleProtocolMessage)
 


### PR DESCRIPTION
**Subsystem**
kRPC Client

**Problem Description**
Cancellation hooks were not instantiated because of the lazy scope 

**Solution**
Call scope then it should be resolved
