### PR TITLE
setup: Add Kotlin Konan toolchain paths

### DIFF
--- a/cinterop-c/toolchain/konan_llvm_bundles.json
+++ b/cinterop-c/toolchain/konan_llvm_bundles.json
@@ -1,11 +1,43 @@
 {
+  "2.1.0": {
+    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-63"
+  },
+  "2.1.10": {
+    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-63"
+  },
+  "2.1.20": {
+    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-63"
+  },
+  "2.1.21": {
+    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-65"
+  },
+  "2.2.0": {
+    "linux-x86_64": "llvm-19-x86_64-linux-essentials-100",
+    "macos-aarch64": "llvm-19-aarch64-macos-essentials-74",
+    "macos-x86_64": "llvm-19-x86_64-macos-essentials-71"
+  },
+  "2.2.10": {
+    "linux-x86_64": "llvm-19-x86_64-linux-essentials-103",
+    "macos-aarch64": "llvm-19-aarch64-macos-essentials-75",
+    "macos-x86_64": "llvm-19-x86_64-macos-essentials-72"
+  },
+  "2.2.20": {
+    "linux-x86_64": "llvm-19-x86_64-linux-essentials-103",
+    "macos-aarch64": "llvm-19-aarch64-macos-essentials-79",
+    "macos-x86_64": "llvm-19-x86_64-macos-essentials-75"
+  },
+  "2.2.21": {
+    "linux-x86_64": "llvm-19-x86_64-linux-essentials-103",
+    "macos-aarch64": "llvm-19-aarch64-macos-essentials-79",
+    "macos-x86_64": "llvm-19-x86_64-macos-essentials-75"
+  },
   "2.3.0": {
     "linux-x86_64": "llvm-19-x86_64-linux-essentials-103",
     "macos-aarch64": "llvm-19-aarch64-macos-essentials-79",
     "macos-x86_64": "llvm-19-x86_64-macos-essentials-75"
   },
   "_metadata": {
-    "generated_at": "2026-02-19T13:18:52Z",
+    "generated_at": "2026-02-25T16:33:11Z",
     "source": "https://raw.githubusercontent.com/JetBrains/kotlin/v<kotlin-version>/kotlin-native/gradle.properties",
     "supported_hosts": [
       "linux-x86_64",

--- a/cinterop-c/toolchain/precompute_konan_llvm_bundles.py
+++ b/cinterop-c/toolchain/precompute_konan_llvm_bundles.py
@@ -47,12 +47,12 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def parse_versions_file(path: Path) -> str | None:
-    """Extract kotlin-lang value from versions-root/libs.versions.toml."""
+def parse_versions_file(path: Path) -> tuple[str | None, str | None]:
+    """Extract kotlin-compiler and kotlin-lang values from versions-root/libs.versions.toml. """
     kotlin_lang: str | None = None
-    # Keep parsing intentionally narrow to avoid requiring a TOML dependency:
-    # this script only needs kotlin-lang from versions-root/libs.versions.toml.
+    kotlin_compiler: str | None = None
     kotlin_lang_re = re.compile(r'^\s*kotlin-lang\s*=\s*"([^"]+)"\s*$')
+    kotlin_compiler_re = re.compile(r'^\s*kotlin-compiler\s*=\s*"([^"]+)"\s*$')
 
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         line = raw_line.split("#", 1)[0].strip()
@@ -62,17 +62,22 @@ def parse_versions_file(path: Path) -> str | None:
         kotlin_lang_match = kotlin_lang_re.match(line)
         if kotlin_lang_match:
             kotlin_lang = kotlin_lang_match.group(1)
-    return kotlin_lang
+            continue
+
+        kotlin_compiler_match = kotlin_compiler_re.match(line)
+        if kotlin_compiler_match:
+            kotlin_compiler = kotlin_compiler_match.group(1)
+
+    return kotlin_lang, kotlin_compiler
 
 
 def resolve_default_kotlin_compiler_version(repo_root: Path) -> str:
     """Resolve the default compiler version, honoring env overrides and project fallback rules."""
     versions_file = repo_root / "versions-root" / "libs.versions.toml"
-    parsed_kotlin_lang = parse_versions_file(versions_file)
+    parsed_kotlin_lang, parsed_kotlin_compiler = parse_versions_file(versions_file)
 
     kotlin_lang = os.getenv("KOTLIN_VERSION") or parsed_kotlin_lang
-    # Ignore kotlin-compiler from TOML and default to kotlin-lang unless explicitly overridden.
-    kotlin_compiler = os.getenv("KOTLIN_COMPILER_VERSION") or kotlin_lang
+    kotlin_compiler = os.getenv("KOTLIN_COMPILER_VERSION") or parsed_kotlin_compiler
 
     if not kotlin_lang:
         raise RuntimeError("Unable to resolve kotlin-lang version")

--- a/cinterop-c/toolchain/resolve_konan_llvm_resource_dir.py
+++ b/cinterop-c/toolchain/resolve_konan_llvm_resource_dir.py
@@ -80,14 +80,14 @@ def main() -> int:
     if not isinstance(version_entry, dict):
         fail(
             f"Missing precomputed LLVM mapping for Kotlin compiler version {kotlin_version}. "
-            f"Run ./toolchain/precompute_konan_llvm_bundles.py {kotlin_version} and commit {map_file.name}."
+            f"Run `./toolchain/precompute_konan_llvm_bundles.py {kotlin_version}` and commit {map_file.name}."
         )
 
     bundle_name = version_entry.get(host_tuple)
     if not isinstance(bundle_name, str) or not bundle_name:
         fail(
             f"Mapping for Kotlin compiler version {kotlin_version} does not contain host tuple {host_tuple}. "
-            f"Run ./toolchain/precompute_konan_llvm_bundles.py {kotlin_version} and commit {map_file.name}."
+            f"Run `./toolchain/precompute_konan_llvm_bundles.py {kotlin_version}` and commit {map_file.name}."
         )
 
     bundle_dir = konan_deps / bundle_name


### PR DESCRIPTION
Add the Kotlin 2.1.0 konan path to the `konan_llvm_bundles.json`, so it is possible to sync the project in IDE when working on the compiler-plugin.
