### PR TITLE
KRPC-219 Add grpc-marshaller dependency to protobuf-core

### DIFF
--- a/protobuf/protobuf-core/build.gradle.kts
+++ b/protobuf/protobuf-core/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
             dependencies {
                 api(projects.protobuf.protobufApi)
                 api(projects.protobuf.protobufWkt)
+                api(projects.grpc.grpcMarshaller)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add `grpc-marshaller` as an `api` dependency of `protobuf-core` so generated protobuf code can resolve `MessageMarshaller` and `MarshallerConfig` without requiring users to add the dependency manually.

## Test plan
- [x] `./gradlew jvmTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)