### PR TITLE
pb: Add well-known Any extension functions

### DIFF
--- a/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/WithCodec.kt
+++ b/grpc/grpc-codec/src/commonMain/kotlin/kotlinx/rpc/grpc/codec/WithCodec.kt
@@ -59,7 +59,7 @@ public expect annotation class WithCodec(val codec: KClass<out MessageCodec<*>>)
  */
 @InternalRpcApi
 @CheckedTypeAnnotation(WithCodec::class)
-@Target(AnnotationTarget.TYPE_PARAMETER)
+@Target(AnnotationTarget.TYPE_PARAMETER, AnnotationTarget.CLASS)
 public annotation class HasWithCodec
 
 /**
@@ -117,11 +117,11 @@ public inline fun <@HasWithCodec reified T: Any> codec(config: CodecConfig? = nu
  * @see MessageCodec
  * @see CodecConfig
  */
-@Suppress("UNCHECKED_CAST")
 public fun <@HasWithCodec T: Any> codec(messageType: KType, config: CodecConfig? = null): MessageCodec<T> {
     val classifier = messageType.classifier ?: error("Expected denotable type, found $messageType")
     val classifierClass = classifier as? KClass<*> ?: error("Expected class type, found $messageType")
 
+    @Suppress("UNCHECKED_CAST")
     return codec(classifierClass as KClass<T>, config)
 }
 

--- a/protobuf/protobuf-core/src/commonMain/kotlin/kotlinx/rpc/protobuf/GeneratedProtoMessage.kt
+++ b/protobuf/protobuf-core/src/commonMain/kotlin/kotlinx/rpc/protobuf/GeneratedProtoMessage.kt
@@ -5,8 +5,10 @@
 package kotlinx.rpc.protobuf
 
 import kotlinx.rpc.annotations.CheckedTypeAnnotation
+import kotlinx.rpc.grpc.codec.HasWithCodec
 import kotlinx.rpc.internal.utils.InternalRpcApi
 
+@HasWithCodec
 @InternalRpcApi
 @CheckedTypeAnnotation
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE_PARAMETER)

--- a/protobuf/protobuf-core/src/commonMain/kotlin/kotlinx/rpc/protobuf/internal/ProtoDescriptor.kt
+++ b/protobuf/protobuf-core/src/commonMain/kotlin/kotlinx/rpc/protobuf/internal/ProtoDescriptor.kt
@@ -8,6 +8,7 @@ import kotlinx.rpc.internal.internalRpcError
 import kotlinx.rpc.internal.utils.InternalRpcApi
 import kotlinx.rpc.protobuf.GeneratedProtoMessage
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 /**
  * Added by the compiler plugin to proto message classes to associate them with their descriptor.
@@ -25,6 +26,14 @@ public interface ProtoDescriptor<@GeneratedProtoMessage Message: Any> {
 }
 
 internal inline fun <@GeneratedProtoMessage reified T: Any> protoDescriptorOf(): ProtoDescriptor<T> = protoDescriptorOf(T::class)
+
+internal fun <@GeneratedProtoMessage T: Any> protoDescriptorOf(kType: KType): ProtoDescriptor<T> {
+    val classifier = kType.classifier ?: error("Expected denotable type, found $kType")
+    val classifierClass = classifier as? KClass<*> ?: error("Expected class type, found $kType")
+
+    @Suppress("UNCHECKED_CAST")
+    return protoDescriptorOf(classifierClass as KClass<T>)
+}
 
 internal fun <@GeneratedProtoMessage T: Any> protoDescriptorOf(clazz: KClass<T>): ProtoDescriptor<T> {
     val maybeDescriptor = findProtoDescriptorOf(clazz)

--- a/protobuf/protobuf-core/src/commonTest/kotlin/kotlinx/rpc/protobuf/test/AnyExtensionTest.kt
+++ b/protobuf/protobuf-core/src/commonTest/kotlin/kotlinx/rpc/protobuf/test/AnyExtensionTest.kt
@@ -7,6 +7,7 @@ package kotlinx.rpc.protobuf.test
 import Outer
 import com.google.protobuf.kotlin.pack
 import com.google.protobuf.kotlin.unpack
+import com.google.protobuf.kotlin.unpackOrNull
 import com.google.protobuf.kotlin.Any
 import com.google.protobuf.kotlin.Duration
 import com.google.protobuf.kotlin.Empty
@@ -24,6 +25,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AnyExtensionTest {
@@ -193,5 +196,25 @@ class AnyExtensionTest {
         val innerUnpacked = innerPacked.unpack<NestedOuter.Inner.SuperInner.DuperInner.EvenMoreInner.CantBelieveItsSoInner>()
         assertEquals(987654, innerUnpacked.num)
         assertEquals("type.googleapis.com/test.nested.NestedOuter.Inner.SuperInner.DuperInner.EvenMoreInner.CantBelieveItsSoInner", innerPacked.typeUrl)
+    }
+
+    @Test
+    fun testUnpackOrNull() {
+        val original = AllPrimitives {
+            int32 = 42
+            string = "test"
+        }
+
+        val packed = Any.pack(original)
+
+        // Test successful unpack
+        val unpacked = packed.unpackOrNull<AllPrimitives>()
+        assertNotNull(unpacked)
+        assertEquals(original.int32, unpacked.int32)
+        assertEquals(original.string, unpacked.string)
+
+        // Test failed unpack returns null instead of throwing
+        val wrongType = packed.unpackOrNull<Timestamp>()
+        assertNull(wrongType)
     }
 }


### PR DESCRIPTION
**Subsystem**
Protobuf

**Problem Description**
Protobuf libraries provide special functions for the well-known `com.google.protobuf.Any` message type.

**Solution**
This PR adds the following extension functions:

```kotlin
fun <@GeneratedProtoMessage reified T: kotlin.Any> Any.contains(): Boolean
fun <@GeneratedProtoMessage @HasWithCodec reified T : kotlin.Any> Any.Companion.pack(
    value: T,
    urlPrefix: String = "type.googleapis.com",
): Any
fun <@GeneratedProtoMessage @HasWithCodec reified T : kotlin.Any> Any.unpack(): T 
```

which makes it easy to unpack and pack the Any message:
```kotlin
val any = com.google.protobuf.kotlin.Any.pack(Timestamp { seconds = 123 })
if (any.contains<Timestamp>()) {
    val timestamp = any.unpack<Timestamp>()
}
```

