### PR TITLE
grpc: Fix `retry/retryWhen` logic on rpc flow

### DIFF
--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/test/proto/GrpcEdgeCaseTest.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/test/proto/GrpcEdgeCaseTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.test.proto
+
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.test.runTest
+import kotlinx.rpc.grpc.StatusCode
+import kotlinx.rpc.grpc.StatusException
+import kotlinx.rpc.grpc.client.GrpcClient
+import kotlinx.rpc.grpc.status
+import kotlinx.rpc.grpc.statusCode
+import kotlinx.rpc.grpc.test.EchoRequest
+import kotlinx.rpc.grpc.test.EchoService
+import kotlinx.rpc.grpc.test.assertGrpcFailure
+import kotlinx.rpc.grpc.test.invoke
+import kotlinx.rpc.withService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class GrpcEdgeCaseTest {
+
+    @Test
+    fun `test flow retry - should always return the same status code`() {
+        // create a client without starting a server
+        val client = GrpcClient("localhost", 1234) {
+            credentials = plaintext()
+        }
+        assertGrpcFailure(StatusCode.UNAVAILABLE) {
+            runTest {
+                val service = client.withService<EchoService>()
+                service.ServerStreamingEcho(message = EchoRequest {
+                    message = "Echo"
+                }).retryWhen { cause, attempt ->
+                    // we expect the cause to be UNAVAILABLE for every retry
+                    println("Caused by: $cause, attempt: $attempt")
+                    assertEquals(StatusCode.UNAVAILABLE, (cause as? StatusException)?.status?.statusCode)
+                    attempt < 3
+                }.collect { println(it) }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
**Subsystem**
gRPC

**Problem Description**
The current implementation results in unexpected behavior when users call the `retry/retryWhen` API on the flow returned by a server streaming RPC service. 
```kt
myService.receiveMessages(user).retryWhen { cause, _ ->
   // retry after 2000 if server was not available
   val shouldRetry = (cause as? StatusException)?.status?.statusCode != StatusCode.UNAVAILABLE
   if (shouldRetry) delay(2000)
   shouldRetry
}
```
While one would expect that the RPC call is retried and might eventually succeed,
it will always cause an exception (even if the retried call succeeded)

**Solution**
The cause for the problem lies in the flow creation. The flow creation happens after interceptors were applied to the request and after certain states in the call scope were created.

To fix this, we wrap the call scope creation in a `flow{}`, so if the user retries this flow, it will also create a new call scope object.

