### PR TITLE
Protobuf Shortest Unambiguous Names: Gradle

### DIFF
--- a/gradle-plugin/src/main/kotlin/kotlinx/rpc/protoc/DefaultProtoSourceSet.kt
+++ b/gradle-plugin/src/main/kotlin/kotlinx/rpc/protoc/DefaultProtoSourceSet.kt
@@ -79,7 +79,7 @@ internal open class DefaultProtoSourceSet(
     private val explicitApiModeEnabled = project.provider {
         val isMain = androidProperties.orNull?.isTest?.not() ?: name.lowercase().endsWith("main")
 
-        isMain && project.the<KotlinProjectExtension>().explicitApi != ExplicitApiMode.Disabled
+        isMain && project.the<KotlinProjectExtension>().explicitApi == ExplicitApiMode.Strict
     }
 
     override val plugins = project.objects.setProperty<ProtocPlugin>()
@@ -105,8 +105,11 @@ internal open class DefaultProtoSourceSet(
         })
     }
 
+    internal val platformOption = project.objects.property<String>().convention("")
+
     private fun initPlugin(copy: ProtocPlugin, configure: Action<ProtocPlugin>?) {
         copy.options.put("explicitApiModeEnabled", explicitApiModeEnabled)
+        copy.options.put("platform", platformOption)
 
         configure?.execute(copy)
     }
@@ -272,4 +275,14 @@ internal fun DefaultProtoSourceSet.protoTaskProperties(): ProtoTask.Properties {
         isTest = name.lowercase().endsWith("test"),
         sourceSetNames = setOf(name),
     )
+}
+
+internal object PlatformOption {
+    const val JVM = "jvm"
+    const val ANDROID = "android"
+    const val ANDROID_NATIVE = "android-native"
+    const val JS = "js"
+    const val NATIVE = "native"
+    const val COMMON = "common"
+    const val WASM = "wasm"
 }

--- a/gradle-plugin/src/test/kotlin/kotlinx/rpc/GrpcAndroidProjectTest.kt
+++ b/gradle-plugin/src/test/kotlin/kotlinx/rpc/GrpcAndroidProjectTest.kt
@@ -7,6 +7,7 @@
 package kotlinx.rpc
 
 import kotlinx.rpc.base.GrpcBaseTest
+import kotlinx.rpc.protoc.PlatformOption
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.TestInstance
@@ -339,6 +340,12 @@ class GrpcAndroidProjectTest : GrpcBaseTest() {
         firstRunDebug.assertOutcomes(SSetsAndroid.Default.release)
         firstRunDebug.assertOutcomes(SSetsAndroid.Default.androidTestDebug)
         firstRunDebug.assertOutcomes(SSetsAndroid.Default.testRelease)
+    }
+
+    @TestFactory
+    fun `Android Platform Option`() = runGrpcTest {
+        runPlatformOptionTest(SSetsAndroid.Default.debug, PlatformOption.ANDROID)
+        runPlatformOptionTest(SSetsAndroid.Default.testDebug, PlatformOption.ANDROID)
     }
 
     @TestFactory

--- a/gradle-plugin/src/test/kotlin/kotlinx/rpc/GrpcJvmProjectTest.kt
+++ b/gradle-plugin/src/test/kotlin/kotlinx/rpc/GrpcJvmProjectTest.kt
@@ -5,6 +5,7 @@
 package kotlinx.rpc
 
 import kotlinx.rpc.base.GrpcBaseTest
+import kotlinx.rpc.protoc.PlatformOption
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.TestInstance
@@ -150,10 +151,12 @@ plugins:
     out: myPlugin
     opt:
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
   - local: some2
     out: myPlugin2
     opt:
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
   - local: [protoc-gen-kotlin-multiplatform]
     out: kotlin-multiplatform
     opt:
@@ -162,6 +165,7 @@ plugins:
       - generateFileLevelComments=true
       - indentSize=4
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
   - local: [protoc-gen-grpc-kotlin-multiplatform]
     out: grpc-kotlin-multiplatform
     opt:
