### PR TITLE
grpc: Add protoServiceName to @Grpc annotation

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcDeclarationScanner.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcDeclarationScanner.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.util.dumpKotlinLike
 import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.ir.util.hasDefaultValue
+import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.packageFqName
 
 /**
@@ -35,6 +36,10 @@ internal object RpcDeclarationScanner {
         // if the protoPackage is not set by the annotation, we use the service kotlin package name
         val protoPackage = grpcAnnotation?.arguments?.getOrNull(0)?.asConstString()
             ?: service.packageFqName?.asString() ?: ""
+
+        // if the simpleServiceName is set in the @Grpc annotation, we use it instead of the service's class name
+        val simpleName = grpcAnnotation?.arguments?.getOrNull(1)?.asConstString()
+            ?.takeIf { it.isNotBlank() } ?: service.kotlinFqName.shortName().asString()
 
         val declarations = service.declarations.memoryOptimizedMap { declaration ->
             when (declaration) {
@@ -86,6 +91,7 @@ internal object RpcDeclarationScanner {
             service = service,
             stubClass = stubClassNotNull,
             methods = declarations.filterNotNull(),
+            simpleName = simpleName,
             protoPackage = protoPackage.trim()
         )
     }

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/ServiceDeclaration.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/ServiceDeclaration.kt
@@ -21,11 +21,11 @@ internal class ServiceDeclaration(
     val service: IrClass,
     val stubClass: IrClass,
     val methods: List<Method>,
-    val protoPackage: String,
+    val simpleName: String,
+    protoPackage: String,
 ) {
     // todo change to extension after KRPC-178
     val isGrpc = service.hasAnnotation(RpcClassId.grpcAnnotation)
-    val simpleName = service.kotlinFqName.shortName().asString()
     val fqName = service.kotlinFqName.asString()
 
     // the name of the service based on the proto file (or @Grpc annotation)

--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/annotations/Grpc.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/annotations/Grpc.kt
@@ -7,11 +7,54 @@ package kotlinx.rpc.grpc.annotations
 import kotlinx.rpc.annotations.Rpc
 
 /**
- * Annotation used for marking gRPC services.
+ * Marks an interface as a gRPC service definition.
+ *
+ * The annotation supports customizing the gRPC service name and package used in the protocol.
+ * By default, the service name is derived from the interface name and the package from the Kotlin package.
+ *
+ * Example:
+ * ```kotlin
+ * @Grpc(protoPackage = "com.example.api", protoServiceName = "RpcUserService")
+ * interface UserService {
+ *     suspend fun getUser(request: GetUserRequest): User
+ *
+ *     @Grpc.Method(name = "CustomName", safe = true, idempotent = true)
+ *     suspend fun searchUsers(query: SearchQuery): SearchResults
+ * }
+ * ```
+ *
+ * @property protoPackage The Protocol Buffers package name for this service. If empty (default),
+ *   the Kotlin package name is used. This affects the fully qualified service name in gRPC
+ *   (e.g., "com.example.api.RpcUserService").
+ * @property protoServiceName The Protocol Buffers service name. If empty (default), the interface
+ *   name is used. Useful when the service name in the proto definition differs from the Kotlin
+ *   interface name, such as when multiple client/server interfaces map to the same proto service.
+ *
+ * @see Grpc.Method
+ * @see kotlinx.rpc.annotations.Rpc
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.TYPE_PARAMETER)
 @Rpc
-public annotation class Grpc(val protoPackage: String = "") {
+public annotation class Grpc(
+    val protoPackage: String = "",
+    val protoServiceName: String = ""
+) {
+    /**
+     * Configures gRPC-specific metadata for a service method.
+     *
+     * This annotation allows fine-grained control over method behavior and characteristics
+     * that affect how the gRPC method is handled by servers and clients.
+     *
+     * @property name Custom name for the gRPC method. If empty (default), the Kotlin function name is used.
+     * @property safe Indicates whether the method is safe (has no side effects). Safe methods can be
+     *   cached or retried without concern. Default is `false`.
+     * @property idempotent Indicates whether the method is idempotent (multiple identical requests have
+     *   the same effect as a single request). Idempotent methods can be safely retried. Default is `false`.
+     * @property sampledToLocalTracing Controls whether RPCs for this method may be sampled into the local
+     *   tracing store.
+     *
+     * @see Grpc
+     */
     @Target(AnnotationTarget.FUNCTION)
     public annotation class Method(
         val name: String = "",

--- a/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcServiceNameTest.kt
+++ b/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcServiceNameTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.test.integration
+
+import kotlinx.rpc.grpc.test.invoke
+import kotlinx.rpc.RpcServer
+import kotlinx.rpc.grpc.annotations.Grpc
+import kotlinx.rpc.grpc.test.EchoRequest
+import kotlinx.rpc.grpc.test.EchoResponse
+import kotlinx.rpc.registerService
+import kotlinx.rpc.withService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Grpc(protoServiceName = "TestService")
+private interface ServerService {
+    suspend fun echo(request: EchoRequest): EchoResponse
+}
+
+@Grpc(protoServiceName = "TestService")
+private interface ClientService {
+    suspend fun echo(request: EchoRequest): EchoResponse
+}
+
+class GrpcServiceNameTest : GrpcTestBase() {
+
+    override fun RpcServer.registerServices() {
+        registerService<ServerService> { object : ServerService {
+            override suspend fun echo(request: EchoRequest): EchoResponse =
+                EchoResponse { message = request.message }
+        } }
+    }
+
+    @Test
+    fun `test two service interfaces with the same name`() = runGrpcTest { client ->
+        val request = EchoRequest { message = "Hello" }
+        val response = client.withService<ClientService>().echo(request)
+        assertEquals("Hello", response.message)
+    }
+}


### PR DESCRIPTION
**Subsystem**
gRPC


**Solution**
This pull request enhances support for customizing gRPC service names via the `@Grpc` annotation. It introduces the ability to specify a custom Protocol Buffers service name (`protoServiceName`) distinct from the Kotlin interface name, and updates the code generation logic to respect this.
