### PR TITLE
Preserve Flow<...> in returnType and add returnsFlow flag on RpcCallable

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -797,7 +797,7 @@ internal class RpcStubGenerator(
                 type = ctx.rpcCallable.typeWith(declaration.serviceType),
                 symbol = ctx.rpcCallableDefault.constructors.single(),
                 typeArgumentsCount = 1,
-                valueArgumentsCount = 5,
+                valueArgumentsCount = 6,
                 constructorTypeArgumentsCount = 1,
             )
         }.apply {
@@ -805,15 +805,7 @@ internal class RpcStubGenerator(
 
             callable as ServiceDeclaration.Method
 
-            val returnType = when {
-                callable.function.isNonSuspendingWithFlowReturn() -> {
-                    (callable.function.returnType as IrSimpleType).arguments.single().typeOrFail
-                }
-
-                else -> {
-                    callable.function.returnType
-                }
-            }
+            val returnType = callable.function.returnType
 
             val invokator = invokators[callable.name]
                 ?: error("Expected invokator for ${callable.name} in ${declaration.service.name}")
@@ -889,6 +881,8 @@ internal class RpcStubGenerator(
                 }
             }
 
+            val returnsFlowFlag = (callable.function.returnType.classOrNull == ctx.flow)
+
             arguments {
                 values {
                     +stringConst(callable.name)
@@ -900,6 +894,7 @@ internal class RpcStubGenerator(
                     +arrayOfCall
 
                     +booleanConst(!callable.function.isSuspend)
+                    +booleanConst(returnsFlowFlag)
                 }
             }
         }

--- a/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
@@ -56,6 +56,12 @@ public interface RpcCallable<@Rpc T : Any> {
     public val invokator: RpcInvokator<T>
     public val parameters: Array<out RpcParameter>
     public val isNonSuspendFunction: Boolean
+    /**
+     * True if the method returns Flow<...> and should be treated as a streaming return.
+     * The [returnType] remains the original declared KType (including Flow<...>),
+     * consumers can use this flag to branch logic without relying on type unwrapping.
+     */
+    public val returnsFlow: Boolean
 }
 
 @ExperimentalRpcApi

--- a/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptorDefault.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptorDefault.kt
@@ -15,6 +15,7 @@ public class RpcCallableDefault<@Rpc T : Any>(
     override val invokator: RpcInvokator<T>,
     override val parameters: Array<out RpcParameter>,
     override val isNonSuspendFunction: Boolean,
+    override val returnsFlow: Boolean,
 ) : RpcCallable<T>
 
 @InternalRpcApi


### PR DESCRIPTION
**Subsystem**
Compiler Plugin, Descriptor Core

**Problem Description**
Descriptors for RPC methods that return `Flow<T>` were exposing `returnType.kType == T`  instead of the declared `Flow<T>`.
It is issue #523 

**Solution**
Stop unwrapping `Flow<T>` to `T` in `RpcStubGenerator`, so the generated descriptor now keeps `returnType.kType == Flow<T>`. 
Add `val returnsFlow: Boolean` to `RpcCallable` and implement it in `RpcCallableDefault`; the compiler plugin sets this flag whenever the callable’s return type is a `Flow<*>`.