@@ -170,6 +174,7 @@ plugins:
       - generateFileLevelComments=true
       - indentSize=4
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
 inputs:
   - directory: proto
             """.trimIndent()
@@ -239,6 +244,7 @@ plugins:
       - generateFileLevelComments=true
       - indentSize=4
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
   - local: [protoc-gen-grpc-kotlin-multiplatform]
     out: grpc-kotlin-multiplatform
     opt:
@@ -247,12 +253,14 @@ plugins:
       - generateFileLevelComments=true
       - indentSize=4
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
   - local: [path, to, protoc-gen-myplugin.exe]
     out: myPlugin
     opt:
       - hello=world
       - foo=bar
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
     strategy: all
     include_imports: true
     include_wkt: false
@@ -265,6 +273,7 @@ plugins:
     opt:
       - hello=world
       - explicitApiModeEnabled=true
+      - platform=${PlatformOption.JVM}
       - only=in main
 inputs:
   - directory: proto
@@ -287,6 +296,7 @@ plugins:
       - generateFileLevelComments=true
       - indentSize=4
       - explicitApiModeEnabled=false
+      - platform=jvm
   - local: [protoc-gen-grpc-kotlin-multiplatform]
     out: grpc-kotlin-multiplatform
     opt:
@@ -295,11 +305,13 @@ plugins:
       - generateFileLevelComments=true
       - indentSize=4
       - explicitApiModeEnabled=false
+      - platform=jvm
   - remote: my.remote.plugin
     out: myRemotePlugin
     opt:
       - hello=world
       - explicitApiModeEnabled=false
+      - platform=jvm
       - only=in test
 inputs:
   - directory: proto

--- a/gradle-plugin/src/test/kotlin/kotlinx/rpc/GrpcKmpProjectTest.kt
+++ b/gradle-plugin/src/test/kotlin/kotlinx/rpc/GrpcKmpProjectTest.kt
@@ -7,7 +7,8 @@
 package kotlinx.rpc
 
 import kotlinx.rpc.base.GrpcBaseTest
-import kotlinx.rpc.base.testTestsForAndroidKmpLibExist
+import kotlinx.rpc.base.versionsWhereAndroidKmpLibExist
+import kotlinx.rpc.protoc.PlatformOption
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.TestInstance
@@ -243,7 +244,7 @@ class GrpcKmpProjectTest : GrpcBaseTest() {
 
     @TestFactory
     fun `KMP Hierarchy Android KMP Library With Test Tasks`() = runGrpcTest(
-        versionsPredicate = { testTestsForAndroidKmpLibExist() },
+        versionsPredicate = { versionsWhereAndroidKmpLibExist() },
     ) {
         runAndCheckFiles(
             SSetsKmp.AndroidKmpLib.commonMain,
@@ -285,7 +286,7 @@ class GrpcKmpProjectTest : GrpcBaseTest() {
 
     @TestFactory
     fun `KMP Hierarchy Android KMP Library With Test Tasks Not Wired`() = runGrpcTest(
-        versionsPredicate = { testTestsForAndroidKmpLibExist() },
+        versionsPredicate = { versionsWhereAndroidKmpLibExist() },
     ) {
         runAndCheckFiles(
             SSetsKmp.AndroidKmpLib.commonMain,
@@ -969,7 +970,7 @@ class GrpcKmpProjectTest : GrpcBaseTest() {
 
     @TestFactory
     fun `Proto Tasks Are Cached Properly Android KMP Library`() = runGrpcTest(
-        versionsPredicate = { testTestsForAndroidKmpLibExist() }
+        versionsPredicate = { versionsWhereAndroidKmpLibExist() }
     ) {
         val firstRunCommonMain = runForSet(SSetsKmp.AndroidKmpLib.commonMain)
 
@@ -1474,6 +1475,35 @@ class GrpcKmpProjectTest : GrpcBaseTest() {
     }
 
     @TestFactory
+    fun `Platform Options`() = runGrpcTest {
+        runPlatformOptionTest(SSetsKmp.Default.commonMain, PlatformOption.COMMON)
+        runPlatformOptionTest(SSetsKmp.Default.jvmMain, PlatformOption.JVM)
+        runPlatformOptionTest(SSetsKmp.Default.wasmJsMain, PlatformOption.JS)
+        runPlatformOptionTest(SSetsKmp.Default.wasmJsMain, PlatformOption.JS)
+        runPlatformOptionTest(SSetsKmp.Default.wasmWasiMain, PlatformOption.WASM)
+        runPlatformOptionTest(SSetsKmp.Default.nativeMain, PlatformOption.NATIVE)
+    }
+
+    @TestFactory
+    fun `Platform Options Android KMP Library`() = runGrpcTest(
+        versionsPredicate = { versionsWhereAndroidKmpLibExist() }
+    ) {
+        runPlatformOptionTest(SSetsKmp.AndroidKmpLib.commonMain, PlatformOption.COMMON)
+        runPlatformOptionTest(SSetsKmp.AndroidKmpLib.jvmMain, PlatformOption.JVM)
+        runPlatformOptionTest(SSetsKmp.AndroidKmpLib.androidMain, PlatformOption.ANDROID)
+        runPlatformOptionTest(SSetsKmp.AndroidKmpLib.androidHostTest, PlatformOption.ANDROID)
+        runPlatformOptionTest(SSetsKmp.AndroidKmpLib.androidDeviceTest, PlatformOption.ANDROID)
+    }
+
+    @TestFactory
+    fun `Platform Options Legacy Android`() = runGrpcTest {
+        runPlatformOptionTest(SSetsKmp.LegacyAndroid.commonMain, PlatformOption.COMMON)
+        runPlatformOptionTest(SSetsKmp.LegacyAndroid.jvmMain, PlatformOption.JVM)
+        runPlatformOptionTest(SSetsKmp.LegacyAndroid.androidDebug, PlatformOption.ANDROID)
+        runPlatformOptionTest(SSetsKmp.LegacyAndroid.androidInstrumentedTestDebug, PlatformOption.ANDROID)
+    }
+
+    @TestFactory
     fun `Buf Tasks`() = runGrpcTest {
         runGradle("test_tasks", "--no-configuration-cache")
     }
@@ -1485,7 +1515,7 @@ class GrpcKmpProjectTest : GrpcBaseTest() {
 
     @TestFactory
     fun `Buf Tasks Android Kmp Library With Test Tasks`() = runGrpcTest(
-        versionsPredicate = { testTestsForAndroidKmpLibExist() }
+        versionsPredicate = { versionsWhereAndroidKmpLibExist() }
     ) {
         runGradle("test_tasks", "--no-configuration-cache")
     }

--- a/gradle-plugin/src/test/kotlin/kotlinx/rpc/base/GrpcBaseTest.kt
+++ b/gradle-plugin/src/test/kotlin/kotlinx/rpc/base/GrpcBaseTest.kt
@@ -394,6 +394,39 @@ abstract class GrpcBaseTest : BaseTest() {
             )
         }
 
+        fun runPlatformOptionTest(sourceSet: SSets, platformOption: String) {
+            runGradle(generateBufGenYaml(sourceSet))
+
+            assertBufGenYaml(
+                sourceSet = sourceSet,
+                content = """
+version: v2
+clean: true
+plugins:
+  - local: [protoc-gen-kotlin-multiplatform]
+    out: kotlin-multiplatform
+    opt:
+      - debugOutput=protoc-gen-kotlin-multiplatform.log
+      - generateComments=true
+      - generateFileLevelComments=true
+      - indentSize=4
+      - explicitApiModeEnabled=false
+      - platform=${platformOption}
+  - local: [protoc-gen-grpc-kotlin-multiplatform]
+    out: grpc-kotlin-multiplatform
+    opt:
+      - debugOutput=protoc-gen-grpc-kotlin-multiplatform.log
+      - generateComments=true
+      - generateFileLevelComments=true
+      - indentSize=4
+      - explicitApiModeEnabled=false
+      - platform=${platformOption}
+inputs:
+  - directory: proto
+            """.trimIndent()
+            )
+        }
+
         fun bufGenerate(sourceSet: SSets) = "bufGenerate${sourceSet.capital}"
         fun processProtoFiles(sourceSet: SSets) = "process${sourceSet.capital}ProtoFiles"
         fun processProtoFilesImports(sourceSet: SSets) = "process${sourceSet.capital}ProtoFilesImports"
@@ -494,6 +527,8 @@ abstract class GrpcBaseTest : BaseTest() {
             jvmMain(ctm.k), jvmTest(ctm.k),
             webMain(minKotlin = KtVersion.v2_2_20), webTest(minKotlin = KtVersion.v2_2_20),
             jsMain(ctm.k), jsTest(ctm.k),
+            wasmJsMain(ctm.k), wasmJsTest(ctm.k),
+            wasmWasiMain(ctm.k), wasmWasiTest(ctm.k),
             nativeMain, nativeTest,
             appleMain, appleTest,
             macosMain, macosTest,

--- a/gradle-plugin/src/test/resources/projects/GrpcAndroidProjectTest/android_platform_option/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/projects/GrpcAndroidProjectTest/android_platform_option/build.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import org.gradle.kotlin.dsl.version
+
+plugins {
+    id("com.android.application") version "<android-version>"
+    kotlin("android") version "<kotlin-version>"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "<rpc-version>"
+}
+
+rpc {
+    protoc()
+}
+
+android {
+    namespace = "com.example.myapp"
+    compileSdk = 34
+}

--- a/gradle-plugin/src/test/resources/projects/GrpcKmpProjectTest/platform_options/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/projects/GrpcKmpProjectTest/platform_options/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import org.gradle.kotlin.dsl.version
+
+plugins {
+    kotlin("multiplatform") version "<kotlin-version>"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "<rpc-version>"
+}
+
+kotlin {
+    jvm()
+
+    js {
+        nodejs()
+    }
+
+    wasmJs {
+        nodejs()
+    }
+
+    wasmWasi {
+        nodejs()
+    }
+
+    macosArm64()
+}
+
+rpc {
+    protoc()
+}

--- a/gradle-plugin/src/test/resources/projects/GrpcKmpProjectTest/platform_options_android_kmp_library/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/projects/GrpcKmpProjectTest/platform_options_android_kmp_library/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import org.gradle.kotlin.dsl.version
+
+plugins {
+    kotlin("multiplatform") version "<kotlin-version>"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "<rpc-version>"
+    id("com.android.kotlin.multiplatform.library") version "<android-version>"
+}
+
+kotlin {
+    jvm()
+    androidLibrary {
+        namespace = "com.example.namespace"
+        compileSdk = 34
+
+        withDeviceTestBuilder {
+            sourceSetTreeName = "test"
+        }
+
+        withHostTestBuilder {
+            sourceSetTreeName = "test"
+        }
+    }
+}
+
+rpc {
+    protoc()
+}

--- a/gradle-plugin/src/test/resources/projects/GrpcKmpProjectTest/platform_options_legacy_android/build.gradle.kts
+++ b/gradle-plugin/src/test/resources/projects/GrpcKmpProjectTest/platform_options_legacy_android/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+import org.gradle.kotlin.dsl.version
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
+
+plugins {
+    kotlin("multiplatform") version "<kotlin-version>"
+    id("org.jetbrains.kotlinx.rpc.plugin") version "<rpc-version>"
+    id("com.android.application") version "<android-version>"
+}
+
+kotlin {
+    jvm()
+
+    androidTarget {
+        instrumentedTestVariant {
+            sourceSetTree.set(KotlinSourceSetTree.test)
+        }
+
+        unitTestVariant {
+            sourceSetTree.set(KotlinSourceSetTree.test)
+        }
+    }
+}
+
+android {
+    namespace = "com.example.myapp"
+    compileSdk = 34
+}
+
+rpc {
+    protoc()
+}


### PR DESCRIPTION
**Subsystem**
Gradle Plugin

**ToC**
This is part 2/3 for the feature
 - [x] Add implicit imports
 - [x] Add Gradle plugin support for platforms
 - [ ] Update codegen to use new scoped strings

**Problem Description**
For properly resolving platform's implicit imports we need to know for which platform the generation is currently in progress.

**Solution**
Detect platforms in build time and pass an option to the protoc-gen plugins
