### PR TITLE
pb: Use static defaults for generated protobuf messages (KRPC-520)

### DIFF
--- a/protobuf/protobuf-api/src/commonMain/kotlin/kotlinx/rpc/protobuf/internal/InternalExtensionDescriptor.kt
+++ b/protobuf/protobuf-api/src/commonMain/kotlin/kotlinx/rpc/protobuf/internal/InternalExtensionDescriptor.kt
@@ -480,35 +480,41 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
             asInternal: (V) -> InternalMessage,
             encodeWith: (V, WireEncoder, ProtoConfig?) -> Unit,
             decodeWith: (V, WireDecoder, ProtoConfig?) -> Unit
-        ): InternalExtensionDescriptor<T, V> = InternalExtensionDescriptor(
-            fieldNumber = fieldNumber,
-            name = name,
-            wireType = WireType.LENGTH_DELIMITED,
-            messageType = extendee,
-            valueType = valueType,
-            defaultValue = lazy { default() },
-            size = { fieldNr, value ->
-                val size = asInternal(value.encodingCast(valueType))._size
-                WireSize.tag(fieldNr, WireType.LENGTH_DELIMITED) + WireSize.uInt32(size.toUInt()) + size
-            },
-            encode = { enc, fieldNr, value, config ->
-                val value = value.encodingCast(valueType)
-                val internal = asInternal(value)
-                enc.writeMessage(fieldNr, internal) { encodeWith(value, it, config) }
-            },
-            decode = { currentMessage, dec, config ->
-                val msg = currentMessage?.let { valueType.cast(it) } ?: run { default() }
-                val internal = asInternal(msg)
-                dec.readMessage(internal) { _, dec ->
-                    decodeWith(msg, dec, config)
+        ): InternalExtensionDescriptor<T, V> {
+            val sharedDefault = lazy(default)
+            return InternalExtensionDescriptor(
+                fieldNumber = fieldNumber,
+                name = name,
+                wireType = WireType.LENGTH_DELIMITED,
+                messageType = extendee,
+                valueType = valueType,
+                defaultValue = sharedDefault,
+                size = { fieldNr, value ->
+                    val size = asInternal(value.encodingCast(valueType))._size
+                    WireSize.tag(fieldNr, WireType.LENGTH_DELIMITED) + WireSize.uInt32(size.toUInt()) + size
+                },
+                encode = { enc, fieldNr, value, config ->
+                    val value = value.encodingCast(valueType)
+                    val internal = asInternal(value)
+                    enc.writeMessage(fieldNr, internal) { encodeWith(value, it, config) }
+                },
+                decode = { currentMessage, dec, config ->
+                    val msg = currentMessage?.let { valueType.cast(it) } ?: run {
+                        @Suppress("UNCHECKED_CAST")
+                        asInternal(sharedDefault.value).copyInternal() as V
+                    }
+                    val internal = asInternal(msg)
+                    dec.readMessage(internal) { _, dec ->
+                        decodeWith(msg, dec, config)
+                    }
+                    msg
+                },
+                copy = {
+                    @Suppress("UNCHECKED_CAST")
+                    asInternal(it.encodingCast(valueType)).copyInternal() as V
                 }
-                msg
-            },
-            copy = {
-                @Suppress("UNCHECKED_CAST")
-                asInternal(it.encodingCast(valueType)).copyInternal() as V
-            }
-        )
+            )
+        }
 
         public fun <@GeneratedProtoMessage T : Any, V : Any> group(
             fieldNumber: Int,
@@ -519,38 +525,44 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
             asInternal: (V) -> InternalMessage,
             encodeWith: (V, WireEncoder, ProtoConfig?) -> Unit,
             decodeWith: (V, WireDecoder, ProtoConfig?, KTag?) -> Unit,
-        ): InternalExtensionDescriptor<T, V> = InternalExtensionDescriptor(
-            fieldNumber = fieldNumber,
-            name = name,
-            wireType = WireType.START_GROUP,
-            messageType = extendee,
-            valueType = valueType,
-            defaultValue = lazy { default() },
-            size = { fieldNr, value ->
-                val groupSize = asInternal(value.encodingCast(valueType))._size
-                WireSize.tag(fieldNr, WireType.START_GROUP) +
-                    groupSize +
-                    WireSize.tag(fieldNr, WireType.END_GROUP)
-            },
-            encode = { enc, fieldNr, value, config ->
-                val value = value.encodingCast(valueType)
-                val internal = asInternal(value)
-                enc.writeGroupMessage(fieldNr, internal) { encodeWith(value, it, config) }
-            },
-            decode = { currentMessage, dec, config ->
-                val msg = currentMessage?.let { valueType.cast(it) } ?: run { default() }
-                val internal = asInternal(msg)
-                val startGroup = KTag(fieldNumber, WireType.START_GROUP)
-                dec.readGroup(internal) { _, decoder ->
-                    decodeWith(msg, decoder, config, startGroup)
+        ): InternalExtensionDescriptor<T, V> {
+            val sharedDefault = lazy(default)
+            return InternalExtensionDescriptor(
+                fieldNumber = fieldNumber,
+                name = name,
+                wireType = WireType.START_GROUP,
+                messageType = extendee,
+                valueType = valueType,
+                defaultValue = sharedDefault,
+                size = { fieldNr, value ->
+                    val groupSize = asInternal(value.encodingCast(valueType))._size
+                    WireSize.tag(fieldNr, WireType.START_GROUP) +
+                        groupSize +
+                        WireSize.tag(fieldNr, WireType.END_GROUP)
+                },
+                encode = { enc, fieldNr, value, config ->
+                    val value = value.encodingCast(valueType)
+                    val internal = asInternal(value)
+                    enc.writeGroupMessage(fieldNr, internal) { encodeWith(value, it, config) }
+                },
+                decode = { currentMessage, dec, config ->
+                    val msg = currentMessage?.let { valueType.cast(it) } ?: run {
+                        @Suppress("UNCHECKED_CAST")
+                        asInternal(sharedDefault.value).copyInternal() as V
+                    }
+                    val internal = asInternal(msg)
+                    val startGroup = KTag(fieldNumber, WireType.START_GROUP)
+                    dec.readGroup(internal) { _, decoder ->
+                        decodeWith(msg, decoder, config, startGroup)
+                    }
+                    msg
+                },
+                copy = {
+                    @Suppress("UNCHECKED_CAST")
+                    asInternal(it.encodingCast(valueType)).copyInternal() as V
                 }
-                msg
-            },
-            copy = {
-                @Suppress("UNCHECKED_CAST")
-                asInternal(it.encodingCast(valueType)).copyInternal() as V
-            }
-        )
+            )
+        }
 
         public fun <@GeneratedProtoMessage T : Any, E : Any> repeated(
             elementDescriptor: InternalExtensionDescriptor<T, E>,
@@ -558,6 +570,7 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
         ): InternalExtensionDescriptor<T, List<E>> {
             @Suppress("UNCHECKED_CAST")
             val listType = List::class as KClass<List<E>>
+            val sharedDefault = lazy(defaultValue)
 
             return InternalExtensionDescriptor(
                 fieldNumber = elementDescriptor.fieldNumber,
@@ -565,7 +578,7 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
                 wireType = elementDescriptor.wireType,
                 messageType = elementDescriptor.messageType,
                 valueType = listType,
-                defaultValue = lazy(defaultValue),
+                defaultValue = sharedDefault,
                 size = { _, value ->
                     // Non-packed repeated extensions write one field occurrence per element.
                     listType.cast(value).sumOf { rawElement ->
@@ -580,7 +593,7 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
                 decode = { currentValue, dec, config ->
                     val result = currentValue
                         ?.let { listType.cast(it) as MutableList }
-                        ?: defaultValue().toMutableList()
+                        ?: sharedDefault.value.toMutableList()
                     result += elementDescriptor.decode(null, dec, config)
                     result
                 },
@@ -608,6 +621,7 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
             @Suppress("UNCHECKED_CAST")
             val listType = List::class as KClass<List<E>>
             val elementTagSize = WireSize.tag(elementDescriptor.fieldNumber, elementDescriptor.wireType)
+            val sharedDefault = lazy(defaultValue)
 
             return InternalExtensionDescriptor(
                 fieldNumber = elementDescriptor.fieldNumber,
@@ -616,7 +630,7 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
                 acceptedWireTypes = setOf(WireType.LENGTH_DELIMITED, elementDescriptor.wireType),
                 messageType = elementDescriptor.messageType,
                 valueType = listType,
-                defaultValue = lazy(defaultValue),
+                defaultValue = sharedDefault,
                 size = { _, value ->
                     val elements = listType.cast(value)
                     if (elements.isEmpty()) {
@@ -639,14 +653,14 @@ public class InternalExtensionDescriptor<@GeneratedProtoMessage T : Any, V : Any
                 decode = { currentValue, dec, config ->
                     val result = currentValue
                         ?.let { listType.cast(it) as MutableList }
-                        ?: defaultValue().toMutableList()
+                        ?: sharedDefault.value.toMutableList()
                     result += elementDescriptor.decode(null, dec, config)
                     result
                 },
                 decodePacked = { currentValue, dec, _ ->
                     val result = currentValue
                         ?.let { listType.cast(it) as MutableList }
-                        ?: defaultValue().toMutableList()
+                        ?: sharedDefault.value.toMutableList()
                     result += decodePackedValues(dec)
                     result
                 },

--- a/protobuf/protobuf-api/src/commonMain/kotlin/kotlinx/rpc/protobuf/internal/InternalMessage.kt
+++ b/protobuf/protobuf-api/src/commonMain/kotlin/kotlinx/rpc/protobuf/internal/InternalMessage.kt
@@ -91,11 +91,23 @@ public class MsgFieldDelegate<T>(
     private var valueSet = false
     private var value: T? = null
 
+    private fun storeValue(thisRef: InternalMessage, value: T) {
+        presenceIdx?.let { thisRef.presenceMask[it] = true }
+        this.value = value
+        valueSet = true
+    }
+
+    override operator fun setValue(thisRef: InternalMessage, property: KProperty<*>, value: T) {
+        storeValue(thisRef, value)
+    }
+
+    /**
+     * Returns the set value or the default if not set.
+     */
     override operator fun getValue(thisRef: InternalMessage, property: KProperty<*>): T {
         if (!valueSet) {
             if (defaultProvider != null) {
-                value = defaultProvider.invoke()
-                valueSet = true
+                return defaultProvider.invoke()
             } else {
                 error("Property ${property.name} not initialized")
             }
@@ -104,10 +116,18 @@ public class MsgFieldDelegate<T>(
         return value as T
     }
 
-    override operator fun setValue(thisRef: InternalMessage, property: KProperty<*>, value: T) {
-        presenceIdx?.let { thisRef.presenceMask[it] = true }
-        this@MsgFieldDelegate.value = value
-        valueSet = true
+    /**
+     * Gets the value if set, otherwise create a new instance from the [factory].
+     * This is used during decoding to create a new instance or merge with the existing one.
+     * It will also set the presence of the field.
+     */
+    public fun getOrCreate(thisRef: InternalMessage, factory: () -> T): T {
+        if (!valueSet) {
+            storeValue(thisRef, factory())
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return value as T
     }
 }
 

--- a/protobuf/protobuf-api/src/commonTest/kotlin/kotlinx/rpc/protobuf/test/ProtoExtensionTest.kt
+++ b/protobuf/protobuf-api/src/commonTest/kotlin/kotlinx/rpc/protobuf/test/ProtoExtensionTest.kt
@@ -192,6 +192,29 @@ class ProtoExtensionTest {
     }
 
     @Test
+    fun `test extension default instance is not mutated during decoding`() {
+        val registry = ProtoExtensionRegistry {
+            +ExtensionBase.msg
+        }
+        val codec = grpcMarshallerOf<ExtensionBase>(ProtoConfig(extensionRegistry = registry))
+        val populated = ExtensionBase {
+            msg = AllPrimitives {
+                int32 = 123
+                requiredString = "required"
+                requiredBytes = byteArrayOf(1).asByteString()
+            }
+        }
+
+        val decodedPopulated = codec.decode(grpcMarshallerOf<ExtensionBase>().encode(populated))
+        assertEquals(123, decodedPopulated.msg.int32)
+
+        val decodedEmpty = codec.decode(Buffer())
+        assertEquals(0, decodedEmpty.msg.int32)
+        assertEquals("", decodedEmpty.msg.requiredString)
+        assertByteStringContentEquals(byteArrayOf(), decodedEmpty.msg.requiredBytes)
+    }
+
+    @Test
     fun `test extension message decode with missing extension`() {
         val message = completeMessage()
         val codec = grpcMarshallerOf<ExtensionBase>()

--- a/protobuf/protobuf-api/src/commonTest/kotlin/kotlinx/rpc/protobuf/test/ProtosTest.kt
+++ b/protobuf/protobuf-api/src/commonTest/kotlin/kotlinx/rpc/protobuf/test/ProtosTest.kt
@@ -383,6 +383,55 @@ class ProtosTest {
         assertEquals("fourth", decoded.other.arg3)
     }
 
+    @Test
+    fun testSharedDefaultsAreNotMutatedDuringDecoding() {
+        val referenceMarshaller = grpcMarshallerOf<Reference>()
+        val populatedReference = Reference {
+            other = Other {
+                arg1 = "first"
+                arg2 = "second"
+            }
+        }
+
+        val decodedReference = encodeDecode(populatedReference, referenceMarshaller)
+        assertEquals("first", decodedReference.other.arg1)
+        assertEquals("second", decodedReference.other.arg2)
+
+        val emptyReference = referenceMarshaller.decode(Buffer())
+        assertNull(emptyReference.other.arg1)
+        assertNull(emptyReference.other.arg2)
+        assertNull(emptyReference.other.arg3)
+
+        val repeatedMarshaller = grpcMarshallerOf<Repeated>()
+        val populatedRepeated = Repeated {
+            listInt32 = listOf(1, 2, 3)
+            listMessage = listOf(Repeated.Other { a = 7 })
+        }
+
+        val decodedRepeated = encodeDecode(populatedRepeated, repeatedMarshaller)
+        assertEquals(listOf(1, 2, 3), decodedRepeated.listInt32)
+        assertEquals(1, decodedRepeated.listMessage.size)
+        assertEquals(7, decodedRepeated.listMessage.single().a)
+
+        val emptyRepeated = repeatedMarshaller.decode(Buffer())
+        assertTrue(emptyRepeated.listInt32.isEmpty())
+        assertTrue(emptyRepeated.listMessage.isEmpty())
+
+        val mapMarshaller = grpcMarshallerOf<TestMap>()
+        val populatedMap = TestMap {
+            primitives = mapOf("one" to 1L)
+            messages = mapOf(1 to PresenceCheck { RequiredPresence = 7 })
+        }
+
+        val decodedMap = encodeDecode(populatedMap, mapMarshaller)
+        assertEquals(mapOf("one" to 1L), decodedMap.primitives)
+        assertEquals(7, decodedMap.messages.getValue(1).RequiredPresence)
+
+        val emptyMap = mapMarshaller.decode(Buffer())
+        assertTrue(emptyMap.primitives.isEmpty())
+        assertTrue(emptyMap.messages.isEmpty())
+    }
+
 
     @Test
     fun testMap() {

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Any.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Any.kt
@@ -37,8 +37,10 @@ public class AnyInternal: Any.Builder, InternalMessage(fieldsWithPresence = 0) {
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var typeUrl: String by MsgFieldDelegate { "" }
-    public override var value: ByteString by MsgFieldDelegate { ByteString() }
+    internal val __typeUrlDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var typeUrl: String by __typeUrlDelegate
+    internal val __valueDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate { ByteString() }
+    public override var value: ByteString by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -120,7 +122,9 @@ public class AnyInternal: Any.Builder, InternalMessage(fieldsWithPresence = 0) {
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Any by lazy { AnyInternal() }
+    }
 }
 
 @InternalRpcApi

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Api.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Api.kt
@@ -49,13 +49,20 @@ public class ApiInternal: Api.Builder, InternalMessage(fieldsWithPresence = 1) {
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var methods: List<Method> by MsgFieldDelegate { mutableListOf() }
-    public override var options: List<Option> by MsgFieldDelegate { mutableListOf() }
-    public override var version: String by MsgFieldDelegate { "" }
-    public override var sourceContext: SourceContext by MsgFieldDelegate(PresenceIndices.sourceContext) { SourceContextInternal() }
-    public override var mixins: List<Mixin> by MsgFieldDelegate { mutableListOf() }
-    public override var syntax: Syntax by MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __methodsDelegate: MsgFieldDelegate<List<Method>> = MsgFieldDelegate { emptyList() }
+    public override var methods: List<Method> by __methodsDelegate
+    internal val __optionsDelegate: MsgFieldDelegate<List<Option>> = MsgFieldDelegate { emptyList() }
+    public override var options: List<Option> by __optionsDelegate
+    internal val __versionDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var version: String by __versionDelegate
+    internal val __sourceContextDelegate: MsgFieldDelegate<SourceContext> = MsgFieldDelegate(PresenceIndices.sourceContext) { SourceContextInternal.DEFAULT }
+    public override var sourceContext: SourceContext by __sourceContextDelegate
+    internal val __mixinsDelegate: MsgFieldDelegate<List<Mixin>> = MsgFieldDelegate { emptyList() }
+    public override var mixins: List<Mixin> by __mixinsDelegate
+    internal val __syntaxDelegate: MsgFieldDelegate<Syntax> = MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
+    public override var syntax: Syntax by __syntaxDelegate
 
     private val _owner: ApiInternal = this
 
@@ -175,7 +182,9 @@ public class ApiInternal: Api.Builder, InternalMessage(fieldsWithPresence = 1) {
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Api by lazy { ApiInternal() }
+    }
 }
 
 public class MethodInternal: Method.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -188,13 +197,20 @@ public class MethodInternal: Method.Builder, InternalMessage(fieldsWithPresence 
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var requestTypeUrl: String by MsgFieldDelegate { "" }
-    public override var requestStreaming: Boolean by MsgFieldDelegate { false }
-    public override var responseTypeUrl: String by MsgFieldDelegate { "" }
-    public override var responseStreaming: Boolean by MsgFieldDelegate { false }
-    public override var options: List<Option> by MsgFieldDelegate { mutableListOf() }
-    public override var syntax: Syntax by MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __requestTypeUrlDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var requestTypeUrl: String by __requestTypeUrlDelegate
+    internal val __requestStreamingDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    public override var requestStreaming: Boolean by __requestStreamingDelegate
+    internal val __responseTypeUrlDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var responseTypeUrl: String by __responseTypeUrlDelegate
+    internal val __responseStreamingDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    public override var responseStreaming: Boolean by __responseStreamingDelegate
+    internal val __optionsDelegate: MsgFieldDelegate<List<Option>> = MsgFieldDelegate { emptyList() }
+    public override var options: List<Option> by __optionsDelegate
+    internal val __syntaxDelegate: MsgFieldDelegate<Syntax> = MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
+    public override var syntax: Syntax by __syntaxDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -296,7 +312,9 @@ public class MethodInternal: Method.Builder, InternalMessage(fieldsWithPresence 
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Method by lazy { MethodInternal() }
+    }
 }
 
 public class MixinInternal: Mixin.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -309,8 +327,10 @@ public class MixinInternal: Mixin.Builder, InternalMessage(fieldsWithPresence = 
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var root: String by MsgFieldDelegate { "" }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __rootDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var root: String by __rootDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -392,7 +412,9 @@ public class MixinInternal: Mixin.Builder, InternalMessage(fieldsWithPresence = 
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Mixin by lazy { MixinInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -469,29 +491,29 @@ public fun ApiInternal.Companion.decodeWith(msg: ApiInternal, decoder: WireDecod
                 msg.name = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__methodsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = MethodInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> MethodInternal.decodeWith(msg, decoder, config) })
-                (msg.methods as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__optionsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = OptionInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> OptionInternal.decodeWith(msg, decoder, config) })
-                (msg.options as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 4 && tag.wireType == WireType.LENGTH_DELIMITED -> {
                 msg.version = decoder.readString()
             }
             tag.fieldNr == 5 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.sourceContext = SourceContextInternal()
-                }
-
-                decoder.readMessage(msg.sourceContext.asInternal(), { msg, decoder -> SourceContextInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__sourceContextDelegate.getOrCreate(msg) { SourceContextInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> SourceContextInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 6 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mixinsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = MixinInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> MixinInternal.decodeWith(msg, decoder, config) })
-                (msg.mixins as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 7 && tag.wireType == WireType.VARINT -> {
                 msg.syntax = Syntax.fromNumber(decoder.readEnum())
@@ -627,9 +649,10 @@ public fun MethodInternal.Companion.decodeWith(msg: MethodInternal, decoder: Wir
                 msg.responseStreaming = decoder.readBool()
             }
             tag.fieldNr == 6 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__optionsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = OptionInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> OptionInternal.decodeWith(msg, decoder, config) })
-                (msg.options as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 7 && tag.wireType == WireType.VARINT -> {
                 msg.syntax = Syntax.fromNumber(decoder.readEnum())

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Duration.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Duration.kt
@@ -39,8 +39,10 @@ public class DurationInternal: Duration.Builder, InternalMessage(fieldsWithPrese
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var seconds: Long by MsgFieldDelegate { 0L }
-    public override var nanos: Int by MsgFieldDelegate { 0 }
+    internal val __secondsDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    public override var seconds: Long by __secondsDelegate
+    internal val __nanosDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    public override var nanos: Int by __nanosDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -122,7 +124,9 @@ public class DurationInternal: Duration.Builder, InternalMessage(fieldsWithPrese
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Duration by lazy { DurationInternal() }
+    }
 }
 
 @InternalRpcApi

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Empty.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Empty.kt
@@ -103,7 +103,9 @@ public class EmptyInternal: Empty.Builder, InternalMessage(fieldsWithPresence = 
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Empty by lazy { EmptyInternal() }
+    }
 }
 
 @InternalRpcApi

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/FieldMask.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/FieldMask.kt
@@ -43,7 +43,8 @@ public class FieldMaskInternal: FieldMask.Builder, InternalMessage(fieldsWithPre
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var paths: List<String> by MsgFieldDelegate { mutableListOf() }
+    internal val __pathsDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    public override var paths: List<String> by __pathsDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -121,7 +122,9 @@ public class FieldMaskInternal: FieldMask.Builder, InternalMessage(fieldsWithPre
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: FieldMask by lazy { FieldMaskInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -152,8 +155,9 @@ public fun FieldMaskInternal.Companion.decodeWith(msg: FieldMaskInternal, decode
         val tag = decoder.readTag() ?: break // EOF, we read the whole message
         when {
             tag.fieldNr == 1 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__pathsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.paths as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/SourceContext.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/SourceContext.kt
@@ -36,7 +36,8 @@ public class SourceContextInternal: SourceContext.Builder, InternalMessage(field
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var fileName: String by MsgFieldDelegate { "" }
+    internal val __fileNameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var fileName: String by __fileNameDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -114,7 +115,9 @@ public class SourceContextInternal: SourceContext.Builder, InternalMessage(field
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: SourceContext by lazy { SourceContextInternal() }
+    }
 }
 
 @InternalRpcApi

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Struct.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Struct.kt
@@ -43,7 +43,8 @@ public class StructInternal: Struct.Builder, InternalMessage(fieldsWithPresence 
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var fields: Map<String, Value> by MsgFieldDelegate { mutableMapOf() }
+    internal val __fieldsDelegate: MsgFieldDelegate<Map<String, Value>> = MsgFieldDelegate { emptyMap() }
+    public override var fields: Map<String, Value> by __fieldsDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -103,8 +104,10 @@ public class StructInternal: Struct.Builder, InternalMessage(fieldsWithPresence 
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        public var key: String by MsgFieldDelegate { "" }
-        public var value: Value by MsgFieldDelegate(PresenceIndices.value) { ValueInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        public var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Value> = MsgFieldDelegate(PresenceIndices.value) { ValueInternal.DEFAULT }
+        public var value: Value by __valueDelegate
 
         public override fun hashCode(): Int {
             checkRequiredFields()
@@ -186,7 +189,9 @@ public class StructInternal: Struct.Builder, InternalMessage(fieldsWithPresence 
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Struct by lazy { StructInternal() }
+    }
 }
 
 public class ValueInternal: Value.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -326,7 +331,9 @@ public class ValueInternal: Value.Builder, InternalMessage(fieldsWithPresence = 
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Value by lazy { ValueInternal() }
+    }
 }
 
 public class ListValueInternal: ListValue.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -339,7 +346,8 @@ public class ListValueInternal: ListValue.Builder, InternalMessage(fieldsWithPre
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var values: List<Value> by MsgFieldDelegate { mutableListOf() }
+    internal val __valuesDelegate: MsgFieldDelegate<List<Value>> = MsgFieldDelegate { emptyList() }
+    public override var values: List<Value> by __valuesDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -417,7 +425,9 @@ public class ListValueInternal: ListValue.Builder, InternalMessage(fieldsWithPre
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: ListValue by lazy { ListValueInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -457,9 +467,10 @@ public fun StructInternal.Companion.decodeWith(msg: StructInternal, decoder: Wir
         val tag = decoder.readTag() ?: break // EOF, we read the whole message
         when {
             tag.fieldNr == 1 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__fieldsDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(StructInternal.FieldsEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> StructInternal.FieldsEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.fields as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             else -> {
@@ -672,9 +683,10 @@ public fun ListValueInternal.Companion.decodeWith(msg: ListValueInternal, decode
         val tag = decoder.readTag() ?: break // EOF, we read the whole message
         when {
             tag.fieldNr == 1 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__valuesDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.values as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -749,11 +761,8 @@ public fun StructInternal.FieldsEntryInternal.Companion.decodeWith(msg: StructIn
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.value = ValueInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Timestamp.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Timestamp.kt
@@ -39,8 +39,10 @@ public class TimestampInternal: Timestamp.Builder, InternalMessage(fieldsWithPre
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var seconds: Long by MsgFieldDelegate { 0L }
-    public override var nanos: Int by MsgFieldDelegate { 0 }
+    internal val __secondsDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    public override var seconds: Long by __secondsDelegate
+    internal val __nanosDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    public override var nanos: Int by __nanosDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -122,7 +124,9 @@ public class TimestampInternal: Timestamp.Builder, InternalMessage(fieldsWithPre
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Timestamp by lazy { TimestampInternal() }
+    }
 }
 
 @InternalRpcApi

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Type.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Type.kt
@@ -48,13 +48,20 @@ public class TypeInternal: Type.Builder, InternalMessage(fieldsWithPresence = 1)
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var fields: List<Field> by MsgFieldDelegate { mutableListOf() }
-    public override var oneofs: List<String> by MsgFieldDelegate { mutableListOf() }
-    public override var options: List<Option> by MsgFieldDelegate { mutableListOf() }
-    public override var sourceContext: SourceContext by MsgFieldDelegate(PresenceIndices.sourceContext) { SourceContextInternal() }
-    public override var syntax: Syntax by MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
-    public override var edition: String by MsgFieldDelegate { "" }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __fieldsDelegate: MsgFieldDelegate<List<Field>> = MsgFieldDelegate { emptyList() }
+    public override var fields: List<Field> by __fieldsDelegate
+    internal val __oneofsDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    public override var oneofs: List<String> by __oneofsDelegate
+    internal val __optionsDelegate: MsgFieldDelegate<List<Option>> = MsgFieldDelegate { emptyList() }
+    public override var options: List<Option> by __optionsDelegate
+    internal val __sourceContextDelegate: MsgFieldDelegate<SourceContext> = MsgFieldDelegate(PresenceIndices.sourceContext) { SourceContextInternal.DEFAULT }
+    public override var sourceContext: SourceContext by __sourceContextDelegate
+    internal val __syntaxDelegate: MsgFieldDelegate<Syntax> = MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
+    public override var syntax: Syntax by __syntaxDelegate
+    internal val __editionDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var edition: String by __editionDelegate
 
     private val _owner: TypeInternal = this
 
@@ -174,7 +181,9 @@ public class TypeInternal: Type.Builder, InternalMessage(fieldsWithPresence = 1)
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Type by lazy { TypeInternal() }
+    }
 }
 
 public class FieldInternal: Field.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -187,16 +196,26 @@ public class FieldInternal: Field.Builder, InternalMessage(fieldsWithPresence = 
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var kind: Field.Kind by MsgFieldDelegate { Field.Kind.TYPE_UNKNOWN }
-    public override var cardinality: Field.Cardinality by MsgFieldDelegate { Field.Cardinality.CARDINALITY_UNKNOWN }
-    public override var number: Int by MsgFieldDelegate { 0 }
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var typeUrl: String by MsgFieldDelegate { "" }
-    public override var oneofIndex: Int by MsgFieldDelegate { 0 }
-    public override var packed: Boolean by MsgFieldDelegate { false }
-    public override var options: List<Option> by MsgFieldDelegate { mutableListOf() }
-    public override var jsonName: String by MsgFieldDelegate { "" }
-    public override var defaultValue: String by MsgFieldDelegate { "" }
+    internal val __kindDelegate: MsgFieldDelegate<Field.Kind> = MsgFieldDelegate { Field.Kind.TYPE_UNKNOWN }
+    public override var kind: Field.Kind by __kindDelegate
+    internal val __cardinalityDelegate: MsgFieldDelegate<Field.Cardinality> = MsgFieldDelegate { Field.Cardinality.CARDINALITY_UNKNOWN }
+    public override var cardinality: Field.Cardinality by __cardinalityDelegate
+    internal val __numberDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    public override var number: Int by __numberDelegate
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __typeUrlDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var typeUrl: String by __typeUrlDelegate
+    internal val __oneofIndexDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    public override var oneofIndex: Int by __oneofIndexDelegate
+    internal val __packedDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    public override var packed: Boolean by __packedDelegate
+    internal val __optionsDelegate: MsgFieldDelegate<List<Option>> = MsgFieldDelegate { emptyList() }
+    public override var options: List<Option> by __optionsDelegate
+    internal val __jsonNameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var jsonName: String by __jsonNameDelegate
+    internal val __defaultValueDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var defaultValue: String by __defaultValueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -310,7 +329,9 @@ public class FieldInternal: Field.Builder, InternalMessage(fieldsWithPresence = 
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Field by lazy { FieldInternal() }
+    }
 }
 
 public class EnumInternal: Enum.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -327,12 +348,18 @@ public class EnumInternal: Enum.Builder, InternalMessage(fieldsWithPresence = 1)
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var enumvalue: List<EnumValue> by MsgFieldDelegate { mutableListOf() }
-    public override var options: List<Option> by MsgFieldDelegate { mutableListOf() }
-    public override var sourceContext: SourceContext by MsgFieldDelegate(PresenceIndices.sourceContext) { SourceContextInternal() }
-    public override var syntax: Syntax by MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
-    public override var edition: String by MsgFieldDelegate { "" }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __enumvalueDelegate: MsgFieldDelegate<List<EnumValue>> = MsgFieldDelegate { emptyList() }
+    public override var enumvalue: List<EnumValue> by __enumvalueDelegate
+    internal val __optionsDelegate: MsgFieldDelegate<List<Option>> = MsgFieldDelegate { emptyList() }
+    public override var options: List<Option> by __optionsDelegate
+    internal val __sourceContextDelegate: MsgFieldDelegate<SourceContext> = MsgFieldDelegate(PresenceIndices.sourceContext) { SourceContextInternal.DEFAULT }
+    public override var sourceContext: SourceContext by __sourceContextDelegate
+    internal val __syntaxDelegate: MsgFieldDelegate<Syntax> = MsgFieldDelegate { Syntax.SYNTAX_PROTO2 }
+    public override var syntax: Syntax by __syntaxDelegate
+    internal val __editionDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var edition: String by __editionDelegate
 
     private val _owner: EnumInternal = this
 
@@ -448,7 +475,9 @@ public class EnumInternal: Enum.Builder, InternalMessage(fieldsWithPresence = 1)
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Enum by lazy { EnumInternal() }
+    }
 }
 
 public class EnumValueInternal: EnumValue.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -461,9 +490,12 @@ public class EnumValueInternal: EnumValue.Builder, InternalMessage(fieldsWithPre
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var number: Int by MsgFieldDelegate { 0 }
-    public override var options: List<Option> by MsgFieldDelegate { mutableListOf() }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __numberDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    public override var number: Int by __numberDelegate
+    internal val __optionsDelegate: MsgFieldDelegate<List<Option>> = MsgFieldDelegate { emptyList() }
+    public override var options: List<Option> by __optionsDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -549,7 +581,9 @@ public class EnumValueInternal: EnumValue.Builder, InternalMessage(fieldsWithPre
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: EnumValue by lazy { EnumValueInternal() }
+    }
 }
 
 public class OptionInternal: Option.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -566,8 +600,10 @@ public class OptionInternal: Option.Builder, InternalMessage(fieldsWithPresence 
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var name: String by MsgFieldDelegate { "" }
-    public override var value: Any by MsgFieldDelegate(PresenceIndices.value) { AnyInternal() }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var name: String by __nameDelegate
+    internal val __valueDelegate: MsgFieldDelegate<Any> = MsgFieldDelegate(PresenceIndices.value) { AnyInternal.DEFAULT }
+    public override var value: Any by __valueDelegate
 
     private val _owner: OptionInternal = this
 
@@ -667,7 +703,9 @@ public class OptionInternal: Option.Builder, InternalMessage(fieldsWithPresence 
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Option by lazy { OptionInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -740,25 +778,25 @@ public fun TypeInternal.Companion.decodeWith(msg: TypeInternal, decoder: WireDec
                 msg.name = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__fieldsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = FieldInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> FieldInternal.decodeWith(msg, decoder, config) })
-                (msg.fields as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__oneofsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.oneofs as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 4 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__optionsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = OptionInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> OptionInternal.decodeWith(msg, decoder, config) })
-                (msg.options as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 5 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.sourceContext = SourceContextInternal()
-                }
-
-                decoder.readMessage(msg.sourceContext.asInternal(), { msg, decoder -> SourceContextInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__sourceContextDelegate.getOrCreate(msg) { SourceContextInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> SourceContextInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 6 && tag.wireType == WireType.VARINT -> {
                 msg.syntax = Syntax.fromNumber(decoder.readEnum())
@@ -915,9 +953,10 @@ public fun FieldInternal.Companion.decodeWith(msg: FieldInternal, decoder: WireD
                 msg.packed = decoder.readBool()
             }
             tag.fieldNr == 9 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__optionsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = OptionInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> OptionInternal.decodeWith(msg, decoder, config) })
-                (msg.options as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 10 && tag.wireType == WireType.LENGTH_DELIMITED -> {
                 msg.jsonName = decoder.readString()
@@ -1062,21 +1101,20 @@ public fun EnumInternal.Companion.decodeWith(msg: EnumInternal, decoder: WireDec
                 msg.name = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__enumvalueDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = EnumValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> EnumValueInternal.decodeWith(msg, decoder, config) })
-                (msg.enumvalue as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__optionsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = OptionInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> OptionInternal.decodeWith(msg, decoder, config) })
-                (msg.options as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 4 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.sourceContext = SourceContextInternal()
-                }
-
-                decoder.readMessage(msg.sourceContext.asInternal(), { msg, decoder -> SourceContextInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__sourceContextDelegate.getOrCreate(msg) { SourceContextInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> SourceContextInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 5 && tag.wireType == WireType.VARINT -> {
                 msg.syntax = Syntax.fromNumber(decoder.readEnum())
@@ -1186,9 +1224,10 @@ public fun EnumValueInternal.Companion.decodeWith(msg: EnumValueInternal, decode
                 msg.number = decoder.readInt32()
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__optionsDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = OptionInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> OptionInternal.decodeWith(msg, decoder, config) })
-                (msg.options as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -1271,11 +1310,8 @@ public fun OptionInternal.Companion.decodeWith(msg: OptionInternal, decoder: Wir
                 msg.name = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.value = AnyInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { AnyInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Wrappers.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Wrappers.kt
@@ -44,7 +44,8 @@ public class DoubleValueInternal: DoubleValue.Builder, InternalMessage(fieldsWit
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: Double by MsgFieldDelegate { 0.0 }
+    internal val __valueDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate { 0.0 }
+    public override var value: Double by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -122,7 +123,9 @@ public class DoubleValueInternal: DoubleValue.Builder, InternalMessage(fieldsWit
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: DoubleValue by lazy { DoubleValueInternal() }
+    }
 }
 
 public class FloatValueInternal: FloatValue.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -135,7 +138,8 @@ public class FloatValueInternal: FloatValue.Builder, InternalMessage(fieldsWithP
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: Float by MsgFieldDelegate { 0.0f }
+    internal val __valueDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate { 0.0f }
+    public override var value: Float by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -213,7 +217,9 @@ public class FloatValueInternal: FloatValue.Builder, InternalMessage(fieldsWithP
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: FloatValue by lazy { FloatValueInternal() }
+    }
 }
 
 public class Int64ValueInternal: Int64Value.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -226,7 +232,8 @@ public class Int64ValueInternal: Int64Value.Builder, InternalMessage(fieldsWithP
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: Long by MsgFieldDelegate { 0L }
+    internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    public override var value: Long by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -304,7 +311,9 @@ public class Int64ValueInternal: Int64Value.Builder, InternalMessage(fieldsWithP
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Int64Value by lazy { Int64ValueInternal() }
+    }
 }
 
 public class UInt64ValueInternal: UInt64Value.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -317,7 +326,8 @@ public class UInt64ValueInternal: UInt64Value.Builder, InternalMessage(fieldsWit
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: ULong by MsgFieldDelegate { 0uL }
+    internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+    public override var value: ULong by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -395,7 +405,9 @@ public class UInt64ValueInternal: UInt64Value.Builder, InternalMessage(fieldsWit
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: UInt64Value by lazy { UInt64ValueInternal() }
+    }
 }
 
 public class Int32ValueInternal: Int32Value.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -408,7 +420,8 @@ public class Int32ValueInternal: Int32Value.Builder, InternalMessage(fieldsWithP
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: Int by MsgFieldDelegate { 0 }
+    internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    public override var value: Int by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -486,7 +499,9 @@ public class Int32ValueInternal: Int32Value.Builder, InternalMessage(fieldsWithP
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: Int32Value by lazy { Int32ValueInternal() }
+    }
 }
 
 public class UInt32ValueInternal: UInt32Value.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -499,7 +514,8 @@ public class UInt32ValueInternal: UInt32Value.Builder, InternalMessage(fieldsWit
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: UInt by MsgFieldDelegate { 0u }
+    internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+    public override var value: UInt by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -577,7 +593,9 @@ public class UInt32ValueInternal: UInt32Value.Builder, InternalMessage(fieldsWit
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: UInt32Value by lazy { UInt32ValueInternal() }
+    }
 }
 
 public class BoolValueInternal: BoolValue.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -590,7 +608,8 @@ public class BoolValueInternal: BoolValue.Builder, InternalMessage(fieldsWithPre
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: Boolean by MsgFieldDelegate { false }
+    internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    public override var value: Boolean by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -668,7 +687,9 @@ public class BoolValueInternal: BoolValue.Builder, InternalMessage(fieldsWithPre
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: BoolValue by lazy { BoolValueInternal() }
+    }
 }
 
 public class StringValueInternal: StringValue.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -681,7 +702,8 @@ public class StringValueInternal: StringValue.Builder, InternalMessage(fieldsWit
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: String by MsgFieldDelegate { "" }
+    internal val __valueDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    public override var value: String by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -759,7 +781,9 @@ public class StringValueInternal: StringValue.Builder, InternalMessage(fieldsWit
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: StringValue by lazy { StringValueInternal() }
+    }
 }
 
 public class BytesValueInternal: BytesValue.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -772,7 +796,8 @@ public class BytesValueInternal: BytesValue.Builder, InternalMessage(fieldsWithP
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    public override var value: ByteString by MsgFieldDelegate { ByteString() }
+    internal val __valueDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate { ByteString() }
+    public override var value: ByteString by __valueDelegate
 
     public override fun hashCode(): Int {
         checkRequiredFields()
@@ -850,7 +875,9 @@ public class BytesValueInternal: BytesValue.Builder, InternalMessage(fieldsWithP
     }
 
     @InternalRpcApi
-    public companion object
+    public companion object {
+        public val DEFAULT: BytesValue by lazy { BytesValueInternal() }
+    }
 }
 
 @InternalRpcApi

--- a/protoc-gen/common/src/main/kotlin/kotlinx/rpc/protoc/gen/core/codeRequestToModel.kt
+++ b/protoc-gen/common/src/main/kotlin/kotlinx/rpc/protoc/gen/core/codeRequestToModel.kt
@@ -314,6 +314,7 @@ private fun Descriptors.Descriptor.toModel(comments: Comments?, nameTable: FqNam
         nameTable.register { declaration.internalClassName }
         nameTable.register { declaration.builderClassName }
         nameTable.register { declaration.internalCompanionName }
+        nameTable.register { declaration.defaultObjectRef }
 
         if (declaration.isUserFacing && declaration.hasPresenceFieldsRecursive()) {
             nameTable.register { declaration.presenceInterfaceName }

--- a/protoc-gen/common/src/main/kotlin/kotlinx/rpc/protoc/gen/core/model/FieldType.kt
+++ b/protoc-gen/common/src/main/kotlin/kotlinx/rpc/protoc/gen/core/model/FieldType.kt
@@ -17,19 +17,19 @@ enum class WireType {
 }
 
 sealed interface FieldType {
-    val defaultValue: ScopedFormattedString?
+    val defaultValue: ScopedFormattedString
     val wireType: WireType
 
     val isPackable: Boolean get() = false
 
     data class List(val value: FieldType) : FieldType {
-        override val defaultValue: ScopedFormattedString = "mutableListOf()".scoped()
+        override val defaultValue: ScopedFormattedString = "emptyList()".scoped()
         override val wireType: WireType by lazy { value.wireType }
         override val isPackable: Boolean = value.isPackable
     }
 
     data class Map(val entry: Entry) : FieldType {
-        override val defaultValue: ScopedFormattedString = "mutableMapOf()".scoped()
+        override val defaultValue: ScopedFormattedString = "emptyMap()".scoped()
         override val wireType: WireType = WireType.LENGTH_DELIMITED
 
         data class Entry(val dec: Lazy<MessageDeclaration>, val key: FieldType, val value: FieldType)
@@ -44,7 +44,7 @@ sealed interface FieldType {
     }
 
     data class Message(val dec: Lazy<MessageDeclaration>) : FieldType {
-        override val defaultValue: ScopedFormattedString? = null
+        override val defaultValue: ScopedFormattedString by lazy { "%T.DEFAULT".scoped(dec.value.internalClassName) }
         override val wireType: WireType by lazy { if (dec.value.isGroup) WireType.START_GROUP else WireType.LENGTH_DELIMITED }
     }
 

--- a/protoc-gen/common/src/main/kotlin/kotlinx/rpc/protoc/gen/core/model/model.kt
+++ b/protoc-gen/common/src/main/kotlin/kotlinx/rpc/protoc/gen/core/model/model.kt
@@ -74,6 +74,7 @@ data class MessageDeclaration(
 
     val internalCompanionName: FqName.Declaration by lazy { internalClassName.nested("Companion") }
     val presenceIndicesName: FqName.Declaration by lazy { internalClassName.nested("PresenceIndices") }
+    val defaultObjectRef: FqName.Declaration by lazy { internalClassName.nested("DEFAULT") }
     val marshallerObjectName: FqName.Declaration by lazy { internalClassName.nested("MARSHALLER") }
     val bytesDefaultsName: FqName.Declaration by lazy { internalClassName.nested("BytesDefaults") }
 

--- a/protoc-gen/protobuf/src/main/kotlin/kotlinx/rpc/protoc/gen/ModelToProtobufKotlinCommonGenerator.kt
+++ b/protoc-gen/protobuf/src/main/kotlin/kotlinx/rpc/protoc/gen/ModelToProtobufKotlinCommonGenerator.kt
@@ -223,52 +223,8 @@ class ModelToProtobufKotlinCommonGenerator(
                 value = "null".scoped(),
             )
 
-            val override = if (declaration.isUserFacing) "override" else ""
             declaration.actualFields.forEachIndexed { i, field ->
-                val value = when {
-                    field.nullable && field.presenceIdx == null -> {
-                        "null".scoped()
-                    }
-
-                    field.type is FieldType.Message -> {
-                        "%T(%T.${field.name}) { %T() }".scoped(
-                            FqName.RpcClasses.MsgFieldDelegate,
-                            declaration.presenceIndicesName,
-                            (field.type as FieldType.Message).dec.value.internalClassName,
-                        )
-                    }
-
-                    else -> {
-                        val fieldPresence = if (field.presenceIdx != null) {
-                            "(%T.${field.name})".scoped(declaration.presenceIndicesName)
-                        } else {
-                            ScopedFormattedString.empty
-                        }
-
-                        FqName.RpcClasses.MsgFieldDelegate
-                            .scoped()
-                            .merge(
-                                other = fieldPresence,
-                                another = field.safeDefaultValue(declaration),
-                            ) { msgFieldDelegate, fieldPresence, fieldDefault ->
-                                "$msgFieldDelegate$fieldPresence { $fieldDefault }"
-                            }
-                    }
-                }
-
-                property(
-                    name = field.name,
-                    modifiers = override,
-                    value = value,
-                    isVar = true,
-                    type = field.typeFqName(),
-                    propertyInitializer = if (field.nullable && field.presenceIdx == null) {
-                        CodeGenerator.PropertyInitializer.PLAIN
-                    } else {
-                        CodeGenerator.PropertyInitializer.DELEGATE
-                    },
-                    needsNewLineAfterDeclaration = i == declaration.actualFields.lastIndex,
-                )
+                generatedInternalFieldPropertyDeclaration(i, field, declaration)
             }
 
             generateInternalPresenceObjectProperty(declaration)
@@ -285,8 +241,67 @@ class ModelToProtobufKotlinCommonGenerator(
 
             generateMarshallerObject(declaration)
             generateDescriptorObject(declaration)
-            generateCompanionObject()
+            generateCompanionObject(declaration)
         }
+    }
+
+    private fun CodeGenerator.generatedInternalFieldPropertyDeclaration(index: Int, field: FieldDeclaration, msg: MessageDeclaration) {
+        val isOneOfField = field.type is FieldType.OneOf
+        val override = if (msg.isUserFacing) "override" else ""
+        val value = when {
+            isOneOfField -> {
+                "null".scoped()
+            }
+
+            else -> {
+                val fieldPresence = if (field.presenceIdx != null) {
+                    "(%T.${field.name})".scoped(msg.presenceIndicesName)
+                } else {
+                    ScopedFormattedString.empty
+                }
+
+                FqName.RpcClasses.MsgFieldDelegate
+                    .scoped()
+                    .merge(
+                        other = fieldPresence,
+                        another = field.safeDefaultValue(msg),
+                    ) { msgFieldDelegate, fieldPresence, fieldDefault ->
+                        "$msgFieldDelegate$fieldPresence { $fieldDefault }"
+                    }
+            }
+        }
+
+        val delegateType = FqName.RpcClasses.MsgFieldDelegate.scoped()
+            .merge(field.typeFqName()) { msgFieldDelegate, fieldFqName ->
+            "$msgFieldDelegate<$fieldFqName>"
+        }
+
+        if (!isOneOfField) {
+            // create a delegate and store it using __<name>Delegate
+            property(
+                name = field.internalDelegateName,
+                modifiers = "internal",
+                type = delegateType,
+                value = value,
+                needsNewLineAfterDeclaration = false
+            )
+        }
+
+        val propertyValue = if (isOneOfField) value else field.internalDelegateName.scoped()
+
+        property(
+            name = field.name,
+            modifiers = override,
+            value = propertyValue,
+            isVar = true,
+            type = field.typeFqName(),
+            propertyInitializer = if (isOneOfField) {
+                CodeGenerator.PropertyInitializer.PLAIN
+            } else {
+                CodeGenerator.PropertyInitializer.DELEGATE
+            },
+            needsNewLineAfterDeclaration = index == msg.actualFields.lastIndex,
+        )
     }
 
     /**
@@ -319,13 +334,15 @@ class ModelToProtobufKotlinCommonGenerator(
         }
     }
 
-    private fun CodeGenerator.generateCompanionObject() {
+    private fun CodeGenerator.generateCompanionObject(declaration: MessageDeclaration) {
         clazz(
             name = "",
             modifiers = "companion",
             annotations = listOf(FqName.Annotations.InternalRpcApi.scopedAnnotation()),
             declarationType = CodeGenerator.DeclarationType.Object
-        )
+        ) {
+            generateMessageDefault(declaration)
+        }
     }
 
     private fun CodeGenerator.generateHashCode(declaration: MessageDeclaration) {
@@ -1045,6 +1062,17 @@ class ModelToProtobufKotlinCommonGenerator(
         }
     }
 
+    private fun CodeGenerator.generateMessageDefault(declaration: MessageDeclaration) {
+        if (!declaration.isUserFacing) return
+
+        property(
+            name = "DEFAULT",
+            type = declaration.name.scoped(),
+            propertyInitializer = CodeGenerator.PropertyInitializer.DELEGATE,
+            value = "lazy { %T() }".scoped(declaration.internalClassName),
+        )
+    }
+
     private fun CodeGenerator.generateMarshallerObject(declaration: MessageDeclaration) {
         if (!declaration.isUserFacing) return
 
@@ -1267,6 +1295,30 @@ class ModelToProtobufKotlinCommonGenerator(
         wrapperCtor: (ScopedFormattedString) -> ScopedFormattedString = { it },
         beforeValueDecoding: CodeGenerator.() -> Unit = {},
     ) {
+        fun CodeGenerator.repeatedDecodeTarget(): ScopedFormattedString {
+            code(
+                "val target = msg.${field.internalDelegateName}.getOrCreate(msg) { mutableListOf() } as %T"
+                    .scoped(FqName.Implicits.MutableList)
+            )
+            return "target".scoped()
+        }
+
+        fun CodeGenerator.mapDecodeTarget(): ScopedFormattedString {
+            code(
+                "val target = msg.${field.internalDelegateName}.getOrCreate(msg) { mutableMapOf() } as %T"
+                    .scoped(FqName.Implicits.MutableMap)
+            )
+            return "target".scoped()
+        }
+
+        fun CodeGenerator.messageDecodeTarget(internalClassName: FqName.Declaration): ScopedFormattedString {
+            if (field.isPartOfOneof) return lvalue
+
+            code("val target = msg.${field.internalDelegateName}.getOrCreate(msg) { %T() }"
+                .scoped(internalClassName))
+            return "target".scoped()
+        }
+
         when (val fieldType = field.type) {
             is FieldType.IntegralType -> whenCase(
                 "tag.fieldNr == ${field.number} && tag.wireType == %T"
@@ -1285,8 +1337,9 @@ class ModelToProtobufKotlinCommonGenerator(
                         "tag.fieldNr == ${field.number} && tag.wireType == %T"
                             .scoped(FqName.RpcClasses.WireType_LENGTH_DELIMITED)
                     ) {
+                        val target = repeatedDecodeTarget()
                         beforeValueDecoding()
-                        generateDecodeFieldValue(fieldType, lvalue, isPacked = true, wrapperCtor = wrapperCtor)
+                        generateDecodeFieldValue(fieldType, target, isPacked = true, wrapperCtor = wrapperCtor)
                     }
                 }
 
@@ -1294,8 +1347,9 @@ class ModelToProtobufKotlinCommonGenerator(
                     "tag.fieldNr == ${field.number} && tag.wireType == %T"
                         .scoped(FqName.RpcClasses.WireType.nested(fieldType.value.wireType.name))
                 ) {
+                    val target = repeatedDecodeTarget()
                     beforeValueDecoding()
-                    generateDecodeFieldValue(fieldType, lvalue, isPacked = false, wrapperCtor = wrapperCtor)
+                    generateDecodeFieldValue(fieldType, target, isPacked = false, wrapperCtor = wrapperCtor)
                 }
             }
 
@@ -1354,19 +1408,9 @@ class ModelToProtobufKotlinCommonGenerator(
                     "tag.fieldNr == ${field.number} && tag.wireType == %T"
                         .scoped(FqName.RpcClasses.WireType.nested(fieldType.wireType.name))
                 ) {
-                    if (field.presenceIdx != null) {
-                        // check if the current sub message object was already set, if not, set a new one
-                        // to set the field's presence tracker to true
-                        ifBranch(condition = "!msg.presenceMask[${field.presenceIdx}]".scoped(), ifBlock = {
-                            code(
-                                lvalue.merge(fieldType.dec.value.internalClassName.scoped()) { lvalue, internalClassName ->
-                                    "$lvalue = $internalClassName()"
-                                }
-                            )
-                        })
-                    }
+                    val target = messageDecodeTarget(fieldType.dec.value.internalClassName)
                     beforeValueDecoding()
-                    generateDecodeFieldValue(fieldType, lvalue, wrapperCtor = wrapperCtor)
+                    generateDecodeFieldValue(fieldType, target, wrapperCtor = wrapperCtor)
                 }
             }
 
@@ -1374,8 +1418,9 @@ class ModelToProtobufKotlinCommonGenerator(
                 "tag.fieldNr == ${field.number} && tag.wireType == %T"
                     .scoped(FqName.RpcClasses.WireType_LENGTH_DELIMITED)
             ) {
+                val target = mapDecodeTarget()
                 beforeValueDecoding()
-                generateDecodeFieldValue(fieldType, lvalue, wrapperCtor = wrapperCtor)
+                generateDecodeFieldValue(fieldType, target, wrapperCtor = wrapperCtor)
             }
         }
     }
@@ -1386,16 +1431,20 @@ class ModelToProtobufKotlinCommonGenerator(
         isPacked: Boolean = false,
         wrapperCtor: (ScopedFormattedString) -> ScopedFormattedString = { it },
     ) {
+        fun emitAssignment(raw: ScopedFormattedString) {
+            code(lvalue.merge(wrapperCtor(raw)) { target, value -> "$target = $value" })
+        }
+
         when (fieldType) {
             is FieldType.IntegralType -> {
                 val raw = "decoder.read${fieldType.decodeEncodeFuncName()}()".scoped()
-                code(lvalue.merge(wrapperCtor(raw)) { lvalue, ctor -> "$lvalue = $ctor" })
+                emitAssignment(raw)
             }
 
             is FieldType.List -> if (isPacked) {
-                val fieldType = fieldType.value
-                val conversion = if (fieldType is FieldType.Enum) {
-                    ".map { %T.fromNumber(it) }".scoped(fieldType.dec.value.name)
+                val elementType = fieldType.value
+                val conversion = if (elementType is FieldType.Enum) {
+                    ".map { %T.fromNumber(it) }".scoped(elementType.dec.value.name)
                 } else {
                     "".scoped()
                 }
@@ -1405,8 +1454,8 @@ class ModelToProtobufKotlinCommonGenerator(
                 // parsers must be prepared to accept multiple key-value pairs.
                 // In this case, the payloads should be concatenated.
                 code(
-                    lvalue.merge(conversion) { lvalue, conversion ->
-                        "$lvalue += decoder.readPacked${fieldType.decodeEncodeFuncName()}()$conversion"
+                    lvalue.merge(conversion) { target, packedConversion ->
+                        "$target.addAll(decoder.readPacked${elementType.decodeEncodeFuncName()}()$packedConversion)"
                     }
                 )
             } else {
@@ -1418,47 +1467,30 @@ class ModelToProtobufKotlinCommonGenerator(
 
                     else -> generateDecodeFieldValue(fieldType.value, "val elem".scoped(), wrapperCtor = wrapperCtor)
                 }
-                code(
-                    lvalue.merge(FqName.Implicits.MutableList.scoped()) { lvalue, mutableList ->
-                        "($lvalue as $mutableList).add(elem)"
-                    }
-                )
+                code(lvalue.wrapIn { target -> "$target.add(elem)" })
             }
 
             is FieldType.Enum -> {
                 val raw = "%T.fromNumber(decoder.read${fieldType.decodeEncodeFuncName()}())"
                     .scoped(fieldType.dec.value.name)
 
-                code(
-                    lvalue.merge(wrapperCtor(raw)) { lvalue, ctor -> "$lvalue = $ctor" }
-                )
+                emitAssignment(raw)
             }
 
-            is FieldType.OneOf -> {
-                fieldType.dec.variants.forEach { variant ->
-                    val variantName = fieldType.dec.name.nested(variant.name).scoped()
-                    readMatchCase(
-                        field = variant,
-                        lvalue = lvalue,
-                        wrapperCtor = { raw ->
-                            variantName.merge(raw) { variantName, raw -> "$variantName($raw)" }
-                        }
-                    )
-                }
-            }
+            is FieldType.OneOf -> error("Oneof decoding is handled in readMatchCase")
 
             is FieldType.Message -> {
                 val msg = fieldType.dec.value
                 if (msg.isGroup) {
                     code(
-                        lvalue.merge(msg.internalClassName.scoped()) { lvalue, internalClassName ->
-                            "decoder.readGroup($lvalue.asInternal()) { msg, decoder -> $internalClassName.decodeWith(msg, decoder, config, tag) }"
+                        lvalue.merge(msg.internalClassName.scoped()) { target, internalClassName ->
+                            "decoder.readGroup($target.asInternal()) { msg, decoder -> $internalClassName.decodeWith(msg, decoder, config, tag) }"
                         }
                     )
                 } else {
                     code(
-                        lvalue.merge(msg.internalClassName.scoped()) { lvalue, internalClassName ->
-                            "decoder.readMessage($lvalue.asInternal(), { msg, decoder -> $internalClassName.decodeWith(msg, decoder, config) })"
+                        lvalue.merge(msg.internalClassName.scoped()) { target, internalClassName ->
+                            "decoder.readMessage($target.asInternal(), { msg, decoder -> $internalClassName.decodeWith(msg, decoder, config) })"
                         }
                     )
                 }
@@ -1472,11 +1504,7 @@ class ModelToProtobufKotlinCommonGenerator(
                         isPacked = false,
                         wrapperCtor = wrapperCtor
                     )
-                    code(
-                        lvalue.merge(FqName.Implicits.MutableMap.scoped()) { lvalue, mutableMap ->
-                            "($lvalue as $mutableMap)[key] = value"
-                        }
-                    )
+                    code(lvalue.wrapIn { target -> "$target[key] = value" })
                 }
             }
         }
@@ -2293,7 +2321,7 @@ class ModelToProtobufKotlinCommonGenerator(
                 function = "%T.group".scoped(FqName.RpcClasses.InternalExtensionDescriptor),
                 namedArgs = field.baseExtensionDescriptorArgs() + listOf(
                     "valueType" to "%T::class".scoped(message.name),
-                    "default" to "{ %T() }".scoped(message.internalClassName),
+                    "default" to "{ %T }".scoped(message.defaultObjectRef),
                     "asInternal" to "{ it.asInternal() }".scoped(),
                     "encodeWith" to "{ value, encoder, config -> value.asInternal().encodeWith(encoder, config) }".scoped(),
                     "decodeWith" to "{ value, decoder, config, startGroup -> %T.decodeWith(value.asInternal(), decoder, config, startGroup) }".scoped(
@@ -2306,7 +2334,7 @@ class ModelToProtobufKotlinCommonGenerator(
                 function = "%T.message".scoped(FqName.RpcClasses.InternalExtensionDescriptor),
                 namedArgs = field.baseExtensionDescriptorArgs() + listOf(
                     "valueType" to "%T::class".scoped(message.name),
-                    "default" to "{ %T() }".scoped(message.internalClassName),
+                    "default" to "{ %T }".scoped(message.defaultObjectRef),
                     "asInternal" to "{ it.asInternal() }".scoped(),
                     "encodeWith" to "{ value, encoder, config -> value.asInternal().encodeWith(encoder, config) }".scoped(),
                     "decodeWith" to "{ value, decoder, config -> %T.decodeWith(value.asInternal(), decoder, config) }".scoped(
@@ -2359,6 +2387,9 @@ private fun FieldDeclaration.baseExtensionDescriptorArgs(): List<Pair<String, Sc
         "extendee" to "%T::class".scoped(containingType.value.name),
     )
 }
+
+// we use double "__" to avoid conflicts with internal names that start with "_"
+private val FieldDeclaration.internalDelegateName: String get() = "__${rawName}Delegate"
 
 private fun EnumDeclaration.generatedValueName(descriptor: Descriptors.EnumValueDescriptor): FqName {
     originalEntries.firstOrNull { it.dec == descriptor }?.let { return it.name }

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf/conformance/_rpc_internal/Conformance.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf/conformance/_rpc_internal/Conformance.kt
@@ -39,9 +39,12 @@ class TestStatusInternal: TestStatus.Builder, InternalMessage(fieldsWithPresence
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var name: String by MsgFieldDelegate { "" }
-    override var failureMessage: String by MsgFieldDelegate { "" }
-    override var matchedName: String by MsgFieldDelegate { "" }
+    internal val __nameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var name: String by __nameDelegate
+    internal val __failureMessageDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var failureMessage: String by __failureMessageDelegate
+    internal val __matchedNameDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var matchedName: String by __matchedNameDelegate
 
     override fun hashCode(): Int {
         checkRequiredFields()
@@ -127,7 +130,9 @@ class TestStatusInternal: TestStatus.Builder, InternalMessage(fieldsWithPresence
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestStatus by lazy { TestStatusInternal() }
+    }
 }
 
 class FailureSetInternal: FailureSet.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -140,7 +145,8 @@ class FailureSetInternal: FailureSet.Builder, InternalMessage(fieldsWithPresence
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var test: List<TestStatus> by MsgFieldDelegate { mutableListOf() }
+    internal val __testDelegate: MsgFieldDelegate<List<TestStatus>> = MsgFieldDelegate { emptyList() }
+    override var test: List<TestStatus> by __testDelegate
 
     override fun hashCode(): Int {
         checkRequiredFields()
@@ -218,7 +224,9 @@ class FailureSetInternal: FailureSet.Builder, InternalMessage(fieldsWithPresence
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: FailureSet by lazy { FailureSetInternal() }
+    }
 }
 
 class ConformanceRequestInternal: ConformanceRequest.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -235,11 +243,16 @@ class ConformanceRequestInternal: ConformanceRequest.Builder, InternalMessage(fi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var requestedOutputFormat: WireFormat by MsgFieldDelegate { WireFormat.UNSPECIFIED }
-    override var messageType: String by MsgFieldDelegate { "" }
-    override var testCategory: TestCategory by MsgFieldDelegate { TestCategory.UNSPECIFIED_TEST }
-    override var jspbEncodingOptions: JspbEncodingConfig by MsgFieldDelegate(PresenceIndices.jspbEncodingOptions) { JspbEncodingConfigInternal() }
-    override var printUnknownFields: Boolean by MsgFieldDelegate { false }
+    internal val __requestedOutputFormatDelegate: MsgFieldDelegate<WireFormat> = MsgFieldDelegate { WireFormat.UNSPECIFIED }
+    override var requestedOutputFormat: WireFormat by __requestedOutputFormatDelegate
+    internal val __messageTypeDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var messageType: String by __messageTypeDelegate
+    internal val __testCategoryDelegate: MsgFieldDelegate<TestCategory> = MsgFieldDelegate { TestCategory.UNSPECIFIED_TEST }
+    override var testCategory: TestCategory by __testCategoryDelegate
+    internal val __jspbEncodingOptionsDelegate: MsgFieldDelegate<JspbEncodingConfig> = MsgFieldDelegate(PresenceIndices.jspbEncodingOptions) { JspbEncodingConfigInternal.DEFAULT }
+    override var jspbEncodingOptions: JspbEncodingConfig by __jspbEncodingOptionsDelegate
+    internal val __printUnknownFieldsDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    override var printUnknownFields: Boolean by __printUnknownFieldsDelegate
     override var payload: ConformanceRequest.Payload? = null
 
     private val _owner: ConformanceRequestInternal = this
@@ -372,7 +385,9 @@ class ConformanceRequestInternal: ConformanceRequest.Builder, InternalMessage(fi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ConformanceRequest by lazy { ConformanceRequestInternal() }
+    }
 }
 
 class ConformanceResponseInternal: ConformanceResponse.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -484,7 +499,9 @@ class ConformanceResponseInternal: ConformanceResponse.Builder, InternalMessage(
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ConformanceResponse by lazy { ConformanceResponseInternal() }
+    }
 }
 
 class JspbEncodingConfigInternal: JspbEncodingConfig.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -497,7 +514,8 @@ class JspbEncodingConfigInternal: JspbEncodingConfig.Builder, InternalMessage(fi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var useJspbArrayAnyFormat: Boolean by MsgFieldDelegate { false }
+    internal val __useJspbArrayAnyFormatDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    override var useJspbArrayAnyFormat: Boolean by __useJspbArrayAnyFormatDelegate
 
     override fun hashCode(): Int {
         checkRequiredFields()
@@ -575,7 +593,9 @@ class JspbEncodingConfigInternal: JspbEncodingConfig.Builder, InternalMessage(fi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: JspbEncodingConfig by lazy { JspbEncodingConfigInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -696,9 +716,10 @@ fun FailureSetInternal.Companion.decodeWith(msg: FailureSetInternal, decoder: Wi
         val tag = decoder.readTag() ?: break // EOF, we read the whole message
         when {
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__testDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestStatusInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TestStatusInternal.decodeWith(msg, decoder, config) })
-                (msg.test as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -808,11 +829,8 @@ fun ConformanceRequestInternal.Companion.decodeWith(msg: ConformanceRequestInter
                 msg.testCategory = TestCategory.fromNumber(decoder.readEnum())
             }
             tag.fieldNr == 6 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.jspbEncodingOptions = JspbEncodingConfigInternal()
-                }
-
-                decoder.readMessage(msg.jspbEncodingOptions.asInternal(), { msg, decoder -> JspbEncodingConfigInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__jspbEncodingOptionsDelegate.getOrCreate(msg) { JspbEncodingConfigInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> JspbEncodingConfigInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 9 && tag.wireType == WireType.VARINT -> {
                 msg.printUnknownFields = decoder.readBool()

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/edition2023/_rpc_internal/TestMessagesEdition2023.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/edition2023/_rpc_internal/TestMessagesEdition2023.kt
@@ -72,7 +72,8 @@ class ComplexMessageInternal: ComplexMessage.Builder, InternalMessage(fieldsWith
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var d: Int? by MsgFieldDelegate(PresenceIndices.d) { null }
+    internal val __dDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.d) { null }
+    override var d: Int? by __dDelegate
 
     private val _owner: ComplexMessageInternal = this
 
@@ -168,7 +169,9 @@ class ComplexMessageInternal: ComplexMessage.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ComplexMessage by lazy { ComplexMessageInternal() }
+    }
 }
 
 class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, InternalMessage(fieldsWithPresence = 24) {
@@ -208,98 +211,190 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var optionalInt32: Int? by MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
-    override var optionalInt64: Long? by MsgFieldDelegate(PresenceIndices.optionalInt64) { null }
-    override var optionalUint32: UInt? by MsgFieldDelegate(PresenceIndices.optionalUint32) { null }
-    override var optionalUint64: ULong? by MsgFieldDelegate(PresenceIndices.optionalUint64) { null }
-    override var optionalSint32: Int? by MsgFieldDelegate(PresenceIndices.optionalSint32) { null }
-    override var optionalSint64: Long? by MsgFieldDelegate(PresenceIndices.optionalSint64) { null }
-    override var optionalFixed32: UInt? by MsgFieldDelegate(PresenceIndices.optionalFixed32) { null }
-    override var optionalFixed64: ULong? by MsgFieldDelegate(PresenceIndices.optionalFixed64) { null }
-    override var optionalSfixed32: Int? by MsgFieldDelegate(PresenceIndices.optionalSfixed32) { null }
-    override var optionalSfixed64: Long? by MsgFieldDelegate(PresenceIndices.optionalSfixed64) { null }
-    override var optionalFloat: Float? by MsgFieldDelegate(PresenceIndices.optionalFloat) { null }
-    override var optionalDouble: Double? by MsgFieldDelegate(PresenceIndices.optionalDouble) { null }
-    override var optionalBool: Boolean? by MsgFieldDelegate(PresenceIndices.optionalBool) { null }
-    override var optionalString: String? by MsgFieldDelegate(PresenceIndices.optionalString) { null }
-    override var optionalBytes: ByteString? by MsgFieldDelegate(PresenceIndices.optionalBytes) { null }
-    override var optionalNestedMessage: TestAllTypesEdition2023.NestedMessage by MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal() }
-    override var optionalForeignMessage: ForeignMessageEdition2023 by MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageEdition2023Internal() }
-    override var optionalNestedEnum: TestAllTypesEdition2023.NestedEnum? by MsgFieldDelegate(PresenceIndices.optionalNestedEnum) { null }
-    override var optionalForeignEnum: ForeignEnumEdition2023? by MsgFieldDelegate(PresenceIndices.optionalForeignEnum) { null }
-    override var optionalStringPiece: String? by MsgFieldDelegate(PresenceIndices.optionalStringPiece) { null }
-    override var optionalCord: String? by MsgFieldDelegate(PresenceIndices.optionalCord) { null }
-    override var recursiveMessage: TestAllTypesEdition2023 by MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesEdition2023Internal() }
-    override var repeatedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedString: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBytes: List<ByteString> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedMessage: List<TestAllTypesEdition2023.NestedMessage> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignMessage: List<ForeignMessageEdition2023> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedEnum: List<TestAllTypesEdition2023.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignEnum: List<ForeignEnumEdition2023> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStringPiece: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedCord: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var packedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var packedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var packedNestedEnum: List<TestAllTypesEdition2023.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedNestedEnum: List<TestAllTypesEdition2023.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var mapInt32Int32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt64Int64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint32Uint32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint64Uint64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint32Sint32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint64Sint64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed32Fixed32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed64Fixed64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed32Sfixed32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed64Sfixed64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Float: Map<Int, Float> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Double: Map<Int, Double> by MsgFieldDelegate { mutableMapOf() }
-    override var mapBoolBool: Map<Boolean, Boolean> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringString: Map<String, String> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringBytes: Map<String, ByteString> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedMessage: Map<String, TestAllTypesEdition2023.NestedMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignMessage: Map<String, ForeignMessageEdition2023> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedEnum: Map<String, TestAllTypesEdition2023.NestedEnum> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignEnum: Map<String, ForeignEnumEdition2023> by MsgFieldDelegate { mutableMapOf() }
-    override var groupliketype: TestAllTypesEdition2023.GroupLikeType by MsgFieldDelegate(PresenceIndices.groupliketype) { GroupLikeTypeInternal() }
-    override var delimitedField: TestAllTypesEdition2023.GroupLikeType by MsgFieldDelegate(PresenceIndices.delimitedField) { GroupLikeTypeInternal() }
+    internal val __optionalInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
+    override var optionalInt32: Int? by __optionalInt32Delegate
+    internal val __optionalInt64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalInt64) { null }
+    override var optionalInt64: Long? by __optionalInt64Delegate
+    internal val __optionalUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.optionalUint32) { null }
+    override var optionalUint32: UInt? by __optionalUint32Delegate
+    internal val __optionalUint64Delegate: MsgFieldDelegate<ULong?> = MsgFieldDelegate(PresenceIndices.optionalUint64) { null }
+    override var optionalUint64: ULong? by __optionalUint64Delegate
+    internal val __optionalSint32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalSint32) { null }
+    override var optionalSint32: Int? by __optionalSint32Delegate
+    internal val __optionalSint64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalSint64) { null }
+    override var optionalSint64: Long? by __optionalSint64Delegate
+    internal val __optionalFixed32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.optionalFixed32) { null }
+    override var optionalFixed32: UInt? by __optionalFixed32Delegate
+    internal val __optionalFixed64Delegate: MsgFieldDelegate<ULong?> = MsgFieldDelegate(PresenceIndices.optionalFixed64) { null }
+    override var optionalFixed64: ULong? by __optionalFixed64Delegate
+    internal val __optionalSfixed32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalSfixed32) { null }
+    override var optionalSfixed32: Int? by __optionalSfixed32Delegate
+    internal val __optionalSfixed64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalSfixed64) { null }
+    override var optionalSfixed64: Long? by __optionalSfixed64Delegate
+    internal val __optionalFloatDelegate: MsgFieldDelegate<Float?> = MsgFieldDelegate(PresenceIndices.optionalFloat) { null }
+    override var optionalFloat: Float? by __optionalFloatDelegate
+    internal val __optionalDoubleDelegate: MsgFieldDelegate<Double?> = MsgFieldDelegate(PresenceIndices.optionalDouble) { null }
+    override var optionalDouble: Double? by __optionalDoubleDelegate
+    internal val __optionalBoolDelegate: MsgFieldDelegate<Boolean?> = MsgFieldDelegate(PresenceIndices.optionalBool) { null }
+    override var optionalBool: Boolean? by __optionalBoolDelegate
+    internal val __optionalStringDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalString) { null }
+    override var optionalString: String? by __optionalStringDelegate
+    internal val __optionalBytesDelegate: MsgFieldDelegate<ByteString?> = MsgFieldDelegate(PresenceIndices.optionalBytes) { null }
+    override var optionalBytes: ByteString? by __optionalBytesDelegate
+    internal val __optionalNestedMessageDelegate: MsgFieldDelegate<TestAllTypesEdition2023.NestedMessage> = MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal.DEFAULT }
+    override var optionalNestedMessage: TestAllTypesEdition2023.NestedMessage by __optionalNestedMessageDelegate
+    internal val __optionalForeignMessageDelegate: MsgFieldDelegate<ForeignMessageEdition2023> = MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageEdition2023Internal.DEFAULT }
+    override var optionalForeignMessage: ForeignMessageEdition2023 by __optionalForeignMessageDelegate
+    internal val __optionalNestedEnumDelegate: MsgFieldDelegate<TestAllTypesEdition2023.NestedEnum?> = MsgFieldDelegate(PresenceIndices.optionalNestedEnum) { null }
+    override var optionalNestedEnum: TestAllTypesEdition2023.NestedEnum? by __optionalNestedEnumDelegate
+    internal val __optionalForeignEnumDelegate: MsgFieldDelegate<ForeignEnumEdition2023?> = MsgFieldDelegate(PresenceIndices.optionalForeignEnum) { null }
+    override var optionalForeignEnum: ForeignEnumEdition2023? by __optionalForeignEnumDelegate
+    internal val __optionalStringPieceDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalStringPiece) { null }
+    override var optionalStringPiece: String? by __optionalStringPieceDelegate
+    internal val __optionalCordDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalCord) { null }
+    override var optionalCord: String? by __optionalCordDelegate
+    internal val __recursiveMessageDelegate: MsgFieldDelegate<TestAllTypesEdition2023> = MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesEdition2023Internal.DEFAULT }
+    override var recursiveMessage: TestAllTypesEdition2023 by __recursiveMessageDelegate
+    internal val __repeatedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32: List<Int> by __repeatedInt32Delegate
+    internal val __repeatedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt64: List<Long> by __repeatedInt64Delegate
+    internal val __repeatedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint32: List<UInt> by __repeatedUint32Delegate
+    internal val __repeatedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint64: List<ULong> by __repeatedUint64Delegate
+    internal val __repeatedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint32: List<Int> by __repeatedSint32Delegate
+    internal val __repeatedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint64: List<Long> by __repeatedSint64Delegate
+    internal val __repeatedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed32: List<UInt> by __repeatedFixed32Delegate
+    internal val __repeatedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed64: List<ULong> by __repeatedFixed64Delegate
+    internal val __repeatedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed32: List<Int> by __repeatedSfixed32Delegate
+    internal val __repeatedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed64: List<Long> by __repeatedSfixed64Delegate
+    internal val __repeatedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFloat: List<Float> by __repeatedFloatDelegate
+    internal val __repeatedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDouble: List<Double> by __repeatedDoubleDelegate
+    internal val __repeatedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBool: List<Boolean> by __repeatedBoolDelegate
+    internal val __repeatedStringDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedString: List<String> by __repeatedStringDelegate
+    internal val __repeatedBytesDelegate: MsgFieldDelegate<List<ByteString>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBytes: List<ByteString> by __repeatedBytesDelegate
+    internal val __repeatedNestedMessageDelegate: MsgFieldDelegate<List<TestAllTypesEdition2023.NestedMessage>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedMessage: List<TestAllTypesEdition2023.NestedMessage> by __repeatedNestedMessageDelegate
+    internal val __repeatedForeignMessageDelegate: MsgFieldDelegate<List<ForeignMessageEdition2023>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignMessage: List<ForeignMessageEdition2023> by __repeatedForeignMessageDelegate
+    internal val __repeatedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesEdition2023.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedEnum: List<TestAllTypesEdition2023.NestedEnum> by __repeatedNestedEnumDelegate
+    internal val __repeatedForeignEnumDelegate: MsgFieldDelegate<List<ForeignEnumEdition2023>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignEnum: List<ForeignEnumEdition2023> by __repeatedForeignEnumDelegate
+    internal val __repeatedStringPieceDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStringPiece: List<String> by __repeatedStringPieceDelegate
+    internal val __repeatedCordDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedCord: List<String> by __repeatedCordDelegate
+    internal val __packedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedInt32: List<Int> by __packedInt32Delegate
+    internal val __packedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedInt64: List<Long> by __packedInt64Delegate
+    internal val __packedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedUint32: List<UInt> by __packedUint32Delegate
+    internal val __packedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedUint64: List<ULong> by __packedUint64Delegate
+    internal val __packedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSint32: List<Int> by __packedSint32Delegate
+    internal val __packedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSint64: List<Long> by __packedSint64Delegate
+    internal val __packedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed32: List<UInt> by __packedFixed32Delegate
+    internal val __packedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed64: List<ULong> by __packedFixed64Delegate
+    internal val __packedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed32: List<Int> by __packedSfixed32Delegate
+    internal val __packedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed64: List<Long> by __packedSfixed64Delegate
+    internal val __packedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var packedFloat: List<Float> by __packedFloatDelegate
+    internal val __packedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var packedDouble: List<Double> by __packedDoubleDelegate
+    internal val __packedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var packedBool: List<Boolean> by __packedBoolDelegate
+    internal val __packedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesEdition2023.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var packedNestedEnum: List<TestAllTypesEdition2023.NestedEnum> by __packedNestedEnumDelegate
+    internal val __unpackedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt32: List<Int> by __unpackedInt32Delegate
+    internal val __unpackedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt64: List<Long> by __unpackedInt64Delegate
+    internal val __unpackedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint32: List<UInt> by __unpackedUint32Delegate
+    internal val __unpackedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint64: List<ULong> by __unpackedUint64Delegate
+    internal val __unpackedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint32: List<Int> by __unpackedSint32Delegate
+    internal val __unpackedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint64: List<Long> by __unpackedSint64Delegate
+    internal val __unpackedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed32: List<UInt> by __unpackedFixed32Delegate
+    internal val __unpackedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed64: List<ULong> by __unpackedFixed64Delegate
+    internal val __unpackedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed32: List<Int> by __unpackedSfixed32Delegate
+    internal val __unpackedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed64: List<Long> by __unpackedSfixed64Delegate
+    internal val __unpackedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFloat: List<Float> by __unpackedFloatDelegate
+    internal val __unpackedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var unpackedDouble: List<Double> by __unpackedDoubleDelegate
+    internal val __unpackedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var unpackedBool: List<Boolean> by __unpackedBoolDelegate
+    internal val __unpackedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesEdition2023.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var unpackedNestedEnum: List<TestAllTypesEdition2023.NestedEnum> by __unpackedNestedEnumDelegate
+    internal val __mapInt32Int32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Int32: Map<Int, Int> by __mapInt32Int32Delegate
+    internal val __mapInt64Int64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt64Int64: Map<Long, Long> by __mapInt64Int64Delegate
+    internal val __mapUint32Uint32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint32Uint32: Map<UInt, UInt> by __mapUint32Uint32Delegate
+    internal val __mapUint64Uint64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint64Uint64: Map<ULong, ULong> by __mapUint64Uint64Delegate
+    internal val __mapSint32Sint32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint32Sint32: Map<Int, Int> by __mapSint32Sint32Delegate
+    internal val __mapSint64Sint64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint64Sint64: Map<Long, Long> by __mapSint64Sint64Delegate
+    internal val __mapFixed32Fixed32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed32Fixed32: Map<UInt, UInt> by __mapFixed32Fixed32Delegate
+    internal val __mapFixed64Fixed64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed64Fixed64: Map<ULong, ULong> by __mapFixed64Fixed64Delegate
+    internal val __mapSfixed32Sfixed32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed32Sfixed32: Map<Int, Int> by __mapSfixed32Sfixed32Delegate
+    internal val __mapSfixed64Sfixed64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed64Sfixed64: Map<Long, Long> by __mapSfixed64Sfixed64Delegate
+    internal val __mapInt32FloatDelegate: MsgFieldDelegate<Map<Int, Float>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Float: Map<Int, Float> by __mapInt32FloatDelegate
+    internal val __mapInt32DoubleDelegate: MsgFieldDelegate<Map<Int, Double>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Double: Map<Int, Double> by __mapInt32DoubleDelegate
+    internal val __mapBoolBoolDelegate: MsgFieldDelegate<Map<Boolean, Boolean>> = MsgFieldDelegate { emptyMap() }
+    override var mapBoolBool: Map<Boolean, Boolean> by __mapBoolBoolDelegate
+    internal val __mapStringStringDelegate: MsgFieldDelegate<Map<String, String>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringString: Map<String, String> by __mapStringStringDelegate
+    internal val __mapStringBytesDelegate: MsgFieldDelegate<Map<String, ByteString>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringBytes: Map<String, ByteString> by __mapStringBytesDelegate
+    internal val __mapStringNestedMessageDelegate: MsgFieldDelegate<Map<String, TestAllTypesEdition2023.NestedMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedMessage: Map<String, TestAllTypesEdition2023.NestedMessage> by __mapStringNestedMessageDelegate
+    internal val __mapStringForeignMessageDelegate: MsgFieldDelegate<Map<String, ForeignMessageEdition2023>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignMessage: Map<String, ForeignMessageEdition2023> by __mapStringForeignMessageDelegate
+    internal val __mapStringNestedEnumDelegate: MsgFieldDelegate<Map<String, TestAllTypesEdition2023.NestedEnum>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedEnum: Map<String, TestAllTypesEdition2023.NestedEnum> by __mapStringNestedEnumDelegate
+    internal val __mapStringForeignEnumDelegate: MsgFieldDelegate<Map<String, ForeignEnumEdition2023>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignEnum: Map<String, ForeignEnumEdition2023> by __mapStringForeignEnumDelegate
+    internal val __groupliketypeDelegate: MsgFieldDelegate<TestAllTypesEdition2023.GroupLikeType> = MsgFieldDelegate(PresenceIndices.groupliketype) { GroupLikeTypeInternal.DEFAULT }
+    override var groupliketype: TestAllTypesEdition2023.GroupLikeType by __groupliketypeDelegate
+    internal val __delimitedFieldDelegate: MsgFieldDelegate<TestAllTypesEdition2023.GroupLikeType> = MsgFieldDelegate(PresenceIndices.delimitedField) { GroupLikeTypeInternal.DEFAULT }
+    override var delimitedField: TestAllTypesEdition2023.GroupLikeType by __delimitedFieldDelegate
     override var oneofField: TestAllTypesEdition2023.OneofField? = null
 
     private val _owner: TestAllTypesEdition2023Internal = this
@@ -1045,8 +1140,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int? by MsgFieldDelegate(PresenceIndices.a) { null }
-        override var corecursive: TestAllTypesEdition2023 by MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesEdition2023Internal() }
+        internal val __aDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.a) { null }
+        override var a: Int? by __aDelegate
+        internal val __corecursiveDelegate: MsgFieldDelegate<TestAllTypesEdition2023> = MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesEdition2023Internal.DEFAULT }
+        override var corecursive: TestAllTypesEdition2023 by __corecursiveDelegate
 
         private val _owner: NestedMessageInternal = this
 
@@ -1156,7 +1253,9 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesEdition2023.NestedMessage by lazy { NestedMessageInternal() }
+        }
     }
 
     class MapInt32Int32EntryInternal: InternalMessage(fieldsWithPresence = 2) {
@@ -1174,8 +1273,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1245,8 +1346,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1316,8 +1419,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate(PresenceIndices.key) { 0u }
-        var value: UInt by MsgFieldDelegate(PresenceIndices.value) { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.key) { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.value) { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1387,8 +1492,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate(PresenceIndices.key) { 0uL }
-        var value: ULong by MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.key) { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1458,8 +1565,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1529,8 +1638,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1600,8 +1711,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate(PresenceIndices.key) { 0u }
-        var value: UInt by MsgFieldDelegate(PresenceIndices.value) { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.key) { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.value) { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1671,8 +1784,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate(PresenceIndices.key) { 0uL }
-        var value: ULong by MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.key) { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1742,8 +1857,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1813,8 +1930,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1884,8 +2003,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Float by MsgFieldDelegate(PresenceIndices.value) { 0.0f }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.value) { 0.0f }
+        var value: Float by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1955,8 +2076,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Double by MsgFieldDelegate(PresenceIndices.value) { 0.0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.value) { 0.0 }
+        var value: Double by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2026,8 +2149,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Boolean by MsgFieldDelegate(PresenceIndices.key) { false }
-        var value: Boolean by MsgFieldDelegate(PresenceIndices.value) { false }
+        internal val __keyDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.key) { false }
+        var key: Boolean by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.value) { false }
+        var value: Boolean by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2097,8 +2222,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: String by MsgFieldDelegate(PresenceIndices.value) { "" }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.value) { "" }
+        var value: String by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2168,8 +2295,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ByteString by MsgFieldDelegate(PresenceIndices.value) { ByteString() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.value) { ByteString() }
+        var value: ByteString by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2239,8 +2368,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: TestAllTypesEdition2023.NestedMessage by MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesEdition2023.NestedMessage> = MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal.DEFAULT }
+        var value: TestAllTypesEdition2023.NestedMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2310,8 +2441,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ForeignMessageEdition2023 by MsgFieldDelegate(PresenceIndices.value) { ForeignMessageEdition2023Internal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignMessageEdition2023> = MsgFieldDelegate(PresenceIndices.value) { ForeignMessageEdition2023Internal.DEFAULT }
+        var value: ForeignMessageEdition2023 by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2381,8 +2514,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: TestAllTypesEdition2023.NestedEnum by MsgFieldDelegate(PresenceIndices.value) { TestAllTypesEdition2023.NestedEnum.FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesEdition2023.NestedEnum> = MsgFieldDelegate(PresenceIndices.value) { TestAllTypesEdition2023.NestedEnum.FOO }
+        var value: TestAllTypesEdition2023.NestedEnum by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2452,8 +2587,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ForeignEnumEdition2023 by MsgFieldDelegate(PresenceIndices.value) { ForeignEnumEdition2023.FOREIGN_FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignEnumEdition2023> = MsgFieldDelegate(PresenceIndices.value) { ForeignEnumEdition2023.FOREIGN_FOO }
+        var value: ForeignEnumEdition2023 by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2523,8 +2660,10 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var groupInt32: Int? by MsgFieldDelegate(PresenceIndices.groupInt32) { null }
-        override var groupUint32: UInt? by MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        internal val __groupInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.groupInt32) { null }
+        override var groupInt32: Int? by __groupInt32Delegate
+        internal val __groupUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        override var groupUint32: UInt? by __groupUint32Delegate
 
         private val _owner: GroupLikeTypeInternal = this
 
@@ -2634,7 +2773,9 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesEdition2023.GroupLikeType by lazy { GroupLikeTypeInternal() }
+        }
     }
 
     @InternalRpcApi
@@ -2669,7 +2810,9 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestAllTypesEdition2023 by lazy { TestAllTypesEdition2023Internal() }
+    }
 }
 
 class ForeignMessageEdition2023Internal: ForeignMessageEdition2023.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -2686,7 +2829,8 @@ class ForeignMessageEdition2023Internal: ForeignMessageEdition2023.Builder, Inte
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var c: Int? by MsgFieldDelegate(PresenceIndices.c) { null }
+    internal val __cDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.c) { null }
+    override var c: Int? by __cDelegate
 
     private val _owner: ForeignMessageEdition2023Internal = this
 
@@ -2782,7 +2926,9 @@ class ForeignMessageEdition2023Internal: ForeignMessageEdition2023.Builder, Inte
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ForeignMessageEdition2023 by lazy { ForeignMessageEdition2023Internal() }
+    }
 }
 
 class GroupLikeTypeInternal: GroupLikeType.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -2799,7 +2945,8 @@ class GroupLikeTypeInternal: GroupLikeType.Builder, InternalMessage(fieldsWithPr
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var c: Int? by MsgFieldDelegate(PresenceIndices.c) { null }
+    internal val __cDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.c) { null }
+    override var c: Int? by __cDelegate
 
     private val _owner: GroupLikeTypeInternal = this
 
@@ -2895,7 +3042,9 @@ class GroupLikeTypeInternal: GroupLikeType.Builder, InternalMessage(fieldsWithPr
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: GroupLikeType by lazy { GroupLikeTypeInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -3666,18 +3815,12 @@ fun TestAllTypesEdition2023Internal.Companion.decodeWith(msg: TestAllTypesEditio
                 msg.optionalBytes = decoder.readBytes()
             }
             tag.fieldNr == 18 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[15]) {
-                    msg.optionalNestedMessage = TestAllTypesEdition2023Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.optionalNestedMessage.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalNestedMessageDelegate.getOrCreate(msg) { TestAllTypesEdition2023Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 19 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[16]) {
-                    msg.optionalForeignMessage = ForeignMessageEdition2023Internal()
-                }
-
-                decoder.readMessage(msg.optionalForeignMessage.asInternal(), { msg, decoder -> ForeignMessageEdition2023Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalForeignMessageDelegate.getOrCreate(msg) { ForeignMessageEdition2023Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageEdition2023Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 21 && tag.wireType == WireType.VARINT -> {
                 msg.optionalNestedEnum = TestAllTypesEdition2023.NestedEnum.fromNumber(decoder.readEnum())
@@ -3692,466 +3835,568 @@ fun TestAllTypesEdition2023Internal.Companion.decodeWith(msg: TestAllTypesEditio
                 msg.optionalCord = decoder.readString()
             }
             tag.fieldNr == 27 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[21]) {
-                    msg.recursiveMessage = TestAllTypesEdition2023Internal()
-                }
-
-                decoder.readMessage(msg.recursiveMessage.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__recursiveMessageDelegate.getOrCreate(msg) { TestAllTypesEdition2023Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 31 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt32 += decoder.readPackedInt32()
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 31 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.repeatedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 32 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt64 += decoder.readPackedInt64()
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 32 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.repeatedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 33 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint32 += decoder.readPackedUInt32()
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 33 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.repeatedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 34 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint64 += decoder.readPackedUInt64()
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 34 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.repeatedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 35 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint32 += decoder.readPackedSInt32()
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 35 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.repeatedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 36 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint64 += decoder.readPackedSInt64()
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 36 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.repeatedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 37 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 37 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.repeatedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 38 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 38 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.repeatedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 39 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 39 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.repeatedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 40 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 40 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.repeatedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 41 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFloat += decoder.readPackedFloat()
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 41 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.repeatedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 42 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedDouble += decoder.readPackedDouble()
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 42 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.repeatedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 43 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedBool += decoder.readPackedBool()
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 43 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.repeatedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 44 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedString as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 45 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBytesDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBytes()
-                (msg.repeatedBytes as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 48 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedNestedMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesEdition2023Internal.NestedMessageInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedNestedMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 49 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedForeignMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignMessageEdition2023Internal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ForeignMessageEdition2023Internal.decodeWith(msg, decoder, config) })
-                (msg.repeatedForeignMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 51 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedNestedEnum += decoder.readPackedEnum().map { TestAllTypesEdition2023.NestedEnum.fromNumber(it) }
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesEdition2023.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 51 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesEdition2023.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.repeatedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 52 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedForeignEnum += decoder.readPackedEnum().map { ForeignEnumEdition2023.fromNumber(it) }
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { ForeignEnumEdition2023.fromNumber(it) })
             }
             tag.fieldNr == 52 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignEnumEdition2023.fromNumber(decoder.readEnum())
-                (msg.repeatedForeignEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 54 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringPieceDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedStringPiece as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 55 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedCordDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedCord as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 75 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt32 += decoder.readPackedInt32()
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 75 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.packedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 76 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt64 += decoder.readPackedInt64()
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 76 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.packedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 77 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint32 += decoder.readPackedUInt32()
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 77 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.packedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 78 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint64 += decoder.readPackedUInt64()
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 78 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.packedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 79 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint32 += decoder.readPackedSInt32()
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 79 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.packedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 80 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint64 += decoder.readPackedSInt64()
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 80 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.packedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 81 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 81 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.packedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 82 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 82 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.packedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 83 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 83 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.packedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 84 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 84 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.packedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 85 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFloat += decoder.readPackedFloat()
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 85 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.packedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 86 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedDouble += decoder.readPackedDouble()
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 86 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.packedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 87 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedBool += decoder.readPackedBool()
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 87 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.packedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 88 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedNestedEnum += decoder.readPackedEnum().map { TestAllTypesEdition2023.NestedEnum.fromNumber(it) }
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesEdition2023.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 88 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesEdition2023.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.packedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 89 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt32 += decoder.readPackedInt32()
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 89 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.unpackedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 90 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt64 += decoder.readPackedInt64()
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 90 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.unpackedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 91 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint32 += decoder.readPackedUInt32()
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 91 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.unpackedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 92 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint64 += decoder.readPackedUInt64()
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 92 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.unpackedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 93 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint32 += decoder.readPackedSInt32()
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 93 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.unpackedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 94 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint64 += decoder.readPackedSInt64()
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 94 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.unpackedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 95 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 95 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.unpackedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 96 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 96 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.unpackedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 97 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 97 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.unpackedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 98 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 98 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.unpackedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 99 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFloat += decoder.readPackedFloat()
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 99 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.unpackedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 100 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedDouble += decoder.readPackedDouble()
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 100 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.unpackedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 101 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedBool += decoder.readPackedBool()
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 101 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.unpackedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 102 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedNestedEnum += decoder.readPackedEnum().map { TestAllTypesEdition2023.NestedEnum.fromNumber(it) }
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesEdition2023.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 102 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesEdition2023.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.unpackedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 56 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32Int32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapInt32Int32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapInt32Int32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Int32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 57 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt64Int64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapInt64Int64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapInt64Int64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt64Int64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 58 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint32Uint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapUint32Uint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapUint32Uint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint32Uint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 59 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint64Uint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapUint64Uint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapUint64Uint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint64Uint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 60 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint32Sint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapSint32Sint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapSint32Sint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint32Sint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 61 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint64Sint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapSint64Sint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapSint64Sint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint64Sint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 62 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed32Fixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapFixed32Fixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapFixed32Fixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed32Fixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 63 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed64Fixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapFixed64Fixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapFixed64Fixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed64Fixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 64 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed32Sfixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapSfixed32Sfixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapSfixed32Sfixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed32Sfixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 65 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed64Sfixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapSfixed64Sfixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapSfixed64Sfixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed64Sfixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 66 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32FloatDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapInt32FloatEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapInt32FloatEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Float as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 67 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32DoubleDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapInt32DoubleEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapInt32DoubleEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Double as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 68 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapBoolBoolDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapBoolBoolEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapBoolBoolEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapBoolBool as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 69 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringStringDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapStringStringEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapStringStringEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringString as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 70 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringBytesDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapStringBytesEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapStringBytesEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringBytes as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 71 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapStringNestedMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapStringNestedMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 72 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapStringForeignMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapStringForeignMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 73 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapStringNestedEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapStringNestedEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 74 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesEdition2023Internal.MapStringForeignEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.MapStringForeignEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 201 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[22]) {
-                    msg.groupliketype = TestAllTypesEdition2023Internal.GroupLikeTypeInternal()
-                }
-
-                decoder.readGroup(msg.groupliketype.asInternal()) { msg, decoder -> TestAllTypesEdition2023Internal.GroupLikeTypeInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__groupliketypeDelegate.getOrCreate(msg) { TestAllTypesEdition2023Internal.GroupLikeTypeInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllTypesEdition2023Internal.GroupLikeTypeInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 202 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[23]) {
-                    msg.delimitedField = TestAllTypesEdition2023Internal.GroupLikeTypeInternal()
-                }
-
-                decoder.readGroup(msg.delimitedField.asInternal()) { msg, decoder -> TestAllTypesEdition2023Internal.GroupLikeTypeInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__delimitedFieldDelegate.getOrCreate(msg) { TestAllTypesEdition2023Internal.GroupLikeTypeInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllTypesEdition2023Internal.GroupLikeTypeInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 111 && tag.wireType == WireType.VARINT -> {
                 msg.oneofField = TestAllTypesEdition2023.OneofField.OneofUint32(decoder.readUInt32())
@@ -4906,11 +5151,8 @@ fun TestAllTypesEdition2023Internal.NestedMessageInternal.Companion.decodeWith(m
                 msg.a = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.corecursive = TestAllTypesEdition2023Internal()
-                }
-
-                decoder.readMessage(msg.corecursive.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__corecursiveDelegate.getOrCreate(msg) { TestAllTypesEdition2023Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -6129,11 +6371,8 @@ fun TestAllTypesEdition2023Internal.MapStringNestedMessageEntryInternal.Companio
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = TestAllTypesEdition2023Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { TestAllTypesEdition2023Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesEdition2023Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -6212,11 +6451,8 @@ fun TestAllTypesEdition2023Internal.MapStringForeignMessageEntryInternal.Compani
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = ForeignMessageEdition2023Internal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> ForeignMessageEdition2023Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { ForeignMessageEdition2023Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageEdition2023Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -6566,7 +6802,7 @@ object TestMessagesEdition2023KtExtensions {
             name = "groupliketype",
             extendee = TestAllTypesEdition2023::class,
             valueType = GroupLikeType::class,
-            default = { GroupLikeTypeInternal() },
+            default = { GroupLikeTypeInternal.DEFAULT },
             asInternal = { it.asInternal() },
             encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
             decodeWith = { value, decoder, config -> GroupLikeTypeInternal.decodeWith(value.asInternal(), decoder, config) },
@@ -6578,7 +6814,7 @@ object TestMessagesEdition2023KtExtensions {
             name = "delimitedExt",
             extendee = TestAllTypesEdition2023::class,
             valueType = GroupLikeType::class,
-            default = { GroupLikeTypeInternal() },
+            default = { GroupLikeTypeInternal.DEFAULT },
             asInternal = { it.asInternal() },
             encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
             decodeWith = { value, decoder, config -> GroupLikeTypeInternal.decodeWith(value.asInternal(), decoder, config) },

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto2/_rpc_internal/TestMessagesProto2Editions.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto2/_rpc_internal/TestMessagesProto2Editions.kt
@@ -133,134 +133,262 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var optionalInt32: Int? by MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
-    override var optionalInt64: Long? by MsgFieldDelegate(PresenceIndices.optionalInt64) { null }
-    override var optionalUint32: UInt? by MsgFieldDelegate(PresenceIndices.optionalUint32) { null }
-    override var optionalUint64: ULong? by MsgFieldDelegate(PresenceIndices.optionalUint64) { null }
-    override var optionalSint32: Int? by MsgFieldDelegate(PresenceIndices.optionalSint32) { null }
-    override var optionalSint64: Long? by MsgFieldDelegate(PresenceIndices.optionalSint64) { null }
-    override var optionalFixed32: UInt? by MsgFieldDelegate(PresenceIndices.optionalFixed32) { null }
-    override var optionalFixed64: ULong? by MsgFieldDelegate(PresenceIndices.optionalFixed64) { null }
-    override var optionalSfixed32: Int? by MsgFieldDelegate(PresenceIndices.optionalSfixed32) { null }
-    override var optionalSfixed64: Long? by MsgFieldDelegate(PresenceIndices.optionalSfixed64) { null }
-    override var optionalFloat: Float? by MsgFieldDelegate(PresenceIndices.optionalFloat) { null }
-    override var optionalDouble: Double? by MsgFieldDelegate(PresenceIndices.optionalDouble) { null }
-    override var optionalBool: Boolean? by MsgFieldDelegate(PresenceIndices.optionalBool) { null }
-    override var optionalString: String? by MsgFieldDelegate(PresenceIndices.optionalString) { null }
-    override var optionalBytes: ByteString? by MsgFieldDelegate(PresenceIndices.optionalBytes) { null }
-    override var optionalNestedMessage: TestAllTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal() }
-    override var optionalForeignMessage: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageProto2Internal() }
-    override var optionalNestedEnum: TestAllTypesProto2.NestedEnum? by MsgFieldDelegate(PresenceIndices.optionalNestedEnum) { null }
-    override var optionalForeignEnum: ForeignEnumProto2? by MsgFieldDelegate(PresenceIndices.optionalForeignEnum) { null }
-    override var optionalStringPiece: String? by MsgFieldDelegate(PresenceIndices.optionalStringPiece) { null }
-    override var optionalCord: String? by MsgFieldDelegate(PresenceIndices.optionalCord) { null }
-    override var recursiveMessage: TestAllTypesProto2 by MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto2Internal() }
-    override var repeatedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedString: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBytes: List<ByteString> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedMessage: List<TestAllTypesProto2.NestedMessage> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignMessage: List<ForeignMessageProto2> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedEnum: List<TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignEnum: List<ForeignEnumProto2> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStringPiece: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedCord: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var packedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var packedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var packedNestedEnum: List<TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedNestedEnum: List<TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var mapInt32Int32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt64Int64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint32Uint32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint64Uint64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint32Sint32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint64Sint64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed32Fixed32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed64Fixed64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed32Sfixed32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed64Sfixed64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Bool: Map<Int, Boolean> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Float: Map<Int, Float> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Double: Map<Int, Double> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32NestedMessage: Map<Int, TestAllTypesProto2.NestedMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapBoolBool: Map<Boolean, Boolean> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringString: Map<String, String> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringBytes: Map<String, ByteString> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedMessage: Map<String, TestAllTypesProto2.NestedMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignMessage: Map<String, ForeignMessageProto2> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedEnum: Map<String, TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignEnum: Map<String, ForeignEnumProto2> by MsgFieldDelegate { mutableMapOf() }
-    override var data: TestAllTypesProto2.Data by MsgFieldDelegate(PresenceIndices.data) { DataInternal() }
-    override var multiwordgroupfield: TestAllTypesProto2.MultiWordGroupField by MsgFieldDelegate(PresenceIndices.multiwordgroupfield) { MultiWordGroupFieldInternal() }
-    override var defaultInt32: Int by MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
-    override var defaultInt64: Long by MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
-    override var defaultUint32: UInt by MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
-    override var defaultUint64: ULong by MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
-    override var defaultSint32: Int by MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
-    override var defaultSint64: Long by MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
-    override var defaultFixed32: UInt by MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
-    override var defaultFixed64: ULong by MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
-    override var defaultSfixed32: Int by MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
-    override var defaultSfixed64: Long by MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
-    override var defaultFloat: Float by MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
-    override var defaultDouble: Double by MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
-    override var defaultBool: Boolean by MsgFieldDelegate(PresenceIndices.defaultBool) { true }
-    override var defaultString: String by MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
-    override var defaultBytes: ByteString by MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
-    override var fieldname1: Int? by MsgFieldDelegate(PresenceIndices.fieldname1) { null }
-    override var fieldName2: Int? by MsgFieldDelegate(PresenceIndices.fieldName2) { null }
-    override var FieldName3: Int? by MsgFieldDelegate(PresenceIndices.FieldName3) { null }
-    override var field_Name4_: Int? by MsgFieldDelegate(PresenceIndices.field_Name4_) { null }
-    override var field0name5: Int? by MsgFieldDelegate(PresenceIndices.field0name5) { null }
-    override var field_0Name6: Int? by MsgFieldDelegate(PresenceIndices.field_0Name6) { null }
-    override var fieldName7: Int? by MsgFieldDelegate(PresenceIndices.fieldName7) { null }
-    override var FieldName8: Int? by MsgFieldDelegate(PresenceIndices.FieldName8) { null }
-    override var field_Name9: Int? by MsgFieldDelegate(PresenceIndices.field_Name9) { null }
-    override var Field_Name10: Int? by MsgFieldDelegate(PresenceIndices.Field_Name10) { null }
-    override var FIELD_NAME11: Int? by MsgFieldDelegate(PresenceIndices.FIELD_NAME11) { null }
-    override var FIELDName12: Int? by MsgFieldDelegate(PresenceIndices.FIELDName12) { null }
-    override var _FieldName13: Int? by MsgFieldDelegate(PresenceIndices._FieldName13) { null }
-    override var __FieldName14: Int? by MsgFieldDelegate(PresenceIndices.__FieldName14) { null }
-    override var field_Name15: Int? by MsgFieldDelegate(PresenceIndices.field_Name15) { null }
-    override var field__Name16: Int? by MsgFieldDelegate(PresenceIndices.field__Name16) { null }
-    override var fieldName17__: Int? by MsgFieldDelegate(PresenceIndices.fieldName17__) { null }
-    override var FieldName18__: Int? by MsgFieldDelegate(PresenceIndices.FieldName18__) { null }
-    override var messageSetCorrect: TestAllTypesProto2.MessageSetCorrect by MsgFieldDelegate(PresenceIndices.messageSetCorrect) { MessageSetCorrectInternal() }
+    internal val __optionalInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
+    override var optionalInt32: Int? by __optionalInt32Delegate
+    internal val __optionalInt64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalInt64) { null }
+    override var optionalInt64: Long? by __optionalInt64Delegate
+    internal val __optionalUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.optionalUint32) { null }
+    override var optionalUint32: UInt? by __optionalUint32Delegate
+    internal val __optionalUint64Delegate: MsgFieldDelegate<ULong?> = MsgFieldDelegate(PresenceIndices.optionalUint64) { null }
+    override var optionalUint64: ULong? by __optionalUint64Delegate
+    internal val __optionalSint32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalSint32) { null }
+    override var optionalSint32: Int? by __optionalSint32Delegate
+    internal val __optionalSint64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalSint64) { null }
+    override var optionalSint64: Long? by __optionalSint64Delegate
+    internal val __optionalFixed32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.optionalFixed32) { null }
+    override var optionalFixed32: UInt? by __optionalFixed32Delegate
+    internal val __optionalFixed64Delegate: MsgFieldDelegate<ULong?> = MsgFieldDelegate(PresenceIndices.optionalFixed64) { null }
+    override var optionalFixed64: ULong? by __optionalFixed64Delegate
+    internal val __optionalSfixed32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalSfixed32) { null }
+    override var optionalSfixed32: Int? by __optionalSfixed32Delegate
+    internal val __optionalSfixed64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalSfixed64) { null }
+    override var optionalSfixed64: Long? by __optionalSfixed64Delegate
+    internal val __optionalFloatDelegate: MsgFieldDelegate<Float?> = MsgFieldDelegate(PresenceIndices.optionalFloat) { null }
+    override var optionalFloat: Float? by __optionalFloatDelegate
+    internal val __optionalDoubleDelegate: MsgFieldDelegate<Double?> = MsgFieldDelegate(PresenceIndices.optionalDouble) { null }
+    override var optionalDouble: Double? by __optionalDoubleDelegate
+    internal val __optionalBoolDelegate: MsgFieldDelegate<Boolean?> = MsgFieldDelegate(PresenceIndices.optionalBool) { null }
+    override var optionalBool: Boolean? by __optionalBoolDelegate
+    internal val __optionalStringDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalString) { null }
+    override var optionalString: String? by __optionalStringDelegate
+    internal val __optionalBytesDelegate: MsgFieldDelegate<ByteString?> = MsgFieldDelegate(PresenceIndices.optionalBytes) { null }
+    override var optionalBytes: ByteString? by __optionalBytesDelegate
+    internal val __optionalNestedMessageDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal.DEFAULT }
+    override var optionalNestedMessage: TestAllTypesProto2.NestedMessage by __optionalNestedMessageDelegate
+    internal val __optionalForeignMessageDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageProto2Internal.DEFAULT }
+    override var optionalForeignMessage: ForeignMessageProto2 by __optionalForeignMessageDelegate
+    internal val __optionalNestedEnumDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedEnum?> = MsgFieldDelegate(PresenceIndices.optionalNestedEnum) { null }
+    override var optionalNestedEnum: TestAllTypesProto2.NestedEnum? by __optionalNestedEnumDelegate
+    internal val __optionalForeignEnumDelegate: MsgFieldDelegate<ForeignEnumProto2?> = MsgFieldDelegate(PresenceIndices.optionalForeignEnum) { null }
+    override var optionalForeignEnum: ForeignEnumProto2? by __optionalForeignEnumDelegate
+    internal val __optionalStringPieceDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalStringPiece) { null }
+    override var optionalStringPiece: String? by __optionalStringPieceDelegate
+    internal val __optionalCordDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalCord) { null }
+    override var optionalCord: String? by __optionalCordDelegate
+    internal val __recursiveMessageDelegate: MsgFieldDelegate<TestAllTypesProto2> = MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto2Internal.DEFAULT }
+    override var recursiveMessage: TestAllTypesProto2 by __recursiveMessageDelegate
+    internal val __repeatedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32: List<Int> by __repeatedInt32Delegate
+    internal val __repeatedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt64: List<Long> by __repeatedInt64Delegate
+    internal val __repeatedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint32: List<UInt> by __repeatedUint32Delegate
+    internal val __repeatedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint64: List<ULong> by __repeatedUint64Delegate
+    internal val __repeatedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint32: List<Int> by __repeatedSint32Delegate
+    internal val __repeatedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint64: List<Long> by __repeatedSint64Delegate
+    internal val __repeatedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed32: List<UInt> by __repeatedFixed32Delegate
+    internal val __repeatedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed64: List<ULong> by __repeatedFixed64Delegate
+    internal val __repeatedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed32: List<Int> by __repeatedSfixed32Delegate
+    internal val __repeatedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed64: List<Long> by __repeatedSfixed64Delegate
+    internal val __repeatedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFloat: List<Float> by __repeatedFloatDelegate
+    internal val __repeatedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDouble: List<Double> by __repeatedDoubleDelegate
+    internal val __repeatedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBool: List<Boolean> by __repeatedBoolDelegate
+    internal val __repeatedStringDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedString: List<String> by __repeatedStringDelegate
+    internal val __repeatedBytesDelegate: MsgFieldDelegate<List<ByteString>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBytes: List<ByteString> by __repeatedBytesDelegate
+    internal val __repeatedNestedMessageDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedMessage>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedMessage: List<TestAllTypesProto2.NestedMessage> by __repeatedNestedMessageDelegate
+    internal val __repeatedForeignMessageDelegate: MsgFieldDelegate<List<ForeignMessageProto2>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignMessage: List<ForeignMessageProto2> by __repeatedForeignMessageDelegate
+    internal val __repeatedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedEnum: List<TestAllTypesProto2.NestedEnum> by __repeatedNestedEnumDelegate
+    internal val __repeatedForeignEnumDelegate: MsgFieldDelegate<List<ForeignEnumProto2>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignEnum: List<ForeignEnumProto2> by __repeatedForeignEnumDelegate
+    internal val __repeatedStringPieceDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStringPiece: List<String> by __repeatedStringPieceDelegate
+    internal val __repeatedCordDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedCord: List<String> by __repeatedCordDelegate
+    internal val __packedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedInt32: List<Int> by __packedInt32Delegate
+    internal val __packedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedInt64: List<Long> by __packedInt64Delegate
+    internal val __packedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedUint32: List<UInt> by __packedUint32Delegate
+    internal val __packedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedUint64: List<ULong> by __packedUint64Delegate
+    internal val __packedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSint32: List<Int> by __packedSint32Delegate
+    internal val __packedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSint64: List<Long> by __packedSint64Delegate
+    internal val __packedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed32: List<UInt> by __packedFixed32Delegate
+    internal val __packedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed64: List<ULong> by __packedFixed64Delegate
+    internal val __packedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed32: List<Int> by __packedSfixed32Delegate
+    internal val __packedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed64: List<Long> by __packedSfixed64Delegate
+    internal val __packedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var packedFloat: List<Float> by __packedFloatDelegate
+    internal val __packedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var packedDouble: List<Double> by __packedDoubleDelegate
+    internal val __packedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var packedBool: List<Boolean> by __packedBoolDelegate
+    internal val __packedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var packedNestedEnum: List<TestAllTypesProto2.NestedEnum> by __packedNestedEnumDelegate
+    internal val __unpackedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt32: List<Int> by __unpackedInt32Delegate
+    internal val __unpackedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt64: List<Long> by __unpackedInt64Delegate
+    internal val __unpackedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint32: List<UInt> by __unpackedUint32Delegate
+    internal val __unpackedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint64: List<ULong> by __unpackedUint64Delegate
+    internal val __unpackedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint32: List<Int> by __unpackedSint32Delegate
+    internal val __unpackedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint64: List<Long> by __unpackedSint64Delegate
+    internal val __unpackedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed32: List<UInt> by __unpackedFixed32Delegate
+    internal val __unpackedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed64: List<ULong> by __unpackedFixed64Delegate
+    internal val __unpackedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed32: List<Int> by __unpackedSfixed32Delegate
+    internal val __unpackedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed64: List<Long> by __unpackedSfixed64Delegate
+    internal val __unpackedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFloat: List<Float> by __unpackedFloatDelegate
+    internal val __unpackedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var unpackedDouble: List<Double> by __unpackedDoubleDelegate
+    internal val __unpackedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var unpackedBool: List<Boolean> by __unpackedBoolDelegate
+    internal val __unpackedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var unpackedNestedEnum: List<TestAllTypesProto2.NestedEnum> by __unpackedNestedEnumDelegate
+    internal val __mapInt32Int32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Int32: Map<Int, Int> by __mapInt32Int32Delegate
+    internal val __mapInt64Int64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt64Int64: Map<Long, Long> by __mapInt64Int64Delegate
+    internal val __mapUint32Uint32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint32Uint32: Map<UInt, UInt> by __mapUint32Uint32Delegate
+    internal val __mapUint64Uint64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint64Uint64: Map<ULong, ULong> by __mapUint64Uint64Delegate
+    internal val __mapSint32Sint32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint32Sint32: Map<Int, Int> by __mapSint32Sint32Delegate
+    internal val __mapSint64Sint64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint64Sint64: Map<Long, Long> by __mapSint64Sint64Delegate
+    internal val __mapFixed32Fixed32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed32Fixed32: Map<UInt, UInt> by __mapFixed32Fixed32Delegate
+    internal val __mapFixed64Fixed64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed64Fixed64: Map<ULong, ULong> by __mapFixed64Fixed64Delegate
+    internal val __mapSfixed32Sfixed32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed32Sfixed32: Map<Int, Int> by __mapSfixed32Sfixed32Delegate
+    internal val __mapSfixed64Sfixed64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed64Sfixed64: Map<Long, Long> by __mapSfixed64Sfixed64Delegate
+    internal val __mapInt32BoolDelegate: MsgFieldDelegate<Map<Int, Boolean>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Bool: Map<Int, Boolean> by __mapInt32BoolDelegate
+    internal val __mapInt32FloatDelegate: MsgFieldDelegate<Map<Int, Float>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Float: Map<Int, Float> by __mapInt32FloatDelegate
+    internal val __mapInt32DoubleDelegate: MsgFieldDelegate<Map<Int, Double>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Double: Map<Int, Double> by __mapInt32DoubleDelegate
+    internal val __mapInt32NestedMessageDelegate: MsgFieldDelegate<Map<Int, TestAllTypesProto2.NestedMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32NestedMessage: Map<Int, TestAllTypesProto2.NestedMessage> by __mapInt32NestedMessageDelegate
+    internal val __mapBoolBoolDelegate: MsgFieldDelegate<Map<Boolean, Boolean>> = MsgFieldDelegate { emptyMap() }
+    override var mapBoolBool: Map<Boolean, Boolean> by __mapBoolBoolDelegate
+    internal val __mapStringStringDelegate: MsgFieldDelegate<Map<String, String>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringString: Map<String, String> by __mapStringStringDelegate
+    internal val __mapStringBytesDelegate: MsgFieldDelegate<Map<String, ByteString>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringBytes: Map<String, ByteString> by __mapStringBytesDelegate
+    internal val __mapStringNestedMessageDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto2.NestedMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedMessage: Map<String, TestAllTypesProto2.NestedMessage> by __mapStringNestedMessageDelegate
+    internal val __mapStringForeignMessageDelegate: MsgFieldDelegate<Map<String, ForeignMessageProto2>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignMessage: Map<String, ForeignMessageProto2> by __mapStringForeignMessageDelegate
+    internal val __mapStringNestedEnumDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedEnum: Map<String, TestAllTypesProto2.NestedEnum> by __mapStringNestedEnumDelegate
+    internal val __mapStringForeignEnumDelegate: MsgFieldDelegate<Map<String, ForeignEnumProto2>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignEnum: Map<String, ForeignEnumProto2> by __mapStringForeignEnumDelegate
+    internal val __dataDelegate: MsgFieldDelegate<TestAllTypesProto2.Data> = MsgFieldDelegate(PresenceIndices.data) { DataInternal.DEFAULT }
+    override var data: TestAllTypesProto2.Data by __dataDelegate
+    internal val __multiwordgroupfieldDelegate: MsgFieldDelegate<TestAllTypesProto2.MultiWordGroupField> = MsgFieldDelegate(PresenceIndices.multiwordgroupfield) { MultiWordGroupFieldInternal.DEFAULT }
+    override var multiwordgroupfield: TestAllTypesProto2.MultiWordGroupField by __multiwordgroupfieldDelegate
+    internal val __defaultInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
+    override var defaultInt32: Int by __defaultInt32Delegate
+    internal val __defaultInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
+    override var defaultInt64: Long by __defaultInt64Delegate
+    internal val __defaultUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
+    override var defaultUint32: UInt by __defaultUint32Delegate
+    internal val __defaultUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
+    override var defaultUint64: ULong by __defaultUint64Delegate
+    internal val __defaultSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
+    override var defaultSint32: Int by __defaultSint32Delegate
+    internal val __defaultSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
+    override var defaultSint64: Long by __defaultSint64Delegate
+    internal val __defaultFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
+    override var defaultFixed32: UInt by __defaultFixed32Delegate
+    internal val __defaultFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
+    override var defaultFixed64: ULong by __defaultFixed64Delegate
+    internal val __defaultSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
+    override var defaultSfixed32: Int by __defaultSfixed32Delegate
+    internal val __defaultSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
+    override var defaultSfixed64: Long by __defaultSfixed64Delegate
+    internal val __defaultFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
+    override var defaultFloat: Float by __defaultFloatDelegate
+    internal val __defaultDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
+    override var defaultDouble: Double by __defaultDoubleDelegate
+    internal val __defaultBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.defaultBool) { true }
+    override var defaultBool: Boolean by __defaultBoolDelegate
+    internal val __defaultStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
+    override var defaultString: String by __defaultStringDelegate
+    internal val __defaultBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
+    override var defaultBytes: ByteString by __defaultBytesDelegate
+    internal val __fieldname1Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldname1) { null }
+    override var fieldname1: Int? by __fieldname1Delegate
+    internal val __fieldName2Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldName2) { null }
+    override var fieldName2: Int? by __fieldName2Delegate
+    internal val __FieldName3Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FieldName3) { null }
+    override var FieldName3: Int? by __FieldName3Delegate
+    internal val __field_Name4_Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_Name4_) { null }
+    override var field_Name4_: Int? by __field_Name4_Delegate
+    internal val __field0name5Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field0name5) { null }
+    override var field0name5: Int? by __field0name5Delegate
+    internal val __field_0Name6Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_0Name6) { null }
+    override var field_0Name6: Int? by __field_0Name6Delegate
+    internal val __fieldName7Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldName7) { null }
+    override var fieldName7: Int? by __fieldName7Delegate
+    internal val __FieldName8Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FieldName8) { null }
+    override var FieldName8: Int? by __FieldName8Delegate
+    internal val __field_Name9Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_Name9) { null }
+    override var field_Name9: Int? by __field_Name9Delegate
+    internal val __Field_Name10Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.Field_Name10) { null }
+    override var Field_Name10: Int? by __Field_Name10Delegate
+    internal val __FIELD_NAME11Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FIELD_NAME11) { null }
+    override var FIELD_NAME11: Int? by __FIELD_NAME11Delegate
+    internal val __FIELDName12Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FIELDName12) { null }
+    override var FIELDName12: Int? by __FIELDName12Delegate
+    internal val ___FieldName13Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices._FieldName13) { null }
+    override var _FieldName13: Int? by ___FieldName13Delegate
+    internal val ____FieldName14Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.__FieldName14) { null }
+    override var __FieldName14: Int? by ____FieldName14Delegate
+    internal val __field_Name15Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_Name15) { null }
+    override var field_Name15: Int? by __field_Name15Delegate
+    internal val __field__Name16Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field__Name16) { null }
+    override var field__Name16: Int? by __field__Name16Delegate
+    internal val __fieldName17__Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldName17__) { null }
+    override var fieldName17__: Int? by __fieldName17__Delegate
+    internal val __FieldName18__Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FieldName18__) { null }
+    override var FieldName18__: Int? by __FieldName18__Delegate
+    internal val __messageSetCorrectDelegate: MsgFieldDelegate<TestAllTypesProto2.MessageSetCorrect> = MsgFieldDelegate(PresenceIndices.messageSetCorrect) { MessageSetCorrectInternal.DEFAULT }
+    override var messageSetCorrect: TestAllTypesProto2.MessageSetCorrect by __messageSetCorrectDelegate
     override var oneofField: TestAllTypesProto2.OneofField? = null
 
     private val _owner: TestAllTypesProto2Internal = this
@@ -1490,8 +1618,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int? by MsgFieldDelegate(PresenceIndices.a) { null }
-        override var corecursive: TestAllTypesProto2 by MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto2Internal() }
+        internal val __aDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.a) { null }
+        override var a: Int? by __aDelegate
+        internal val __corecursiveDelegate: MsgFieldDelegate<TestAllTypesProto2> = MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto2Internal.DEFAULT }
+        override var corecursive: TestAllTypesProto2 by __corecursiveDelegate
 
         private val _owner: NestedMessageInternal = this
 
@@ -1601,7 +1731,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.NestedMessage by lazy { NestedMessageInternal() }
+        }
     }
 
     class MapInt32Int32EntryInternal: InternalMessage(fieldsWithPresence = 2) {
@@ -1619,8 +1751,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1690,8 +1824,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1761,8 +1897,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate(PresenceIndices.key) { 0u }
-        var value: UInt by MsgFieldDelegate(PresenceIndices.value) { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.key) { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.value) { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1832,8 +1970,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate(PresenceIndices.key) { 0uL }
-        var value: ULong by MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.key) { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1903,8 +2043,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1974,8 +2116,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2045,8 +2189,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate(PresenceIndices.key) { 0u }
-        var value: UInt by MsgFieldDelegate(PresenceIndices.value) { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.key) { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.value) { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2116,8 +2262,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate(PresenceIndices.key) { 0uL }
-        var value: ULong by MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.key) { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2187,8 +2335,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2258,8 +2408,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2329,8 +2481,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Boolean by MsgFieldDelegate(PresenceIndices.value) { false }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.value) { false }
+        var value: Boolean by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2400,8 +2554,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Float by MsgFieldDelegate(PresenceIndices.value) { 0.0f }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.value) { 0.0f }
+        var value: Float by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2471,8 +2627,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Double by MsgFieldDelegate(PresenceIndices.value) { 0.0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.value) { 0.0 }
+        var value: Double by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2542,8 +2700,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: TestAllTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal.DEFAULT }
+        var value: TestAllTypesProto2.NestedMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2613,8 +2773,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Boolean by MsgFieldDelegate(PresenceIndices.key) { false }
-        var value: Boolean by MsgFieldDelegate(PresenceIndices.value) { false }
+        internal val __keyDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.key) { false }
+        var key: Boolean by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.value) { false }
+        var value: Boolean by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2684,8 +2846,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: String by MsgFieldDelegate(PresenceIndices.value) { "" }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.value) { "" }
+        var value: String by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2755,8 +2919,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ByteString by MsgFieldDelegate(PresenceIndices.value) { ByteString() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.value) { ByteString() }
+        var value: ByteString by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2826,8 +2992,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: TestAllTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal.DEFAULT }
+        var value: TestAllTypesProto2.NestedMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2897,8 +3065,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.value) { ForeignMessageProto2Internal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.value) { ForeignMessageProto2Internal.DEFAULT }
+        var value: ForeignMessageProto2 by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2968,8 +3138,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: TestAllTypesProto2.NestedEnum by MsgFieldDelegate(PresenceIndices.value) { TestAllTypesProto2.NestedEnum.FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedEnum> = MsgFieldDelegate(PresenceIndices.value) { TestAllTypesProto2.NestedEnum.FOO }
+        var value: TestAllTypesProto2.NestedEnum by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -3039,8 +3211,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ForeignEnumProto2 by MsgFieldDelegate(PresenceIndices.value) { ForeignEnumProto2.FOREIGN_FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignEnumProto2> = MsgFieldDelegate(PresenceIndices.value) { ForeignEnumProto2.FOREIGN_FOO }
+        var value: ForeignEnumProto2 by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -3110,8 +3284,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var groupInt32: Int? by MsgFieldDelegate(PresenceIndices.groupInt32) { null }
-        override var groupUint32: UInt? by MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        internal val __groupInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.groupInt32) { null }
+        override var groupInt32: Int? by __groupInt32Delegate
+        internal val __groupUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        override var groupUint32: UInt? by __groupUint32Delegate
 
         private val _owner: DataInternal = this
 
@@ -3221,7 +3397,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.Data by lazy { DataInternal() }
+        }
     }
 
     class MultiWordGroupFieldInternal: TestAllTypesProto2.MultiWordGroupField.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -3239,8 +3417,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var groupInt32: Int? by MsgFieldDelegate(PresenceIndices.groupInt32) { null }
-        override var groupUint32: UInt? by MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        internal val __groupInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.groupInt32) { null }
+        override var groupInt32: Int? by __groupInt32Delegate
+        internal val __groupUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        override var groupUint32: UInt? by __groupUint32Delegate
 
         private val _owner: MultiWordGroupFieldInternal = this
 
@@ -3350,7 +3530,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MultiWordGroupField by lazy { MultiWordGroupFieldInternal() }
+        }
     }
 
     class MessageSetCorrectInternal: TestAllTypesProto2.MessageSetCorrect.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -3447,7 +3629,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MessageSetCorrect by lazy { MessageSetCorrectInternal() }
+        }
     }
 
     class MessageSetCorrectExtension1Internal: TestAllTypesProto2.MessageSetCorrectExtension1.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -3464,7 +3648,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var str: String? by MsgFieldDelegate(PresenceIndices.str) { null }
+        internal val __strDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.str) { null }
+        override var str: String? by __strDelegate
 
         private val _owner: MessageSetCorrectExtension1Internal = this
 
@@ -3560,7 +3745,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MessageSetCorrectExtension1 by lazy { MessageSetCorrectExtension1Internal() }
+        }
     }
 
     class MessageSetCorrectExtension2Internal: TestAllTypesProto2.MessageSetCorrectExtension2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -3577,7 +3764,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var i: Int? by MsgFieldDelegate(PresenceIndices.i) { null }
+        internal val __iDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.i) { null }
+        override var i: Int? by __iDelegate
 
         private val _owner: MessageSetCorrectExtension2Internal = this
 
@@ -3673,7 +3861,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MessageSetCorrectExtension2 by lazy { MessageSetCorrectExtension2Internal() }
+        }
     }
 
     class ExtensionWithOneofInternal: TestAllTypesProto2.ExtensionWithOneof.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -3778,7 +3968,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.ExtensionWithOneof by lazy { ExtensionWithOneofInternal() }
+        }
     }
 
     @InternalRpcApi
@@ -3813,7 +4005,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestAllTypesProto2 by lazy { TestAllTypesProto2Internal() }
+    }
 }
 
 class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -3830,7 +4024,8 @@ class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessag
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var c: Int? by MsgFieldDelegate(PresenceIndices.c) { null }
+    internal val __cDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.c) { null }
+    override var c: Int? by __cDelegate
 
     private val _owner: ForeignMessageProto2Internal = this
 
@@ -3926,7 +4121,9 @@ class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessag
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ForeignMessageProto2 by lazy { ForeignMessageProto2Internal() }
+    }
 }
 
 class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -3944,8 +4141,10 @@ class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var groupInt32: Int? by MsgFieldDelegate(PresenceIndices.groupInt32) { null }
-    override var groupUint32: UInt? by MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+    internal val __groupInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.groupInt32) { null }
+    override var groupInt32: Int? by __groupInt32Delegate
+    internal val __groupUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+    override var groupUint32: UInt? by __groupUint32Delegate
 
     private val _owner: GroupFieldInternal = this
 
@@ -4055,7 +4254,9 @@ class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: GroupField by lazy { GroupFieldInternal() }
+    }
 }
 
 class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMessage(fieldsWithPresence = 5) {
@@ -4076,12 +4277,18 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var optionalInt32: Int? by MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
-    override var optionalString: String? by MsgFieldDelegate(PresenceIndices.optionalString) { null }
-    override var nestedMessage: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.nestedMessage) { ForeignMessageProto2Internal() }
-    override var optionalgroup: UnknownToTestAllTypes.OptionalGroup by MsgFieldDelegate(PresenceIndices.optionalgroup) { OptionalGroupInternal() }
-    override var optionalBool: Boolean? by MsgFieldDelegate(PresenceIndices.optionalBool) { null }
-    override var repeatedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
+    internal val __optionalInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
+    override var optionalInt32: Int? by __optionalInt32Delegate
+    internal val __optionalStringDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalString) { null }
+    override var optionalString: String? by __optionalStringDelegate
+    internal val __nestedMessageDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.nestedMessage) { ForeignMessageProto2Internal.DEFAULT }
+    override var nestedMessage: ForeignMessageProto2 by __nestedMessageDelegate
+    internal val __optionalgroupDelegate: MsgFieldDelegate<UnknownToTestAllTypes.OptionalGroup> = MsgFieldDelegate(PresenceIndices.optionalgroup) { OptionalGroupInternal.DEFAULT }
+    override var optionalgroup: UnknownToTestAllTypes.OptionalGroup by __optionalgroupDelegate
+    internal val __optionalBoolDelegate: MsgFieldDelegate<Boolean?> = MsgFieldDelegate(PresenceIndices.optionalBool) { null }
+    override var optionalBool: Boolean? by __optionalBoolDelegate
+    internal val __repeatedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32: List<Int> by __repeatedInt32Delegate
 
     private val _owner: UnknownToTestAllTypesInternal = this
 
@@ -4219,7 +4426,8 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int? by MsgFieldDelegate(PresenceIndices.a) { null }
+        internal val __aDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.a) { null }
+        override var a: Int? by __aDelegate
 
         private val _owner: OptionalGroupInternal = this
 
@@ -4315,7 +4523,9 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: UnknownToTestAllTypes.OptionalGroup by lazy { OptionalGroupInternal() }
+        }
     }
 
     @InternalRpcApi
@@ -4350,7 +4560,9 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: UnknownToTestAllTypes by lazy { UnknownToTestAllTypesInternal() }
+    }
 }
 
 class NullHypothesisProto2Internal: NullHypothesisProto2.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -4436,7 +4648,9 @@ class NullHypothesisProto2Internal: NullHypothesisProto2.Builder, InternalMessag
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: NullHypothesisProto2 by lazy { NullHypothesisProto2Internal() }
+    }
 }
 
 class EnumOnlyProto2Internal: EnumOnlyProto2.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -4522,7 +4736,9 @@ class EnumOnlyProto2Internal: EnumOnlyProto2.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: EnumOnlyProto2 by lazy { EnumOnlyProto2Internal() }
+    }
 }
 
 class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -4539,7 +4755,8 @@ class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var data: String? by MsgFieldDelegate(PresenceIndices.data) { null }
+    internal val __dataDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.data) { null }
+    override var data: String? by __dataDelegate
 
     private val _owner: OneStringProto2Internal = this
 
@@ -4635,7 +4852,9 @@ class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: OneStringProto2 by lazy { OneStringProto2Internal() }
+    }
 }
 
 class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -4653,9 +4872,12 @@ class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fiel
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var inline: Int? by MsgFieldDelegate(PresenceIndices.inline) { null }
-    override var concept: String? by MsgFieldDelegate(PresenceIndices.concept) { null }
-    override var requires: List<String> by MsgFieldDelegate { mutableListOf() }
+    internal val __inlineDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.inline) { null }
+    override var inline: Int? by __inlineDelegate
+    internal val __conceptDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.concept) { null }
+    override var concept: String? by __conceptDelegate
+    internal val __requiresDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var requires: List<String> by __requiresDelegate
 
     private val _owner: ProtoWithKeywordsInternal = this
 
@@ -4769,7 +4991,9 @@ class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fiel
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ProtoWithKeywords by lazy { ProtoWithKeywordsInternal() }
+    }
 }
 
 class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, InternalMessage(fieldsWithPresence = 39) {
@@ -4828,45 +5052,84 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var requiredInt32: Int by MsgFieldDelegate(PresenceIndices.requiredInt32) { 0 }
-    override var requiredInt64: Long by MsgFieldDelegate(PresenceIndices.requiredInt64) { 0L }
-    override var requiredUint32: UInt by MsgFieldDelegate(PresenceIndices.requiredUint32) { 0u }
-    override var requiredUint64: ULong by MsgFieldDelegate(PresenceIndices.requiredUint64) { 0uL }
-    override var requiredSint32: Int by MsgFieldDelegate(PresenceIndices.requiredSint32) { 0 }
-    override var requiredSint64: Long by MsgFieldDelegate(PresenceIndices.requiredSint64) { 0L }
-    override var requiredFixed32: UInt by MsgFieldDelegate(PresenceIndices.requiredFixed32) { 0u }
-    override var requiredFixed64: ULong by MsgFieldDelegate(PresenceIndices.requiredFixed64) { 0uL }
-    override var requiredSfixed32: Int by MsgFieldDelegate(PresenceIndices.requiredSfixed32) { 0 }
-    override var requiredSfixed64: Long by MsgFieldDelegate(PresenceIndices.requiredSfixed64) { 0L }
-    override var requiredFloat: Float by MsgFieldDelegate(PresenceIndices.requiredFloat) { 0.0f }
-    override var requiredDouble: Double by MsgFieldDelegate(PresenceIndices.requiredDouble) { 0.0 }
-    override var requiredBool: Boolean by MsgFieldDelegate(PresenceIndices.requiredBool) { false }
-    override var requiredString: String by MsgFieldDelegate(PresenceIndices.requiredString) { "" }
-    override var requiredBytes: ByteString by MsgFieldDelegate(PresenceIndices.requiredBytes) { ByteString() }
-    override var requiredNestedMessage: TestAllRequiredTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.requiredNestedMessage) { NestedMessageInternal() }
-    override var requiredForeignMessage: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.requiredForeignMessage) { ForeignMessageProto2Internal() }
-    override var requiredNestedEnum: TestAllRequiredTypesProto2.NestedEnum by MsgFieldDelegate(PresenceIndices.requiredNestedEnum) { TestAllRequiredTypesProto2.NestedEnum.FOO }
-    override var requiredForeignEnum: ForeignEnumProto2 by MsgFieldDelegate(PresenceIndices.requiredForeignEnum) { ForeignEnumProto2.FOREIGN_FOO }
-    override var requiredStringPiece: String by MsgFieldDelegate(PresenceIndices.requiredStringPiece) { "" }
-    override var requiredCord: String by MsgFieldDelegate(PresenceIndices.requiredCord) { "" }
-    override var recursiveMessage: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllRequiredTypesProto2Internal() }
-    override var optionalRecursiveMessage: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.optionalRecursiveMessage) { TestAllRequiredTypesProto2Internal() }
-    override var data: TestAllRequiredTypesProto2.Data by MsgFieldDelegate(PresenceIndices.data) { DataInternal() }
-    override var defaultInt32: Int by MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
-    override var defaultInt64: Long by MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
-    override var defaultUint32: UInt by MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
-    override var defaultUint64: ULong by MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
-    override var defaultSint32: Int by MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
-    override var defaultSint64: Long by MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
-    override var defaultFixed32: UInt by MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
-    override var defaultFixed64: ULong by MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
-    override var defaultSfixed32: Int by MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
-    override var defaultSfixed64: Long by MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
-    override var defaultFloat: Float by MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
-    override var defaultDouble: Double by MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
-    override var defaultBool: Boolean by MsgFieldDelegate(PresenceIndices.defaultBool) { true }
-    override var defaultString: String by MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
-    override var defaultBytes: ByteString by MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
+    internal val __requiredInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.requiredInt32) { 0 }
+    override var requiredInt32: Int by __requiredInt32Delegate
+    internal val __requiredInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.requiredInt64) { 0L }
+    override var requiredInt64: Long by __requiredInt64Delegate
+    internal val __requiredUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.requiredUint32) { 0u }
+    override var requiredUint32: UInt by __requiredUint32Delegate
+    internal val __requiredUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.requiredUint64) { 0uL }
+    override var requiredUint64: ULong by __requiredUint64Delegate
+    internal val __requiredSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.requiredSint32) { 0 }
+    override var requiredSint32: Int by __requiredSint32Delegate
+    internal val __requiredSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.requiredSint64) { 0L }
+    override var requiredSint64: Long by __requiredSint64Delegate
+    internal val __requiredFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.requiredFixed32) { 0u }
+    override var requiredFixed32: UInt by __requiredFixed32Delegate
+    internal val __requiredFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.requiredFixed64) { 0uL }
+    override var requiredFixed64: ULong by __requiredFixed64Delegate
+    internal val __requiredSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.requiredSfixed32) { 0 }
+    override var requiredSfixed32: Int by __requiredSfixed32Delegate
+    internal val __requiredSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.requiredSfixed64) { 0L }
+    override var requiredSfixed64: Long by __requiredSfixed64Delegate
+    internal val __requiredFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.requiredFloat) { 0.0f }
+    override var requiredFloat: Float by __requiredFloatDelegate
+    internal val __requiredDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.requiredDouble) { 0.0 }
+    override var requiredDouble: Double by __requiredDoubleDelegate
+    internal val __requiredBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.requiredBool) { false }
+    override var requiredBool: Boolean by __requiredBoolDelegate
+    internal val __requiredStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.requiredString) { "" }
+    override var requiredString: String by __requiredStringDelegate
+    internal val __requiredBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.requiredBytes) { ByteString() }
+    override var requiredBytes: ByteString by __requiredBytesDelegate
+    internal val __requiredNestedMessageDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.requiredNestedMessage) { NestedMessageInternal.DEFAULT }
+    override var requiredNestedMessage: TestAllRequiredTypesProto2.NestedMessage by __requiredNestedMessageDelegate
+    internal val __requiredForeignMessageDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.requiredForeignMessage) { ForeignMessageProto2Internal.DEFAULT }
+    override var requiredForeignMessage: ForeignMessageProto2 by __requiredForeignMessageDelegate
+    internal val __requiredNestedEnumDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2.NestedEnum> = MsgFieldDelegate(PresenceIndices.requiredNestedEnum) { TestAllRequiredTypesProto2.NestedEnum.FOO }
+    override var requiredNestedEnum: TestAllRequiredTypesProto2.NestedEnum by __requiredNestedEnumDelegate
+    internal val __requiredForeignEnumDelegate: MsgFieldDelegate<ForeignEnumProto2> = MsgFieldDelegate(PresenceIndices.requiredForeignEnum) { ForeignEnumProto2.FOREIGN_FOO }
+    override var requiredForeignEnum: ForeignEnumProto2 by __requiredForeignEnumDelegate
+    internal val __requiredStringPieceDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.requiredStringPiece) { "" }
+    override var requiredStringPiece: String by __requiredStringPieceDelegate
+    internal val __requiredCordDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.requiredCord) { "" }
+    override var requiredCord: String by __requiredCordDelegate
+    internal val __recursiveMessageDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllRequiredTypesProto2Internal.DEFAULT }
+    override var recursiveMessage: TestAllRequiredTypesProto2 by __recursiveMessageDelegate
+    internal val __optionalRecursiveMessageDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.optionalRecursiveMessage) { TestAllRequiredTypesProto2Internal.DEFAULT }
+    override var optionalRecursiveMessage: TestAllRequiredTypesProto2 by __optionalRecursiveMessageDelegate
+    internal val __dataDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2.Data> = MsgFieldDelegate(PresenceIndices.data) { DataInternal.DEFAULT }
+    override var data: TestAllRequiredTypesProto2.Data by __dataDelegate
+    internal val __defaultInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
+    override var defaultInt32: Int by __defaultInt32Delegate
+    internal val __defaultInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
+    override var defaultInt64: Long by __defaultInt64Delegate
+    internal val __defaultUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
+    override var defaultUint32: UInt by __defaultUint32Delegate
+    internal val __defaultUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
+    override var defaultUint64: ULong by __defaultUint64Delegate
+    internal val __defaultSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
+    override var defaultSint32: Int by __defaultSint32Delegate
+    internal val __defaultSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
+    override var defaultSint64: Long by __defaultSint64Delegate
+    internal val __defaultFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
+    override var defaultFixed32: UInt by __defaultFixed32Delegate
+    internal val __defaultFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
+    override var defaultFixed64: ULong by __defaultFixed64Delegate
+    internal val __defaultSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
+    override var defaultSfixed32: Int by __defaultSfixed32Delegate
+    internal val __defaultSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
+    override var defaultSfixed64: Long by __defaultSfixed64Delegate
+    internal val __defaultFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
+    override var defaultFloat: Float by __defaultFloatDelegate
+    internal val __defaultDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
+    override var defaultDouble: Double by __defaultDoubleDelegate
+    internal val __defaultBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.defaultBool) { true }
+    override var defaultBool: Boolean by __defaultBoolDelegate
+    internal val __defaultStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
+    override var defaultString: String by __defaultStringDelegate
+    internal val __defaultBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
+    override var defaultBytes: ByteString by __defaultBytesDelegate
 
     private val _owner: TestAllRequiredTypesProto2Internal = this
 
@@ -5482,9 +5745,12 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int by MsgFieldDelegate(PresenceIndices.a) { 0 }
-        override var corecursive: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.corecursive) { TestAllRequiredTypesProto2Internal() }
-        override var optionalCorecursive: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.optionalCorecursive) { TestAllRequiredTypesProto2Internal() }
+        internal val __aDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.a) { 0 }
+        override var a: Int by __aDelegate
+        internal val __corecursiveDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.corecursive) { TestAllRequiredTypesProto2Internal.DEFAULT }
+        override var corecursive: TestAllRequiredTypesProto2 by __corecursiveDelegate
+        internal val __optionalCorecursiveDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.optionalCorecursive) { TestAllRequiredTypesProto2Internal.DEFAULT }
+        override var optionalCorecursive: TestAllRequiredTypesProto2 by __optionalCorecursiveDelegate
 
         private val _owner: NestedMessageInternal = this
 
@@ -5608,7 +5874,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.NestedMessage by lazy { NestedMessageInternal() }
+        }
     }
 
     class DataInternal: TestAllRequiredTypesProto2.Data.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -5626,8 +5894,10 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var groupInt32: Int by MsgFieldDelegate(PresenceIndices.groupInt32) { 0 }
-        override var groupUint32: UInt by MsgFieldDelegate(PresenceIndices.groupUint32) { 0u }
+        internal val __groupInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.groupInt32) { 0 }
+        override var groupInt32: Int by __groupInt32Delegate
+        internal val __groupUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.groupUint32) { 0u }
+        override var groupUint32: UInt by __groupUint32Delegate
 
         private val _owner: DataInternal = this
 
@@ -5737,7 +6007,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.Data by lazy { DataInternal() }
+        }
     }
 
     class MessageSetCorrectInternal: TestAllRequiredTypesProto2.MessageSetCorrect.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -5834,7 +6106,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.MessageSetCorrect by lazy { MessageSetCorrectInternal() }
+        }
     }
 
     class MessageSetCorrectExtension1Internal: TestAllRequiredTypesProto2.MessageSetCorrectExtension1.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -5851,7 +6125,8 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var str: String by MsgFieldDelegate(PresenceIndices.str) { "" }
+        internal val __strDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.str) { "" }
+        override var str: String by __strDelegate
 
         private val _owner: MessageSetCorrectExtension1Internal = this
 
@@ -5947,7 +6222,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.MessageSetCorrectExtension1 by lazy { MessageSetCorrectExtension1Internal() }
+        }
     }
 
     class MessageSetCorrectExtension2Internal: TestAllRequiredTypesProto2.MessageSetCorrectExtension2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -5964,7 +6241,8 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var i: Int by MsgFieldDelegate(PresenceIndices.i) { 0 }
+        internal val __iDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.i) { 0 }
+        override var i: Int by __iDelegate
 
         private val _owner: MessageSetCorrectExtension2Internal = this
 
@@ -6060,7 +6338,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.MessageSetCorrectExtension2 by lazy { MessageSetCorrectExtension2Internal() }
+        }
     }
 
     @InternalRpcApi
@@ -6095,7 +6375,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestAllRequiredTypesProto2 by lazy { TestAllRequiredTypesProto2Internal() }
+    }
 }
 
 class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6270,7 +6552,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A1 by lazy { A1Internal() }
+        }
     }
 
     class A2Internal: TestLargeOneof.A2.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6356,7 +6640,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A2 by lazy { A2Internal() }
+        }
     }
 
     class A3Internal: TestLargeOneof.A3.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6442,7 +6728,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A3 by lazy { A3Internal() }
+        }
     }
 
     class A4Internal: TestLargeOneof.A4.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6528,7 +6816,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A4 by lazy { A4Internal() }
+        }
     }
 
     class A5Internal: TestLargeOneof.A5.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6614,7 +6904,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A5 by lazy { A5Internal() }
+        }
     }
 
     @InternalRpcApi
@@ -6649,7 +6941,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestLargeOneof by lazy { TestLargeOneofInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -7553,18 +7847,12 @@ fun TestAllTypesProto2Internal.Companion.decodeWith(msg: TestAllTypesProto2Inter
                 msg.optionalBytes = decoder.readBytes()
             }
             tag.fieldNr == 18 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[15]) {
-                    msg.optionalNestedMessage = TestAllTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.optionalNestedMessage.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalNestedMessageDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 19 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[16]) {
-                    msg.optionalForeignMessage = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.optionalForeignMessage.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalForeignMessageDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 21 && tag.wireType == WireType.VARINT -> {
                 msg.optionalNestedEnum = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
@@ -7579,478 +7867,582 @@ fun TestAllTypesProto2Internal.Companion.decodeWith(msg: TestAllTypesProto2Inter
                 msg.optionalCord = decoder.readString()
             }
             tag.fieldNr == 27 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[21]) {
-                    msg.recursiveMessage = TestAllTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.recursiveMessage.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__recursiveMessageDelegate.getOrCreate(msg) { TestAllTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 31 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt32 += decoder.readPackedInt32()
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 31 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.repeatedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 32 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt64 += decoder.readPackedInt64()
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 32 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.repeatedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 33 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint32 += decoder.readPackedUInt32()
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 33 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.repeatedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 34 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint64 += decoder.readPackedUInt64()
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 34 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.repeatedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 35 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint32 += decoder.readPackedSInt32()
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 35 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.repeatedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 36 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint64 += decoder.readPackedSInt64()
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 36 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.repeatedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 37 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 37 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.repeatedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 38 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 38 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.repeatedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 39 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 39 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.repeatedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 40 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 40 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.repeatedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 41 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFloat += decoder.readPackedFloat()
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 41 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.repeatedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 42 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedDouble += decoder.readPackedDouble()
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 42 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.repeatedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 43 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedBool += decoder.readPackedBool()
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 43 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.repeatedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 44 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedString as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 45 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBytesDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBytes()
-                (msg.repeatedBytes as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 48 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedNestedMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2Internal.NestedMessageInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedNestedMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 49 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedForeignMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignMessageProto2Internal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
-                (msg.repeatedForeignMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 51 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) }
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 51 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.repeatedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 52 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedForeignEnum += decoder.readPackedEnum().map { ForeignEnumProto2.fromNumber(it) }
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { ForeignEnumProto2.fromNumber(it) })
             }
             tag.fieldNr == 52 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignEnumProto2.fromNumber(decoder.readEnum())
-                (msg.repeatedForeignEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 54 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringPieceDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedStringPiece as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 55 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedCordDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedCord as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 75 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt32 += decoder.readPackedInt32()
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 75 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.packedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 76 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt64 += decoder.readPackedInt64()
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 76 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.packedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 77 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint32 += decoder.readPackedUInt32()
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 77 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.packedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 78 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint64 += decoder.readPackedUInt64()
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 78 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.packedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 79 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint32 += decoder.readPackedSInt32()
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 79 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.packedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 80 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint64 += decoder.readPackedSInt64()
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 80 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.packedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 81 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 81 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.packedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 82 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 82 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.packedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 83 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 83 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.packedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 84 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 84 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.packedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 85 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFloat += decoder.readPackedFloat()
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 85 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.packedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 86 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedDouble += decoder.readPackedDouble()
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 86 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.packedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 87 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedBool += decoder.readPackedBool()
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 87 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.packedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 88 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) }
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 88 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.packedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 89 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt32 += decoder.readPackedInt32()
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 89 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.unpackedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 90 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt64 += decoder.readPackedInt64()
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 90 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.unpackedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 91 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint32 += decoder.readPackedUInt32()
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 91 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.unpackedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 92 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint64 += decoder.readPackedUInt64()
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 92 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.unpackedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 93 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint32 += decoder.readPackedSInt32()
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 93 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.unpackedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 94 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint64 += decoder.readPackedSInt64()
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 94 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.unpackedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 95 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 95 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.unpackedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 96 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 96 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.unpackedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 97 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 97 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.unpackedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 98 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 98 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.unpackedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 99 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFloat += decoder.readPackedFloat()
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 99 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.unpackedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 100 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedDouble += decoder.readPackedDouble()
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 100 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.unpackedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 101 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedBool += decoder.readPackedBool()
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 101 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.unpackedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 102 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) }
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 102 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.unpackedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 56 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32Int32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32Int32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32Int32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Int32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 57 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt64Int64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt64Int64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt64Int64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt64Int64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 58 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint32Uint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapUint32Uint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapUint32Uint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint32Uint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 59 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint64Uint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapUint64Uint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapUint64Uint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint64Uint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 60 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint32Sint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSint32Sint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSint32Sint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint32Sint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 61 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint64Sint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSint64Sint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSint64Sint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint64Sint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 62 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed32Fixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapFixed32Fixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapFixed32Fixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed32Fixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 63 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed64Fixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapFixed64Fixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapFixed64Fixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed64Fixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 64 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed32Sfixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSfixed32Sfixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSfixed32Sfixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed32Sfixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 65 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed64Sfixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSfixed64Sfixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSfixed64Sfixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed64Sfixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 104 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32BoolDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32BoolEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32BoolEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Bool as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 66 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32FloatDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32FloatEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32FloatEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Float as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 67 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32DoubleDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32DoubleEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32DoubleEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Double as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 103 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32NestedMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32NestedMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 68 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapBoolBoolDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapBoolBoolEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapBoolBoolEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapBoolBool as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 69 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringStringDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringStringEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringStringEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringString as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 70 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringBytesDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringBytesEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringBytesEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringBytes as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 71 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 72 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 73 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringNestedEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringNestedEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 74 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringForeignEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringForeignEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 201 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[22]) {
-                    msg.data = TestAllTypesProto2Internal.DataInternal()
-                }
-
-                decoder.readGroup(msg.data.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__dataDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.DataInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 204 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[23]) {
-                    msg.multiwordgroupfield = TestAllTypesProto2Internal.MultiWordGroupFieldInternal()
-                }
-
-                decoder.readGroup(msg.multiwordgroupfield.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.MultiWordGroupFieldInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__multiwordgroupfieldDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.MultiWordGroupFieldInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.MultiWordGroupFieldInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 241 && tag.wireType == WireType.VARINT -> {
                 msg.defaultInt32 = decoder.readInt32()
@@ -8152,11 +8544,8 @@ fun TestAllTypesProto2Internal.Companion.decodeWith(msg: TestAllTypesProto2Inter
                 msg.FieldName18__ = decoder.readInt32()
             }
             tag.fieldNr == 500 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[57]) {
-                    msg.messageSetCorrect = TestAllTypesProto2Internal.MessageSetCorrectInternal()
-                }
-
-                decoder.readMessage(msg.messageSetCorrect.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MessageSetCorrectInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__messageSetCorrectDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.MessageSetCorrectInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MessageSetCorrectInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 111 && tag.wireType == WireType.VARINT -> {
                 msg.oneofField = TestAllTypesProto2.OneofField.OneofUint32(decoder.readUInt32())
@@ -9103,28 +9492,24 @@ fun UnknownToTestAllTypesInternal.Companion.decodeWith(msg: UnknownToTestAllType
                 msg.optionalString = decoder.readString()
             }
             tag.fieldNr == 1003 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[2]) {
-                    msg.nestedMessage = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.nestedMessage.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__nestedMessageDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 1004 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[3]) {
-                    msg.optionalgroup = UnknownToTestAllTypesInternal.OptionalGroupInternal()
-                }
-
-                decoder.readGroup(msg.optionalgroup.asInternal()) { msg, decoder -> UnknownToTestAllTypesInternal.OptionalGroupInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__optionalgroupDelegate.getOrCreate(msg) { UnknownToTestAllTypesInternal.OptionalGroupInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> UnknownToTestAllTypesInternal.OptionalGroupInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 1006 && tag.wireType == WireType.VARINT -> {
                 msg.optionalBool = decoder.readBool()
             }
             tag.fieldNr == 1011 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt32 += decoder.readPackedInt32()
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 1011 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.repeatedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -9400,8 +9785,9 @@ fun ProtoWithKeywordsInternal.Companion.decodeWith(msg: ProtoWithKeywordsInterna
                 msg.concept = decoder.readString()
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__requiresDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.requires as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -9842,18 +10228,12 @@ fun TestAllRequiredTypesProto2Internal.Companion.decodeWith(msg: TestAllRequired
                 msg.requiredBytes = decoder.readBytes()
             }
             tag.fieldNr == 18 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[15]) {
-                    msg.requiredNestedMessage = TestAllRequiredTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.requiredNestedMessage.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__requiredNestedMessageDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 19 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[16]) {
-                    msg.requiredForeignMessage = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.requiredForeignMessage.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__requiredForeignMessageDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 21 && tag.wireType == WireType.VARINT -> {
                 msg.requiredNestedEnum = TestAllRequiredTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
@@ -9868,25 +10248,16 @@ fun TestAllRequiredTypesProto2Internal.Companion.decodeWith(msg: TestAllRequired
                 msg.requiredCord = decoder.readString()
             }
             tag.fieldNr == 27 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[21]) {
-                    msg.recursiveMessage = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.recursiveMessage.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__recursiveMessageDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 28 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[22]) {
-                    msg.optionalRecursiveMessage = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.optionalRecursiveMessage.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalRecursiveMessageDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 201 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[23]) {
-                    msg.data = TestAllRequiredTypesProto2Internal.DataInternal()
-                }
-
-                decoder.readGroup(msg.data.asInternal()) { msg, decoder -> TestAllRequiredTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__dataDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal.DataInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllRequiredTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 241 && tag.wireType == WireType.VARINT -> {
                 msg.defaultInt32 = decoder.readInt32()
@@ -10315,11 +10686,8 @@ fun TestAllTypesProto2Internal.NestedMessageInternal.Companion.decodeWith(msg: T
                 msg.a = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.corecursive = TestAllTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.corecursive.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__corecursiveDelegate.getOrCreate(msg) { TestAllTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -11386,11 +11754,8 @@ fun TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal.Companion.deco
                 msg.key = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = TestAllTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -11697,11 +12062,8 @@ fun TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal.Companion.dec
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = TestAllTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -11780,11 +12142,8 @@ fun TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal.Companion.de
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -12557,18 +12916,12 @@ fun TestAllRequiredTypesProto2Internal.NestedMessageInternal.Companion.decodeWit
                 msg.a = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.corecursive = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.corecursive.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__corecursiveDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[2]) {
-                    msg.optionalCorecursive = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.optionalCorecursive.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalCorecursiveDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -13286,7 +13639,7 @@ object TestMessagesProto2EditionsKtExtensions {
             name = "groupfield",
             extendee = com.google.protobuf_test_messages.editions.proto2.TestAllTypesProto2::class,
             valueType = GroupField::class,
-            default = { GroupFieldInternal() },
+            default = { GroupFieldInternal.DEFAULT },
             asInternal = { it.asInternal() },
             encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
             decodeWith = { value, decoder, config -> GroupFieldInternal.decodeWith(value.asInternal(), decoder, config) },
@@ -13300,7 +13653,7 @@ object TestMessagesProto2EditionsKtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrectExtension1::class,
-                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension1Internal() },
+                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension1Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllTypesProto2Internal.MessageSetCorrectExtension1Internal.decodeWith(value.asInternal(), decoder, config) },
@@ -13314,7 +13667,7 @@ object TestMessagesProto2EditionsKtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrectExtension2::class,
-                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension2Internal() },
+                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension2Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllTypesProto2Internal.MessageSetCorrectExtension2Internal.decodeWith(value.asInternal(), decoder, config) },
@@ -13328,7 +13681,7 @@ object TestMessagesProto2EditionsKtExtensions {
                     name = "extensionWithOneof",
                     extendee = com.google.protobuf_test_messages.editions.proto2.TestAllTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.editions.proto2.TestAllTypesProto2.ExtensionWithOneof::class,
-                    default = { TestAllTypesProto2Internal.ExtensionWithOneofInternal() },
+                    default = { TestAllTypesProto2Internal.ExtensionWithOneofInternal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllTypesProto2Internal.ExtensionWithOneofInternal.decodeWith(value.asInternal(), decoder, config) },
@@ -13344,7 +13697,7 @@ object TestMessagesProto2EditionsKtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.MessageSetCorrectExtension1::class,
-                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension1Internal() },
+                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension1Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension1Internal.decodeWith(value.asInternal(), decoder, config) },
@@ -13358,7 +13711,7 @@ object TestMessagesProto2EditionsKtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.editions.proto2.TestAllRequiredTypesProto2.MessageSetCorrectExtension2::class,
-                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension2Internal() },
+                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension2Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension2Internal.decodeWith(value.asInternal(), decoder, config) },

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto3/_rpc_internal/TestMessagesProto3Editions.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto3/_rpc_internal/TestMessagesProto3Editions.kt
@@ -127,149 +127,292 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var optionalInt32: Int by MsgFieldDelegate { 0 }
-    override var optionalInt64: Long by MsgFieldDelegate { 0L }
-    override var optionalUint32: UInt by MsgFieldDelegate { 0u }
-    override var optionalUint64: ULong by MsgFieldDelegate { 0uL }
-    override var optionalSint32: Int by MsgFieldDelegate { 0 }
-    override var optionalSint64: Long by MsgFieldDelegate { 0L }
-    override var optionalFixed32: UInt by MsgFieldDelegate { 0u }
-    override var optionalFixed64: ULong by MsgFieldDelegate { 0uL }
-    override var optionalSfixed32: Int by MsgFieldDelegate { 0 }
-    override var optionalSfixed64: Long by MsgFieldDelegate { 0L }
-    override var optionalFloat: Float by MsgFieldDelegate { 0.0f }
-    override var optionalDouble: Double by MsgFieldDelegate { 0.0 }
-    override var optionalBool: Boolean by MsgFieldDelegate { false }
-    override var optionalString: String by MsgFieldDelegate { "" }
-    override var optionalBytes: ByteString by MsgFieldDelegate { ByteString() }
-    override var optionalNestedMessage: TestAllTypesProto3.NestedMessage by MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal() }
-    override var optionalForeignMessage: ForeignMessage by MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageInternal() }
-    override var optionalNestedEnum: TestAllTypesProto3.NestedEnum by MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
-    override var optionalForeignEnum: ForeignEnum by MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
-    override var optionalAliasedEnum: TestAllTypesProto3.AliasedEnum by MsgFieldDelegate { TestAllTypesProto3.AliasedEnum.ALIAS_FOO }
-    override var optionalStringPiece: String by MsgFieldDelegate { "" }
-    override var optionalCord: String by MsgFieldDelegate { "" }
-    override var recursiveMessage: TestAllTypesProto3 by MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto3Internal() }
-    override var repeatedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedString: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBytes: List<ByteString> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedMessage: List<TestAllTypesProto3.NestedMessage> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignMessage: List<ForeignMessage> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedEnum: List<TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignEnum: List<ForeignEnum> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStringPiece: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedCord: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var packedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var packedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var packedNestedEnum: List<TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedNestedEnum: List<TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var mapInt32Int32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt64Int64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint32Uint32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint64Uint64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint32Sint32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint64Sint64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed32Fixed32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed64Fixed64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed32Sfixed32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed64Sfixed64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Float: Map<Int, Float> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Double: Map<Int, Double> by MsgFieldDelegate { mutableMapOf() }
-    override var mapBoolBool: Map<Boolean, Boolean> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringString: Map<String, String> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringBytes: Map<String, ByteString> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedMessage: Map<String, TestAllTypesProto3.NestedMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignMessage: Map<String, ForeignMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedEnum: Map<String, TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignEnum: Map<String, ForeignEnum> by MsgFieldDelegate { mutableMapOf() }
-    override var optionalBoolWrapper: BoolValue by MsgFieldDelegate(PresenceIndices.optionalBoolWrapper) { BoolValueInternal() }
-    override var optionalInt32Wrapper: Int32Value by MsgFieldDelegate(PresenceIndices.optionalInt32Wrapper) { Int32ValueInternal() }
-    override var optionalInt64Wrapper: Int64Value by MsgFieldDelegate(PresenceIndices.optionalInt64Wrapper) { Int64ValueInternal() }
-    override var optionalUint32Wrapper: UInt32Value by MsgFieldDelegate(PresenceIndices.optionalUint32Wrapper) { UInt32ValueInternal() }
-    override var optionalUint64Wrapper: UInt64Value by MsgFieldDelegate(PresenceIndices.optionalUint64Wrapper) { UInt64ValueInternal() }
-    override var optionalFloatWrapper: FloatValue by MsgFieldDelegate(PresenceIndices.optionalFloatWrapper) { FloatValueInternal() }
-    override var optionalDoubleWrapper: DoubleValue by MsgFieldDelegate(PresenceIndices.optionalDoubleWrapper) { DoubleValueInternal() }
-    override var optionalStringWrapper: StringValue by MsgFieldDelegate(PresenceIndices.optionalStringWrapper) { StringValueInternal() }
-    override var optionalBytesWrapper: BytesValue by MsgFieldDelegate(PresenceIndices.optionalBytesWrapper) { BytesValueInternal() }
-    override var repeatedBoolWrapper: List<BoolValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt32Wrapper: List<Int32Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt64Wrapper: List<Int64Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint32Wrapper: List<UInt32Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint64Wrapper: List<UInt64Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFloatWrapper: List<FloatValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedDoubleWrapper: List<DoubleValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStringWrapper: List<StringValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBytesWrapper: List<BytesValue> by MsgFieldDelegate { mutableListOf() }
-    override var optionalDuration: Duration by MsgFieldDelegate(PresenceIndices.optionalDuration) { DurationInternal() }
-    override var optionalTimestamp: Timestamp by MsgFieldDelegate(PresenceIndices.optionalTimestamp) { TimestampInternal() }
-    override var optionalFieldMask: FieldMask by MsgFieldDelegate(PresenceIndices.optionalFieldMask) { FieldMaskInternal() }
-    override var optionalStruct: Struct by MsgFieldDelegate(PresenceIndices.optionalStruct) { StructInternal() }
-    override var optionalAny: com.google.protobuf.kotlin.Any by MsgFieldDelegate(PresenceIndices.optionalAny) { AnyInternal() }
-    override var optionalValue: Value by MsgFieldDelegate(PresenceIndices.optionalValue) { ValueInternal() }
-    override var optionalNullValue: NullValue by MsgFieldDelegate { NullValue.NULL_VALUE }
-    override var optionalEmpty: Empty by MsgFieldDelegate(PresenceIndices.optionalEmpty) { EmptyInternal() }
-    override var repeatedDuration: List<Duration> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedTimestamp: List<Timestamp> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFieldmask: List<FieldMask> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStruct: List<Struct> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedAny: List<com.google.protobuf.kotlin.Any> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedValue: List<Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedListValue: List<ListValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedEmpty: List<Empty> by MsgFieldDelegate { mutableListOf() }
-    override var fieldname1: Int by MsgFieldDelegate { 0 }
-    override var fieldName2: Int by MsgFieldDelegate { 0 }
-    override var FieldName3: Int by MsgFieldDelegate { 0 }
-    override var field_Name4_: Int by MsgFieldDelegate { 0 }
-    override var field0name5: Int by MsgFieldDelegate { 0 }
-    override var field_0Name6: Int by MsgFieldDelegate { 0 }
-    override var fieldName7: Int by MsgFieldDelegate { 0 }
-    override var FieldName8: Int by MsgFieldDelegate { 0 }
-    override var field_Name9: Int by MsgFieldDelegate { 0 }
-    override var Field_Name10: Int by MsgFieldDelegate { 0 }
-    override var FIELD_NAME11: Int by MsgFieldDelegate { 0 }
-    override var FIELDName12: Int by MsgFieldDelegate { 0 }
-    override var _FieldName13: Int by MsgFieldDelegate { 0 }
-    override var __FieldName14: Int by MsgFieldDelegate { 0 }
-    override var field_Name15: Int by MsgFieldDelegate { 0 }
-    override var field__Name16: Int by MsgFieldDelegate { 0 }
-    override var fieldName17__: Int by MsgFieldDelegate { 0 }
-    override var FieldName18__: Int by MsgFieldDelegate { 0 }
+    internal val __optionalInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var optionalInt32: Int by __optionalInt32Delegate
+    internal val __optionalInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    override var optionalInt64: Long by __optionalInt64Delegate
+    internal val __optionalUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+    override var optionalUint32: UInt by __optionalUint32Delegate
+    internal val __optionalUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+    override var optionalUint64: ULong by __optionalUint64Delegate
+    internal val __optionalSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var optionalSint32: Int by __optionalSint32Delegate
+    internal val __optionalSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    override var optionalSint64: Long by __optionalSint64Delegate
+    internal val __optionalFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+    override var optionalFixed32: UInt by __optionalFixed32Delegate
+    internal val __optionalFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+    override var optionalFixed64: ULong by __optionalFixed64Delegate
+    internal val __optionalSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var optionalSfixed32: Int by __optionalSfixed32Delegate
+    internal val __optionalSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    override var optionalSfixed64: Long by __optionalSfixed64Delegate
+    internal val __optionalFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate { 0.0f }
+    override var optionalFloat: Float by __optionalFloatDelegate
+    internal val __optionalDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate { 0.0 }
+    override var optionalDouble: Double by __optionalDoubleDelegate
+    internal val __optionalBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    override var optionalBool: Boolean by __optionalBoolDelegate
+    internal val __optionalStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var optionalString: String by __optionalStringDelegate
+    internal val __optionalBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate { ByteString() }
+    override var optionalBytes: ByteString by __optionalBytesDelegate
+    internal val __optionalNestedMessageDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedMessage> = MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal.DEFAULT }
+    override var optionalNestedMessage: TestAllTypesProto3.NestedMessage by __optionalNestedMessageDelegate
+    internal val __optionalForeignMessageDelegate: MsgFieldDelegate<ForeignMessage> = MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageInternal.DEFAULT }
+    override var optionalForeignMessage: ForeignMessage by __optionalForeignMessageDelegate
+    internal val __optionalNestedEnumDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedEnum> = MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
+    override var optionalNestedEnum: TestAllTypesProto3.NestedEnum by __optionalNestedEnumDelegate
+    internal val __optionalForeignEnumDelegate: MsgFieldDelegate<ForeignEnum> = MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
+    override var optionalForeignEnum: ForeignEnum by __optionalForeignEnumDelegate
+    internal val __optionalAliasedEnumDelegate: MsgFieldDelegate<TestAllTypesProto3.AliasedEnum> = MsgFieldDelegate { TestAllTypesProto3.AliasedEnum.ALIAS_FOO }
+    override var optionalAliasedEnum: TestAllTypesProto3.AliasedEnum by __optionalAliasedEnumDelegate
+    internal val __optionalStringPieceDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var optionalStringPiece: String by __optionalStringPieceDelegate
+    internal val __optionalCordDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var optionalCord: String by __optionalCordDelegate
+    internal val __recursiveMessageDelegate: MsgFieldDelegate<TestAllTypesProto3> = MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto3Internal.DEFAULT }
+    override var recursiveMessage: TestAllTypesProto3 by __recursiveMessageDelegate
+    internal val __repeatedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32: List<Int> by __repeatedInt32Delegate
+    internal val __repeatedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt64: List<Long> by __repeatedInt64Delegate
+    internal val __repeatedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint32: List<UInt> by __repeatedUint32Delegate
+    internal val __repeatedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint64: List<ULong> by __repeatedUint64Delegate
+    internal val __repeatedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint32: List<Int> by __repeatedSint32Delegate
+    internal val __repeatedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint64: List<Long> by __repeatedSint64Delegate
+    internal val __repeatedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed32: List<UInt> by __repeatedFixed32Delegate
+    internal val __repeatedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed64: List<ULong> by __repeatedFixed64Delegate
+    internal val __repeatedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed32: List<Int> by __repeatedSfixed32Delegate
+    internal val __repeatedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed64: List<Long> by __repeatedSfixed64Delegate
+    internal val __repeatedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFloat: List<Float> by __repeatedFloatDelegate
+    internal val __repeatedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDouble: List<Double> by __repeatedDoubleDelegate
+    internal val __repeatedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBool: List<Boolean> by __repeatedBoolDelegate
+    internal val __repeatedStringDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedString: List<String> by __repeatedStringDelegate
+    internal val __repeatedBytesDelegate: MsgFieldDelegate<List<ByteString>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBytes: List<ByteString> by __repeatedBytesDelegate
+    internal val __repeatedNestedMessageDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedMessage>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedMessage: List<TestAllTypesProto3.NestedMessage> by __repeatedNestedMessageDelegate
+    internal val __repeatedForeignMessageDelegate: MsgFieldDelegate<List<ForeignMessage>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignMessage: List<ForeignMessage> by __repeatedForeignMessageDelegate
+    internal val __repeatedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedEnum: List<TestAllTypesProto3.NestedEnum> by __repeatedNestedEnumDelegate
+    internal val __repeatedForeignEnumDelegate: MsgFieldDelegate<List<ForeignEnum>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignEnum: List<ForeignEnum> by __repeatedForeignEnumDelegate
+    internal val __repeatedStringPieceDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStringPiece: List<String> by __repeatedStringPieceDelegate
+    internal val __repeatedCordDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedCord: List<String> by __repeatedCordDelegate
+    internal val __packedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedInt32: List<Int> by __packedInt32Delegate
+    internal val __packedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedInt64: List<Long> by __packedInt64Delegate
+    internal val __packedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedUint32: List<UInt> by __packedUint32Delegate
+    internal val __packedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedUint64: List<ULong> by __packedUint64Delegate
+    internal val __packedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSint32: List<Int> by __packedSint32Delegate
+    internal val __packedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSint64: List<Long> by __packedSint64Delegate
+    internal val __packedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed32: List<UInt> by __packedFixed32Delegate
+    internal val __packedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed64: List<ULong> by __packedFixed64Delegate
+    internal val __packedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed32: List<Int> by __packedSfixed32Delegate
+    internal val __packedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed64: List<Long> by __packedSfixed64Delegate
+    internal val __packedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var packedFloat: List<Float> by __packedFloatDelegate
+    internal val __packedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var packedDouble: List<Double> by __packedDoubleDelegate
+    internal val __packedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var packedBool: List<Boolean> by __packedBoolDelegate
+    internal val __packedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var packedNestedEnum: List<TestAllTypesProto3.NestedEnum> by __packedNestedEnumDelegate
+    internal val __unpackedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt32: List<Int> by __unpackedInt32Delegate
+    internal val __unpackedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt64: List<Long> by __unpackedInt64Delegate
+    internal val __unpackedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint32: List<UInt> by __unpackedUint32Delegate
+    internal val __unpackedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint64: List<ULong> by __unpackedUint64Delegate
+    internal val __unpackedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint32: List<Int> by __unpackedSint32Delegate
+    internal val __unpackedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint64: List<Long> by __unpackedSint64Delegate
+    internal val __unpackedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed32: List<UInt> by __unpackedFixed32Delegate
+    internal val __unpackedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed64: List<ULong> by __unpackedFixed64Delegate
+    internal val __unpackedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed32: List<Int> by __unpackedSfixed32Delegate
+    internal val __unpackedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed64: List<Long> by __unpackedSfixed64Delegate
+    internal val __unpackedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFloat: List<Float> by __unpackedFloatDelegate
+    internal val __unpackedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var unpackedDouble: List<Double> by __unpackedDoubleDelegate
+    internal val __unpackedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var unpackedBool: List<Boolean> by __unpackedBoolDelegate
+    internal val __unpackedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var unpackedNestedEnum: List<TestAllTypesProto3.NestedEnum> by __unpackedNestedEnumDelegate
+    internal val __mapInt32Int32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Int32: Map<Int, Int> by __mapInt32Int32Delegate
+    internal val __mapInt64Int64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt64Int64: Map<Long, Long> by __mapInt64Int64Delegate
+    internal val __mapUint32Uint32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint32Uint32: Map<UInt, UInt> by __mapUint32Uint32Delegate
+    internal val __mapUint64Uint64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint64Uint64: Map<ULong, ULong> by __mapUint64Uint64Delegate
+    internal val __mapSint32Sint32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint32Sint32: Map<Int, Int> by __mapSint32Sint32Delegate
+    internal val __mapSint64Sint64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint64Sint64: Map<Long, Long> by __mapSint64Sint64Delegate
+    internal val __mapFixed32Fixed32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed32Fixed32: Map<UInt, UInt> by __mapFixed32Fixed32Delegate
+    internal val __mapFixed64Fixed64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed64Fixed64: Map<ULong, ULong> by __mapFixed64Fixed64Delegate
+    internal val __mapSfixed32Sfixed32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed32Sfixed32: Map<Int, Int> by __mapSfixed32Sfixed32Delegate
+    internal val __mapSfixed64Sfixed64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed64Sfixed64: Map<Long, Long> by __mapSfixed64Sfixed64Delegate
+    internal val __mapInt32FloatDelegate: MsgFieldDelegate<Map<Int, Float>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Float: Map<Int, Float> by __mapInt32FloatDelegate
+    internal val __mapInt32DoubleDelegate: MsgFieldDelegate<Map<Int, Double>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Double: Map<Int, Double> by __mapInt32DoubleDelegate
+    internal val __mapBoolBoolDelegate: MsgFieldDelegate<Map<Boolean, Boolean>> = MsgFieldDelegate { emptyMap() }
+    override var mapBoolBool: Map<Boolean, Boolean> by __mapBoolBoolDelegate
+    internal val __mapStringStringDelegate: MsgFieldDelegate<Map<String, String>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringString: Map<String, String> by __mapStringStringDelegate
+    internal val __mapStringBytesDelegate: MsgFieldDelegate<Map<String, ByteString>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringBytes: Map<String, ByteString> by __mapStringBytesDelegate
+    internal val __mapStringNestedMessageDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto3.NestedMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedMessage: Map<String, TestAllTypesProto3.NestedMessage> by __mapStringNestedMessageDelegate
+    internal val __mapStringForeignMessageDelegate: MsgFieldDelegate<Map<String, ForeignMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignMessage: Map<String, ForeignMessage> by __mapStringForeignMessageDelegate
+    internal val __mapStringNestedEnumDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedEnum: Map<String, TestAllTypesProto3.NestedEnum> by __mapStringNestedEnumDelegate
+    internal val __mapStringForeignEnumDelegate: MsgFieldDelegate<Map<String, ForeignEnum>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignEnum: Map<String, ForeignEnum> by __mapStringForeignEnumDelegate
+    internal val __optionalBoolWrapperDelegate: MsgFieldDelegate<BoolValue> = MsgFieldDelegate(PresenceIndices.optionalBoolWrapper) { BoolValueInternal.DEFAULT }
+    override var optionalBoolWrapper: BoolValue by __optionalBoolWrapperDelegate
+    internal val __optionalInt32WrapperDelegate: MsgFieldDelegate<Int32Value> = MsgFieldDelegate(PresenceIndices.optionalInt32Wrapper) { Int32ValueInternal.DEFAULT }
+    override var optionalInt32Wrapper: Int32Value by __optionalInt32WrapperDelegate
+    internal val __optionalInt64WrapperDelegate: MsgFieldDelegate<Int64Value> = MsgFieldDelegate(PresenceIndices.optionalInt64Wrapper) { Int64ValueInternal.DEFAULT }
+    override var optionalInt64Wrapper: Int64Value by __optionalInt64WrapperDelegate
+    internal val __optionalUint32WrapperDelegate: MsgFieldDelegate<UInt32Value> = MsgFieldDelegate(PresenceIndices.optionalUint32Wrapper) { UInt32ValueInternal.DEFAULT }
+    override var optionalUint32Wrapper: UInt32Value by __optionalUint32WrapperDelegate
+    internal val __optionalUint64WrapperDelegate: MsgFieldDelegate<UInt64Value> = MsgFieldDelegate(PresenceIndices.optionalUint64Wrapper) { UInt64ValueInternal.DEFAULT }
+    override var optionalUint64Wrapper: UInt64Value by __optionalUint64WrapperDelegate
+    internal val __optionalFloatWrapperDelegate: MsgFieldDelegate<FloatValue> = MsgFieldDelegate(PresenceIndices.optionalFloatWrapper) { FloatValueInternal.DEFAULT }
+    override var optionalFloatWrapper: FloatValue by __optionalFloatWrapperDelegate
+    internal val __optionalDoubleWrapperDelegate: MsgFieldDelegate<DoubleValue> = MsgFieldDelegate(PresenceIndices.optionalDoubleWrapper) { DoubleValueInternal.DEFAULT }
+    override var optionalDoubleWrapper: DoubleValue by __optionalDoubleWrapperDelegate
+    internal val __optionalStringWrapperDelegate: MsgFieldDelegate<StringValue> = MsgFieldDelegate(PresenceIndices.optionalStringWrapper) { StringValueInternal.DEFAULT }
+    override var optionalStringWrapper: StringValue by __optionalStringWrapperDelegate
+    internal val __optionalBytesWrapperDelegate: MsgFieldDelegate<BytesValue> = MsgFieldDelegate(PresenceIndices.optionalBytesWrapper) { BytesValueInternal.DEFAULT }
+    override var optionalBytesWrapper: BytesValue by __optionalBytesWrapperDelegate
+    internal val __repeatedBoolWrapperDelegate: MsgFieldDelegate<List<BoolValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBoolWrapper: List<BoolValue> by __repeatedBoolWrapperDelegate
+    internal val __repeatedInt32WrapperDelegate: MsgFieldDelegate<List<Int32Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32Wrapper: List<Int32Value> by __repeatedInt32WrapperDelegate
+    internal val __repeatedInt64WrapperDelegate: MsgFieldDelegate<List<Int64Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt64Wrapper: List<Int64Value> by __repeatedInt64WrapperDelegate
+    internal val __repeatedUint32WrapperDelegate: MsgFieldDelegate<List<UInt32Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint32Wrapper: List<UInt32Value> by __repeatedUint32WrapperDelegate
+    internal val __repeatedUint64WrapperDelegate: MsgFieldDelegate<List<UInt64Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint64Wrapper: List<UInt64Value> by __repeatedUint64WrapperDelegate
+    internal val __repeatedFloatWrapperDelegate: MsgFieldDelegate<List<FloatValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFloatWrapper: List<FloatValue> by __repeatedFloatWrapperDelegate
+    internal val __repeatedDoubleWrapperDelegate: MsgFieldDelegate<List<DoubleValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDoubleWrapper: List<DoubleValue> by __repeatedDoubleWrapperDelegate
+    internal val __repeatedStringWrapperDelegate: MsgFieldDelegate<List<StringValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStringWrapper: List<StringValue> by __repeatedStringWrapperDelegate
+    internal val __repeatedBytesWrapperDelegate: MsgFieldDelegate<List<BytesValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBytesWrapper: List<BytesValue> by __repeatedBytesWrapperDelegate
+    internal val __optionalDurationDelegate: MsgFieldDelegate<Duration> = MsgFieldDelegate(PresenceIndices.optionalDuration) { DurationInternal.DEFAULT }
+    override var optionalDuration: Duration by __optionalDurationDelegate
+    internal val __optionalTimestampDelegate: MsgFieldDelegate<Timestamp> = MsgFieldDelegate(PresenceIndices.optionalTimestamp) { TimestampInternal.DEFAULT }
+    override var optionalTimestamp: Timestamp by __optionalTimestampDelegate
+    internal val __optionalFieldMaskDelegate: MsgFieldDelegate<FieldMask> = MsgFieldDelegate(PresenceIndices.optionalFieldMask) { FieldMaskInternal.DEFAULT }
+    override var optionalFieldMask: FieldMask by __optionalFieldMaskDelegate
+    internal val __optionalStructDelegate: MsgFieldDelegate<Struct> = MsgFieldDelegate(PresenceIndices.optionalStruct) { StructInternal.DEFAULT }
+    override var optionalStruct: Struct by __optionalStructDelegate
+    internal val __optionalAnyDelegate: MsgFieldDelegate<com.google.protobuf.kotlin.Any> = MsgFieldDelegate(PresenceIndices.optionalAny) { AnyInternal.DEFAULT }
+    override var optionalAny: com.google.protobuf.kotlin.Any by __optionalAnyDelegate
+    internal val __optionalValueDelegate: MsgFieldDelegate<Value> = MsgFieldDelegate(PresenceIndices.optionalValue) { ValueInternal.DEFAULT }
+    override var optionalValue: Value by __optionalValueDelegate
+    internal val __optionalNullValueDelegate: MsgFieldDelegate<NullValue> = MsgFieldDelegate { NullValue.NULL_VALUE }
+    override var optionalNullValue: NullValue by __optionalNullValueDelegate
+    internal val __optionalEmptyDelegate: MsgFieldDelegate<Empty> = MsgFieldDelegate(PresenceIndices.optionalEmpty) { EmptyInternal.DEFAULT }
+    override var optionalEmpty: Empty by __optionalEmptyDelegate
+    internal val __repeatedDurationDelegate: MsgFieldDelegate<List<Duration>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDuration: List<Duration> by __repeatedDurationDelegate
+    internal val __repeatedTimestampDelegate: MsgFieldDelegate<List<Timestamp>> = MsgFieldDelegate { emptyList() }
+    override var repeatedTimestamp: List<Timestamp> by __repeatedTimestampDelegate
+    internal val __repeatedFieldmaskDelegate: MsgFieldDelegate<List<FieldMask>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFieldmask: List<FieldMask> by __repeatedFieldmaskDelegate
+    internal val __repeatedStructDelegate: MsgFieldDelegate<List<Struct>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStruct: List<Struct> by __repeatedStructDelegate
+    internal val __repeatedAnyDelegate: MsgFieldDelegate<List<com.google.protobuf.kotlin.Any>> = MsgFieldDelegate { emptyList() }
+    override var repeatedAny: List<com.google.protobuf.kotlin.Any> by __repeatedAnyDelegate
+    internal val __repeatedValueDelegate: MsgFieldDelegate<List<Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedValue: List<Value> by __repeatedValueDelegate
+    internal val __repeatedListValueDelegate: MsgFieldDelegate<List<ListValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedListValue: List<ListValue> by __repeatedListValueDelegate
+    internal val __repeatedEmptyDelegate: MsgFieldDelegate<List<Empty>> = MsgFieldDelegate { emptyList() }
+    override var repeatedEmpty: List<Empty> by __repeatedEmptyDelegate
+    internal val __fieldname1Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldname1: Int by __fieldname1Delegate
+    internal val __fieldName2Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldName2: Int by __fieldName2Delegate
+    internal val __FieldName3Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FieldName3: Int by __FieldName3Delegate
+    internal val __field_Name4_Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_Name4_: Int by __field_Name4_Delegate
+    internal val __field0name5Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field0name5: Int by __field0name5Delegate
+    internal val __field_0Name6Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_0Name6: Int by __field_0Name6Delegate
+    internal val __fieldName7Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldName7: Int by __fieldName7Delegate
+    internal val __FieldName8Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FieldName8: Int by __FieldName8Delegate
+    internal val __field_Name9Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_Name9: Int by __field_Name9Delegate
+    internal val __Field_Name10Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var Field_Name10: Int by __Field_Name10Delegate
+    internal val __FIELD_NAME11Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FIELD_NAME11: Int by __FIELD_NAME11Delegate
+    internal val __FIELDName12Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FIELDName12: Int by __FIELDName12Delegate
+    internal val ___FieldName13Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var _FieldName13: Int by ___FieldName13Delegate
+    internal val ____FieldName14Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var __FieldName14: Int by ____FieldName14Delegate
+    internal val __field_Name15Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_Name15: Int by __field_Name15Delegate
+    internal val __field__Name16Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field__Name16: Int by __field__Name16Delegate
+    internal val __fieldName17__Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldName17__: Int by __fieldName17__Delegate
+    internal val __FieldName18__Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FieldName18__: Int by __FieldName18__Delegate
     override var oneofField: TestAllTypesProto3.OneofField? = null
 
     private val _owner: TestAllTypesProto3Internal = this
@@ -1169,8 +1312,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int by MsgFieldDelegate { 0 }
-        override var corecursive: TestAllTypesProto3 by MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto3Internal() }
+        internal val __aDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        override var a: Int by __aDelegate
+        internal val __corecursiveDelegate: MsgFieldDelegate<TestAllTypesProto3> = MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto3Internal.DEFAULT }
+        override var corecursive: TestAllTypesProto3 by __corecursiveDelegate
 
         private val _owner: NestedMessageInternal = this
 
@@ -1270,7 +1415,9 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto3.NestedMessage by lazy { NestedMessageInternal() }
+        }
     }
 
     class MapInt32Int32EntryInternal: InternalMessage(fieldsWithPresence = 0) {
@@ -1283,8 +1430,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Int by MsgFieldDelegate { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1338,8 +1487,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate { 0L }
-        var value: Long by MsgFieldDelegate { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1393,8 +1544,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate { 0u }
-        var value: UInt by MsgFieldDelegate { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1448,8 +1601,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate { 0uL }
-        var value: ULong by MsgFieldDelegate { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1503,8 +1658,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Int by MsgFieldDelegate { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1558,8 +1715,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate { 0L }
-        var value: Long by MsgFieldDelegate { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1613,8 +1772,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate { 0u }
-        var value: UInt by MsgFieldDelegate { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1668,8 +1829,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate { 0uL }
-        var value: ULong by MsgFieldDelegate { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1723,8 +1886,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Int by MsgFieldDelegate { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1778,8 +1943,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate { 0L }
-        var value: Long by MsgFieldDelegate { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1833,8 +2000,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Float by MsgFieldDelegate { 0.0f }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate { 0.0f }
+        var value: Float by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1888,8 +2057,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Double by MsgFieldDelegate { 0.0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate { 0.0 }
+        var value: Double by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1943,8 +2114,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Boolean by MsgFieldDelegate { false }
-        var value: Boolean by MsgFieldDelegate { false }
+        internal val __keyDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+        var key: Boolean by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+        var value: Boolean by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1998,8 +2171,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: String by MsgFieldDelegate { "" }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var value: String by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2053,8 +2228,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: ByteString by MsgFieldDelegate { ByteString() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate { ByteString() }
+        var value: ByteString by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2112,8 +2289,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: TestAllTypesProto3.NestedMessage by MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedMessage> = MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal.DEFAULT }
+        var value: TestAllTypesProto3.NestedMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2177,8 +2356,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: ForeignMessage by MsgFieldDelegate(PresenceIndices.value) { ForeignMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignMessage> = MsgFieldDelegate(PresenceIndices.value) { ForeignMessageInternal.DEFAULT }
+        var value: ForeignMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2238,8 +2419,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: TestAllTypesProto3.NestedEnum by MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedEnum> = MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
+        var value: TestAllTypesProto3.NestedEnum by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2293,8 +2476,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: ForeignEnum by MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignEnum> = MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
+        var value: ForeignEnum by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2370,7 +2555,9 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestAllTypesProto3 by lazy { TestAllTypesProto3Internal() }
+    }
 }
 
 class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -2383,7 +2570,8 @@ class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWith
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var c: Int by MsgFieldDelegate { 0 }
+    internal val __cDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var c: Int by __cDelegate
 
     override fun hashCode(): Int {
         checkRequiredFields()
@@ -2461,7 +2649,9 @@ class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ForeignMessage by lazy { ForeignMessageInternal() }
+    }
 }
 
 class NullHypothesisProto3Internal: NullHypothesisProto3.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -2547,7 +2737,9 @@ class NullHypothesisProto3Internal: NullHypothesisProto3.Builder, InternalMessag
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: NullHypothesisProto3 by lazy { NullHypothesisProto3Internal() }
+    }
 }
 
 class EnumOnlyProto3Internal: EnumOnlyProto3.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -2633,7 +2825,9 @@ class EnumOnlyProto3Internal: EnumOnlyProto3.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: EnumOnlyProto3 by lazy { EnumOnlyProto3Internal() }
+    }
 }
 
 @InternalRpcApi
@@ -3703,18 +3897,12 @@ fun TestAllTypesProto3Internal.Companion.decodeWith(msg: TestAllTypesProto3Inter
                 msg.optionalBytes = decoder.readBytes()
             }
             tag.fieldNr == 18 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.optionalNestedMessage = TestAllTypesProto3Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.optionalNestedMessage.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalNestedMessageDelegate.getOrCreate(msg) { TestAllTypesProto3Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 19 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.optionalForeignMessage = ForeignMessageInternal()
-                }
-
-                decoder.readMessage(msg.optionalForeignMessage.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalForeignMessageDelegate.getOrCreate(msg) { ForeignMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 21 && tag.wireType == WireType.VARINT -> {
                 msg.optionalNestedEnum = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
@@ -3732,652 +3920,729 @@ fun TestAllTypesProto3Internal.Companion.decodeWith(msg: TestAllTypesProto3Inter
                 msg.optionalCord = decoder.readString()
             }
             tag.fieldNr == 27 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[2]) {
-                    msg.recursiveMessage = TestAllTypesProto3Internal()
-                }
-
-                decoder.readMessage(msg.recursiveMessage.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__recursiveMessageDelegate.getOrCreate(msg) { TestAllTypesProto3Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 31 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt32 += decoder.readPackedInt32()
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 31 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.repeatedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 32 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt64 += decoder.readPackedInt64()
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 32 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.repeatedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 33 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint32 += decoder.readPackedUInt32()
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 33 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.repeatedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 34 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint64 += decoder.readPackedUInt64()
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 34 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.repeatedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 35 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint32 += decoder.readPackedSInt32()
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 35 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.repeatedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 36 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint64 += decoder.readPackedSInt64()
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 36 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.repeatedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 37 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 37 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.repeatedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 38 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 38 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.repeatedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 39 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 39 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.repeatedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 40 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 40 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.repeatedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 41 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFloat += decoder.readPackedFloat()
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 41 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.repeatedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 42 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedDouble += decoder.readPackedDouble()
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 42 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.repeatedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 43 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedBool += decoder.readPackedBool()
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 43 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.repeatedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 44 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedString as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 45 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBytesDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBytes()
-                (msg.repeatedBytes as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 48 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedNestedMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3Internal.NestedMessageInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedNestedMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 49 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedForeignMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignMessageInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedForeignMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 51 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) }
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 51 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.repeatedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 52 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedForeignEnum += decoder.readPackedEnum().map { ForeignEnum.fromNumber(it) }
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { ForeignEnum.fromNumber(it) })
             }
             tag.fieldNr == 52 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignEnum.fromNumber(decoder.readEnum())
-                (msg.repeatedForeignEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 54 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringPieceDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedStringPiece as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 55 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedCordDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedCord as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 75 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt32 += decoder.readPackedInt32()
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 75 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.packedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 76 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt64 += decoder.readPackedInt64()
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 76 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.packedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 77 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint32 += decoder.readPackedUInt32()
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 77 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.packedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 78 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint64 += decoder.readPackedUInt64()
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 78 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.packedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 79 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint32 += decoder.readPackedSInt32()
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 79 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.packedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 80 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint64 += decoder.readPackedSInt64()
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 80 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.packedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 81 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 81 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.packedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 82 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 82 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.packedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 83 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 83 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.packedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 84 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 84 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.packedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 85 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFloat += decoder.readPackedFloat()
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 85 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.packedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 86 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedDouble += decoder.readPackedDouble()
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 86 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.packedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 87 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedBool += decoder.readPackedBool()
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 87 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.packedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 88 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) }
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 88 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.packedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 89 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt32 += decoder.readPackedInt32()
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 89 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.unpackedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 90 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt64 += decoder.readPackedInt64()
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 90 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.unpackedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 91 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint32 += decoder.readPackedUInt32()
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 91 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.unpackedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 92 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint64 += decoder.readPackedUInt64()
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 92 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.unpackedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 93 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint32 += decoder.readPackedSInt32()
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 93 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.unpackedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 94 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint64 += decoder.readPackedSInt64()
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 94 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.unpackedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 95 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 95 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.unpackedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 96 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 96 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.unpackedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 97 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 97 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.unpackedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 98 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 98 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.unpackedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 99 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFloat += decoder.readPackedFloat()
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 99 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.unpackedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 100 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedDouble += decoder.readPackedDouble()
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 100 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.unpackedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 101 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedBool += decoder.readPackedBool()
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 101 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.unpackedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 102 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) }
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 102 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.unpackedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 56 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32Int32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt32Int32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt32Int32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Int32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 57 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt64Int64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt64Int64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt64Int64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt64Int64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 58 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint32Uint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapUint32Uint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapUint32Uint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint32Uint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 59 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint64Uint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapUint64Uint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapUint64Uint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint64Uint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 60 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint32Sint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSint32Sint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSint32Sint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint32Sint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 61 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint64Sint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSint64Sint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSint64Sint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint64Sint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 62 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed32Fixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapFixed32Fixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapFixed32Fixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed32Fixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 63 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed64Fixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapFixed64Fixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapFixed64Fixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed64Fixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 64 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed32Sfixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSfixed32Sfixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSfixed32Sfixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed32Sfixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 65 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed64Sfixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSfixed64Sfixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSfixed64Sfixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed64Sfixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 66 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32FloatDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt32FloatEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt32FloatEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Float as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 67 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32DoubleDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt32DoubleEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt32DoubleEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Double as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 68 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapBoolBoolDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapBoolBoolEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapBoolBoolEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapBoolBool as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 69 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringStringDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringStringEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringStringEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringString as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 70 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringBytesDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringBytesEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringBytesEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringBytes as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 71 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 72 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 73 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringNestedEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringNestedEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 74 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringForeignEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringForeignEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 201 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[3]) {
-                    msg.optionalBoolWrapper = BoolValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalBoolWrapper.asInternal(), { msg, decoder -> BoolValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalBoolWrapperDelegate.getOrCreate(msg) { BoolValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> BoolValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 202 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[4]) {
-                    msg.optionalInt32Wrapper = Int32ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalInt32Wrapper.asInternal(), { msg, decoder -> Int32ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalInt32WrapperDelegate.getOrCreate(msg) { Int32ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> Int32ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 203 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[5]) {
-                    msg.optionalInt64Wrapper = Int64ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalInt64Wrapper.asInternal(), { msg, decoder -> Int64ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalInt64WrapperDelegate.getOrCreate(msg) { Int64ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> Int64ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 204 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[6]) {
-                    msg.optionalUint32Wrapper = UInt32ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalUint32Wrapper.asInternal(), { msg, decoder -> UInt32ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalUint32WrapperDelegate.getOrCreate(msg) { UInt32ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> UInt32ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 205 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[7]) {
-                    msg.optionalUint64Wrapper = UInt64ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalUint64Wrapper.asInternal(), { msg, decoder -> UInt64ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalUint64WrapperDelegate.getOrCreate(msg) { UInt64ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> UInt64ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 206 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[8]) {
-                    msg.optionalFloatWrapper = FloatValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalFloatWrapper.asInternal(), { msg, decoder -> FloatValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalFloatWrapperDelegate.getOrCreate(msg) { FloatValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> FloatValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 207 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[9]) {
-                    msg.optionalDoubleWrapper = DoubleValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalDoubleWrapper.asInternal(), { msg, decoder -> DoubleValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalDoubleWrapperDelegate.getOrCreate(msg) { DoubleValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> DoubleValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 208 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[10]) {
-                    msg.optionalStringWrapper = StringValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalStringWrapper.asInternal(), { msg, decoder -> StringValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalStringWrapperDelegate.getOrCreate(msg) { StringValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> StringValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 209 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[11]) {
-                    msg.optionalBytesWrapper = BytesValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalBytesWrapper.asInternal(), { msg, decoder -> BytesValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalBytesWrapperDelegate.getOrCreate(msg) { BytesValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> BytesValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 211 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBoolWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = BoolValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> BoolValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedBoolWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 212 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedInt32WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = Int32ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> Int32ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedInt32Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 213 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedInt64WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = Int64ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> Int64ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedInt64Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 214 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedUint32WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = UInt32ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> UInt32ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedUint32Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 215 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedUint64WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = UInt64ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> UInt64ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedUint64Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 216 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedFloatWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = FloatValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> FloatValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedFloatWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 217 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedDoubleWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = DoubleValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> DoubleValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedDoubleWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 218 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = StringValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> StringValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedStringWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 219 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBytesWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = BytesValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> BytesValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedBytesWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 301 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[12]) {
-                    msg.optionalDuration = DurationInternal()
-                }
-
-                decoder.readMessage(msg.optionalDuration.asInternal(), { msg, decoder -> DurationInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalDurationDelegate.getOrCreate(msg) { DurationInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> DurationInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 302 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[13]) {
-                    msg.optionalTimestamp = TimestampInternal()
-                }
-
-                decoder.readMessage(msg.optionalTimestamp.asInternal(), { msg, decoder -> TimestampInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalTimestampDelegate.getOrCreate(msg) { TimestampInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TimestampInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 303 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[14]) {
-                    msg.optionalFieldMask = FieldMaskInternal()
-                }
-
-                decoder.readMessage(msg.optionalFieldMask.asInternal(), { msg, decoder -> FieldMaskInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalFieldMaskDelegate.getOrCreate(msg) { FieldMaskInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> FieldMaskInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 304 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[15]) {
-                    msg.optionalStruct = StructInternal()
-                }
-
-                decoder.readMessage(msg.optionalStruct.asInternal(), { msg, decoder -> StructInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalStructDelegate.getOrCreate(msg) { StructInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> StructInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 305 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[16]) {
-                    msg.optionalAny = AnyInternal()
-                }
-
-                decoder.readMessage(msg.optionalAny.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalAnyDelegate.getOrCreate(msg) { AnyInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 306 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[17]) {
-                    msg.optionalValue = ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalValue.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalValueDelegate.getOrCreate(msg) { ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 307 && tag.wireType == WireType.VARINT -> {
                 msg.optionalNullValue = NullValue.fromNumber(decoder.readEnum())
             }
             tag.fieldNr == 308 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[18]) {
-                    msg.optionalEmpty = EmptyInternal()
-                }
-
-                decoder.readMessage(msg.optionalEmpty.asInternal(), { msg, decoder -> EmptyInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalEmptyDelegate.getOrCreate(msg) { EmptyInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> EmptyInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 311 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedDurationDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = DurationInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> DurationInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedDuration as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 312 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedTimestampDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TimestampInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TimestampInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedTimestamp as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 313 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedFieldmaskDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = FieldMaskInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> FieldMaskInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedFieldmask as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 324 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStructDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = StructInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> StructInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedStruct as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 315 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedAnyDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = AnyInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedAny as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 316 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedValueDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedValue as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 317 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedListValueDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ListValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ListValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedListValue as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 318 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedEmptyDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = EmptyInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> EmptyInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedEmpty as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 401 && tag.wireType == WireType.VARINT -> {
                 msg.fieldname1 = decoder.readInt32()
@@ -5432,11 +5697,8 @@ fun TestAllTypesProto3Internal.NestedMessageInternal.Companion.decodeWith(msg: T
                 msg.a = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.corecursive = TestAllTypesProto3Internal()
-                }
-
-                decoder.readMessage(msg.corecursive.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__corecursiveDelegate.getOrCreate(msg) { TestAllTypesProto3Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -6655,11 +6917,8 @@ fun TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal.Companion.dec
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.value = TestAllTypesProto3Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { TestAllTypesProto3Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -6738,11 +6997,8 @@ fun TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal.Companion.de
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.value = ForeignMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { ForeignMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto2/_rpc_internal/TestMessagesProto2.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto2/_rpc_internal/TestMessagesProto2.kt
@@ -133,134 +133,262 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var optionalInt32: Int? by MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
-    override var optionalInt64: Long? by MsgFieldDelegate(PresenceIndices.optionalInt64) { null }
-    override var optionalUint32: UInt? by MsgFieldDelegate(PresenceIndices.optionalUint32) { null }
-    override var optionalUint64: ULong? by MsgFieldDelegate(PresenceIndices.optionalUint64) { null }
-    override var optionalSint32: Int? by MsgFieldDelegate(PresenceIndices.optionalSint32) { null }
-    override var optionalSint64: Long? by MsgFieldDelegate(PresenceIndices.optionalSint64) { null }
-    override var optionalFixed32: UInt? by MsgFieldDelegate(PresenceIndices.optionalFixed32) { null }
-    override var optionalFixed64: ULong? by MsgFieldDelegate(PresenceIndices.optionalFixed64) { null }
-    override var optionalSfixed32: Int? by MsgFieldDelegate(PresenceIndices.optionalSfixed32) { null }
-    override var optionalSfixed64: Long? by MsgFieldDelegate(PresenceIndices.optionalSfixed64) { null }
-    override var optionalFloat: Float? by MsgFieldDelegate(PresenceIndices.optionalFloat) { null }
-    override var optionalDouble: Double? by MsgFieldDelegate(PresenceIndices.optionalDouble) { null }
-    override var optionalBool: Boolean? by MsgFieldDelegate(PresenceIndices.optionalBool) { null }
-    override var optionalString: String? by MsgFieldDelegate(PresenceIndices.optionalString) { null }
-    override var optionalBytes: ByteString? by MsgFieldDelegate(PresenceIndices.optionalBytes) { null }
-    override var optionalNestedMessage: TestAllTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal() }
-    override var optionalForeignMessage: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageProto2Internal() }
-    override var optionalNestedEnum: TestAllTypesProto2.NestedEnum? by MsgFieldDelegate(PresenceIndices.optionalNestedEnum) { null }
-    override var optionalForeignEnum: ForeignEnumProto2? by MsgFieldDelegate(PresenceIndices.optionalForeignEnum) { null }
-    override var optionalStringPiece: String? by MsgFieldDelegate(PresenceIndices.optionalStringPiece) { null }
-    override var optionalCord: String? by MsgFieldDelegate(PresenceIndices.optionalCord) { null }
-    override var recursiveMessage: TestAllTypesProto2 by MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto2Internal() }
-    override var repeatedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedString: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBytes: List<ByteString> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedMessage: List<TestAllTypesProto2.NestedMessage> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignMessage: List<ForeignMessageProto2> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedEnum: List<TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignEnum: List<ForeignEnumProto2> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStringPiece: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedCord: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var packedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var packedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var packedNestedEnum: List<TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedNestedEnum: List<TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var mapInt32Int32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt64Int64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint32Uint32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint64Uint64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint32Sint32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint64Sint64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed32Fixed32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed64Fixed64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed32Sfixed32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed64Sfixed64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Bool: Map<Int, Boolean> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Float: Map<Int, Float> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Double: Map<Int, Double> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32NestedMessage: Map<Int, TestAllTypesProto2.NestedMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapBoolBool: Map<Boolean, Boolean> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringString: Map<String, String> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringBytes: Map<String, ByteString> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedMessage: Map<String, TestAllTypesProto2.NestedMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignMessage: Map<String, ForeignMessageProto2> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedEnum: Map<String, TestAllTypesProto2.NestedEnum> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignEnum: Map<String, ForeignEnumProto2> by MsgFieldDelegate { mutableMapOf() }
-    override var data: TestAllTypesProto2.Data by MsgFieldDelegate(PresenceIndices.data) { DataInternal() }
-    override var multiwordgroupfield: TestAllTypesProto2.MultiWordGroupField by MsgFieldDelegate(PresenceIndices.multiwordgroupfield) { MultiWordGroupFieldInternal() }
-    override var defaultInt32: Int by MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
-    override var defaultInt64: Long by MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
-    override var defaultUint32: UInt by MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
-    override var defaultUint64: ULong by MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
-    override var defaultSint32: Int by MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
-    override var defaultSint64: Long by MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
-    override var defaultFixed32: UInt by MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
-    override var defaultFixed64: ULong by MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
-    override var defaultSfixed32: Int by MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
-    override var defaultSfixed64: Long by MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
-    override var defaultFloat: Float by MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
-    override var defaultDouble: Double by MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
-    override var defaultBool: Boolean by MsgFieldDelegate(PresenceIndices.defaultBool) { true }
-    override var defaultString: String by MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
-    override var defaultBytes: ByteString by MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
-    override var fieldname1: Int? by MsgFieldDelegate(PresenceIndices.fieldname1) { null }
-    override var fieldName2: Int? by MsgFieldDelegate(PresenceIndices.fieldName2) { null }
-    override var FieldName3: Int? by MsgFieldDelegate(PresenceIndices.FieldName3) { null }
-    override var field_Name4_: Int? by MsgFieldDelegate(PresenceIndices.field_Name4_) { null }
-    override var field0name5: Int? by MsgFieldDelegate(PresenceIndices.field0name5) { null }
-    override var field_0Name6: Int? by MsgFieldDelegate(PresenceIndices.field_0Name6) { null }
-    override var fieldName7: Int? by MsgFieldDelegate(PresenceIndices.fieldName7) { null }
-    override var FieldName8: Int? by MsgFieldDelegate(PresenceIndices.FieldName8) { null }
-    override var field_Name9: Int? by MsgFieldDelegate(PresenceIndices.field_Name9) { null }
-    override var Field_Name10: Int? by MsgFieldDelegate(PresenceIndices.Field_Name10) { null }
-    override var FIELD_NAME11: Int? by MsgFieldDelegate(PresenceIndices.FIELD_NAME11) { null }
-    override var FIELDName12: Int? by MsgFieldDelegate(PresenceIndices.FIELDName12) { null }
-    override var _FieldName13: Int? by MsgFieldDelegate(PresenceIndices._FieldName13) { null }
-    override var __FieldName14: Int? by MsgFieldDelegate(PresenceIndices.__FieldName14) { null }
-    override var field_Name15: Int? by MsgFieldDelegate(PresenceIndices.field_Name15) { null }
-    override var field__Name16: Int? by MsgFieldDelegate(PresenceIndices.field__Name16) { null }
-    override var fieldName17__: Int? by MsgFieldDelegate(PresenceIndices.fieldName17__) { null }
-    override var FieldName18__: Int? by MsgFieldDelegate(PresenceIndices.FieldName18__) { null }
-    override var messageSetCorrect: TestAllTypesProto2.MessageSetCorrect by MsgFieldDelegate(PresenceIndices.messageSetCorrect) { MessageSetCorrectInternal() }
+    internal val __optionalInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
+    override var optionalInt32: Int? by __optionalInt32Delegate
+    internal val __optionalInt64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalInt64) { null }
+    override var optionalInt64: Long? by __optionalInt64Delegate
+    internal val __optionalUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.optionalUint32) { null }
+    override var optionalUint32: UInt? by __optionalUint32Delegate
+    internal val __optionalUint64Delegate: MsgFieldDelegate<ULong?> = MsgFieldDelegate(PresenceIndices.optionalUint64) { null }
+    override var optionalUint64: ULong? by __optionalUint64Delegate
+    internal val __optionalSint32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalSint32) { null }
+    override var optionalSint32: Int? by __optionalSint32Delegate
+    internal val __optionalSint64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalSint64) { null }
+    override var optionalSint64: Long? by __optionalSint64Delegate
+    internal val __optionalFixed32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.optionalFixed32) { null }
+    override var optionalFixed32: UInt? by __optionalFixed32Delegate
+    internal val __optionalFixed64Delegate: MsgFieldDelegate<ULong?> = MsgFieldDelegate(PresenceIndices.optionalFixed64) { null }
+    override var optionalFixed64: ULong? by __optionalFixed64Delegate
+    internal val __optionalSfixed32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalSfixed32) { null }
+    override var optionalSfixed32: Int? by __optionalSfixed32Delegate
+    internal val __optionalSfixed64Delegate: MsgFieldDelegate<Long?> = MsgFieldDelegate(PresenceIndices.optionalSfixed64) { null }
+    override var optionalSfixed64: Long? by __optionalSfixed64Delegate
+    internal val __optionalFloatDelegate: MsgFieldDelegate<Float?> = MsgFieldDelegate(PresenceIndices.optionalFloat) { null }
+    override var optionalFloat: Float? by __optionalFloatDelegate
+    internal val __optionalDoubleDelegate: MsgFieldDelegate<Double?> = MsgFieldDelegate(PresenceIndices.optionalDouble) { null }
+    override var optionalDouble: Double? by __optionalDoubleDelegate
+    internal val __optionalBoolDelegate: MsgFieldDelegate<Boolean?> = MsgFieldDelegate(PresenceIndices.optionalBool) { null }
+    override var optionalBool: Boolean? by __optionalBoolDelegate
+    internal val __optionalStringDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalString) { null }
+    override var optionalString: String? by __optionalStringDelegate
+    internal val __optionalBytesDelegate: MsgFieldDelegate<ByteString?> = MsgFieldDelegate(PresenceIndices.optionalBytes) { null }
+    override var optionalBytes: ByteString? by __optionalBytesDelegate
+    internal val __optionalNestedMessageDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal.DEFAULT }
+    override var optionalNestedMessage: TestAllTypesProto2.NestedMessage by __optionalNestedMessageDelegate
+    internal val __optionalForeignMessageDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageProto2Internal.DEFAULT }
+    override var optionalForeignMessage: ForeignMessageProto2 by __optionalForeignMessageDelegate
+    internal val __optionalNestedEnumDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedEnum?> = MsgFieldDelegate(PresenceIndices.optionalNestedEnum) { null }
+    override var optionalNestedEnum: TestAllTypesProto2.NestedEnum? by __optionalNestedEnumDelegate
+    internal val __optionalForeignEnumDelegate: MsgFieldDelegate<ForeignEnumProto2?> = MsgFieldDelegate(PresenceIndices.optionalForeignEnum) { null }
+    override var optionalForeignEnum: ForeignEnumProto2? by __optionalForeignEnumDelegate
+    internal val __optionalStringPieceDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalStringPiece) { null }
+    override var optionalStringPiece: String? by __optionalStringPieceDelegate
+    internal val __optionalCordDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalCord) { null }
+    override var optionalCord: String? by __optionalCordDelegate
+    internal val __recursiveMessageDelegate: MsgFieldDelegate<TestAllTypesProto2> = MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto2Internal.DEFAULT }
+    override var recursiveMessage: TestAllTypesProto2 by __recursiveMessageDelegate
+    internal val __repeatedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32: List<Int> by __repeatedInt32Delegate
+    internal val __repeatedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt64: List<Long> by __repeatedInt64Delegate
+    internal val __repeatedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint32: List<UInt> by __repeatedUint32Delegate
+    internal val __repeatedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint64: List<ULong> by __repeatedUint64Delegate
+    internal val __repeatedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint32: List<Int> by __repeatedSint32Delegate
+    internal val __repeatedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint64: List<Long> by __repeatedSint64Delegate
+    internal val __repeatedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed32: List<UInt> by __repeatedFixed32Delegate
+    internal val __repeatedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed64: List<ULong> by __repeatedFixed64Delegate
+    internal val __repeatedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed32: List<Int> by __repeatedSfixed32Delegate
+    internal val __repeatedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed64: List<Long> by __repeatedSfixed64Delegate
+    internal val __repeatedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFloat: List<Float> by __repeatedFloatDelegate
+    internal val __repeatedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDouble: List<Double> by __repeatedDoubleDelegate
+    internal val __repeatedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBool: List<Boolean> by __repeatedBoolDelegate
+    internal val __repeatedStringDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedString: List<String> by __repeatedStringDelegate
+    internal val __repeatedBytesDelegate: MsgFieldDelegate<List<ByteString>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBytes: List<ByteString> by __repeatedBytesDelegate
+    internal val __repeatedNestedMessageDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedMessage>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedMessage: List<TestAllTypesProto2.NestedMessage> by __repeatedNestedMessageDelegate
+    internal val __repeatedForeignMessageDelegate: MsgFieldDelegate<List<ForeignMessageProto2>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignMessage: List<ForeignMessageProto2> by __repeatedForeignMessageDelegate
+    internal val __repeatedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedEnum: List<TestAllTypesProto2.NestedEnum> by __repeatedNestedEnumDelegate
+    internal val __repeatedForeignEnumDelegate: MsgFieldDelegate<List<ForeignEnumProto2>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignEnum: List<ForeignEnumProto2> by __repeatedForeignEnumDelegate
+    internal val __repeatedStringPieceDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStringPiece: List<String> by __repeatedStringPieceDelegate
+    internal val __repeatedCordDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedCord: List<String> by __repeatedCordDelegate
+    internal val __packedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedInt32: List<Int> by __packedInt32Delegate
+    internal val __packedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedInt64: List<Long> by __packedInt64Delegate
+    internal val __packedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedUint32: List<UInt> by __packedUint32Delegate
+    internal val __packedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedUint64: List<ULong> by __packedUint64Delegate
+    internal val __packedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSint32: List<Int> by __packedSint32Delegate
+    internal val __packedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSint64: List<Long> by __packedSint64Delegate
+    internal val __packedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed32: List<UInt> by __packedFixed32Delegate
+    internal val __packedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed64: List<ULong> by __packedFixed64Delegate
+    internal val __packedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed32: List<Int> by __packedSfixed32Delegate
+    internal val __packedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed64: List<Long> by __packedSfixed64Delegate
+    internal val __packedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var packedFloat: List<Float> by __packedFloatDelegate
+    internal val __packedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var packedDouble: List<Double> by __packedDoubleDelegate
+    internal val __packedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var packedBool: List<Boolean> by __packedBoolDelegate
+    internal val __packedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var packedNestedEnum: List<TestAllTypesProto2.NestedEnum> by __packedNestedEnumDelegate
+    internal val __unpackedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt32: List<Int> by __unpackedInt32Delegate
+    internal val __unpackedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt64: List<Long> by __unpackedInt64Delegate
+    internal val __unpackedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint32: List<UInt> by __unpackedUint32Delegate
+    internal val __unpackedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint64: List<ULong> by __unpackedUint64Delegate
+    internal val __unpackedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint32: List<Int> by __unpackedSint32Delegate
+    internal val __unpackedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint64: List<Long> by __unpackedSint64Delegate
+    internal val __unpackedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed32: List<UInt> by __unpackedFixed32Delegate
+    internal val __unpackedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed64: List<ULong> by __unpackedFixed64Delegate
+    internal val __unpackedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed32: List<Int> by __unpackedSfixed32Delegate
+    internal val __unpackedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed64: List<Long> by __unpackedSfixed64Delegate
+    internal val __unpackedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFloat: List<Float> by __unpackedFloatDelegate
+    internal val __unpackedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var unpackedDouble: List<Double> by __unpackedDoubleDelegate
+    internal val __unpackedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var unpackedBool: List<Boolean> by __unpackedBoolDelegate
+    internal val __unpackedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var unpackedNestedEnum: List<TestAllTypesProto2.NestedEnum> by __unpackedNestedEnumDelegate
+    internal val __mapInt32Int32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Int32: Map<Int, Int> by __mapInt32Int32Delegate
+    internal val __mapInt64Int64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt64Int64: Map<Long, Long> by __mapInt64Int64Delegate
+    internal val __mapUint32Uint32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint32Uint32: Map<UInt, UInt> by __mapUint32Uint32Delegate
+    internal val __mapUint64Uint64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint64Uint64: Map<ULong, ULong> by __mapUint64Uint64Delegate
+    internal val __mapSint32Sint32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint32Sint32: Map<Int, Int> by __mapSint32Sint32Delegate
+    internal val __mapSint64Sint64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint64Sint64: Map<Long, Long> by __mapSint64Sint64Delegate
+    internal val __mapFixed32Fixed32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed32Fixed32: Map<UInt, UInt> by __mapFixed32Fixed32Delegate
+    internal val __mapFixed64Fixed64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed64Fixed64: Map<ULong, ULong> by __mapFixed64Fixed64Delegate
+    internal val __mapSfixed32Sfixed32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed32Sfixed32: Map<Int, Int> by __mapSfixed32Sfixed32Delegate
+    internal val __mapSfixed64Sfixed64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed64Sfixed64: Map<Long, Long> by __mapSfixed64Sfixed64Delegate
+    internal val __mapInt32BoolDelegate: MsgFieldDelegate<Map<Int, Boolean>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Bool: Map<Int, Boolean> by __mapInt32BoolDelegate
+    internal val __mapInt32FloatDelegate: MsgFieldDelegate<Map<Int, Float>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Float: Map<Int, Float> by __mapInt32FloatDelegate
+    internal val __mapInt32DoubleDelegate: MsgFieldDelegate<Map<Int, Double>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Double: Map<Int, Double> by __mapInt32DoubleDelegate
+    internal val __mapInt32NestedMessageDelegate: MsgFieldDelegate<Map<Int, TestAllTypesProto2.NestedMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32NestedMessage: Map<Int, TestAllTypesProto2.NestedMessage> by __mapInt32NestedMessageDelegate
+    internal val __mapBoolBoolDelegate: MsgFieldDelegate<Map<Boolean, Boolean>> = MsgFieldDelegate { emptyMap() }
+    override var mapBoolBool: Map<Boolean, Boolean> by __mapBoolBoolDelegate
+    internal val __mapStringStringDelegate: MsgFieldDelegate<Map<String, String>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringString: Map<String, String> by __mapStringStringDelegate
+    internal val __mapStringBytesDelegate: MsgFieldDelegate<Map<String, ByteString>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringBytes: Map<String, ByteString> by __mapStringBytesDelegate
+    internal val __mapStringNestedMessageDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto2.NestedMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedMessage: Map<String, TestAllTypesProto2.NestedMessage> by __mapStringNestedMessageDelegate
+    internal val __mapStringForeignMessageDelegate: MsgFieldDelegate<Map<String, ForeignMessageProto2>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignMessage: Map<String, ForeignMessageProto2> by __mapStringForeignMessageDelegate
+    internal val __mapStringNestedEnumDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto2.NestedEnum>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedEnum: Map<String, TestAllTypesProto2.NestedEnum> by __mapStringNestedEnumDelegate
+    internal val __mapStringForeignEnumDelegate: MsgFieldDelegate<Map<String, ForeignEnumProto2>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignEnum: Map<String, ForeignEnumProto2> by __mapStringForeignEnumDelegate
+    internal val __dataDelegate: MsgFieldDelegate<TestAllTypesProto2.Data> = MsgFieldDelegate(PresenceIndices.data) { DataInternal.DEFAULT }
+    override var data: TestAllTypesProto2.Data by __dataDelegate
+    internal val __multiwordgroupfieldDelegate: MsgFieldDelegate<TestAllTypesProto2.MultiWordGroupField> = MsgFieldDelegate(PresenceIndices.multiwordgroupfield) { MultiWordGroupFieldInternal.DEFAULT }
+    override var multiwordgroupfield: TestAllTypesProto2.MultiWordGroupField by __multiwordgroupfieldDelegate
+    internal val __defaultInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
+    override var defaultInt32: Int by __defaultInt32Delegate
+    internal val __defaultInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
+    override var defaultInt64: Long by __defaultInt64Delegate
+    internal val __defaultUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
+    override var defaultUint32: UInt by __defaultUint32Delegate
+    internal val __defaultUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
+    override var defaultUint64: ULong by __defaultUint64Delegate
+    internal val __defaultSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
+    override var defaultSint32: Int by __defaultSint32Delegate
+    internal val __defaultSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
+    override var defaultSint64: Long by __defaultSint64Delegate
+    internal val __defaultFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
+    override var defaultFixed32: UInt by __defaultFixed32Delegate
+    internal val __defaultFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
+    override var defaultFixed64: ULong by __defaultFixed64Delegate
+    internal val __defaultSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
+    override var defaultSfixed32: Int by __defaultSfixed32Delegate
+    internal val __defaultSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
+    override var defaultSfixed64: Long by __defaultSfixed64Delegate
+    internal val __defaultFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
+    override var defaultFloat: Float by __defaultFloatDelegate
+    internal val __defaultDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
+    override var defaultDouble: Double by __defaultDoubleDelegate
+    internal val __defaultBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.defaultBool) { true }
+    override var defaultBool: Boolean by __defaultBoolDelegate
+    internal val __defaultStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
+    override var defaultString: String by __defaultStringDelegate
+    internal val __defaultBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
+    override var defaultBytes: ByteString by __defaultBytesDelegate
+    internal val __fieldname1Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldname1) { null }
+    override var fieldname1: Int? by __fieldname1Delegate
+    internal val __fieldName2Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldName2) { null }
+    override var fieldName2: Int? by __fieldName2Delegate
+    internal val __FieldName3Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FieldName3) { null }
+    override var FieldName3: Int? by __FieldName3Delegate
+    internal val __field_Name4_Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_Name4_) { null }
+    override var field_Name4_: Int? by __field_Name4_Delegate
+    internal val __field0name5Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field0name5) { null }
+    override var field0name5: Int? by __field0name5Delegate
+    internal val __field_0Name6Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_0Name6) { null }
+    override var field_0Name6: Int? by __field_0Name6Delegate
+    internal val __fieldName7Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldName7) { null }
+    override var fieldName7: Int? by __fieldName7Delegate
+    internal val __FieldName8Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FieldName8) { null }
+    override var FieldName8: Int? by __FieldName8Delegate
+    internal val __field_Name9Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_Name9) { null }
+    override var field_Name9: Int? by __field_Name9Delegate
+    internal val __Field_Name10Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.Field_Name10) { null }
+    override var Field_Name10: Int? by __Field_Name10Delegate
+    internal val __FIELD_NAME11Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FIELD_NAME11) { null }
+    override var FIELD_NAME11: Int? by __FIELD_NAME11Delegate
+    internal val __FIELDName12Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FIELDName12) { null }
+    override var FIELDName12: Int? by __FIELDName12Delegate
+    internal val ___FieldName13Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices._FieldName13) { null }
+    override var _FieldName13: Int? by ___FieldName13Delegate
+    internal val ____FieldName14Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.__FieldName14) { null }
+    override var __FieldName14: Int? by ____FieldName14Delegate
+    internal val __field_Name15Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field_Name15) { null }
+    override var field_Name15: Int? by __field_Name15Delegate
+    internal val __field__Name16Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.field__Name16) { null }
+    override var field__Name16: Int? by __field__Name16Delegate
+    internal val __fieldName17__Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.fieldName17__) { null }
+    override var fieldName17__: Int? by __fieldName17__Delegate
+    internal val __FieldName18__Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.FieldName18__) { null }
+    override var FieldName18__: Int? by __FieldName18__Delegate
+    internal val __messageSetCorrectDelegate: MsgFieldDelegate<TestAllTypesProto2.MessageSetCorrect> = MsgFieldDelegate(PresenceIndices.messageSetCorrect) { MessageSetCorrectInternal.DEFAULT }
+    override var messageSetCorrect: TestAllTypesProto2.MessageSetCorrect by __messageSetCorrectDelegate
     override var oneofField: TestAllTypesProto2.OneofField? = null
 
     private val _owner: TestAllTypesProto2Internal = this
@@ -1490,8 +1618,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int? by MsgFieldDelegate(PresenceIndices.a) { null }
-        override var corecursive: TestAllTypesProto2 by MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto2Internal() }
+        internal val __aDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.a) { null }
+        override var a: Int? by __aDelegate
+        internal val __corecursiveDelegate: MsgFieldDelegate<TestAllTypesProto2> = MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto2Internal.DEFAULT }
+        override var corecursive: TestAllTypesProto2 by __corecursiveDelegate
 
         private val _owner: NestedMessageInternal = this
 
@@ -1601,7 +1731,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.NestedMessage by lazy { NestedMessageInternal() }
+        }
     }
 
     class MapInt32Int32EntryInternal: InternalMessage(fieldsWithPresence = 2) {
@@ -1619,8 +1751,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1690,8 +1824,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1761,8 +1897,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate(PresenceIndices.key) { 0u }
-        var value: UInt by MsgFieldDelegate(PresenceIndices.value) { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.key) { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.value) { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1832,8 +1970,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate(PresenceIndices.key) { 0uL }
-        var value: ULong by MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.key) { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1903,8 +2043,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1974,8 +2116,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2045,8 +2189,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate(PresenceIndices.key) { 0u }
-        var value: UInt by MsgFieldDelegate(PresenceIndices.value) { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.key) { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.value) { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2116,8 +2262,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate(PresenceIndices.key) { 0uL }
-        var value: ULong by MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.key) { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.value) { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2187,8 +2335,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Int by MsgFieldDelegate(PresenceIndices.value) { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.value) { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2258,8 +2408,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate(PresenceIndices.key) { 0L }
-        var value: Long by MsgFieldDelegate(PresenceIndices.value) { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.key) { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.value) { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2329,8 +2481,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Boolean by MsgFieldDelegate(PresenceIndices.value) { false }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.value) { false }
+        var value: Boolean by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2400,8 +2554,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Float by MsgFieldDelegate(PresenceIndices.value) { 0.0f }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.value) { 0.0f }
+        var value: Float by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2471,8 +2627,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: Double by MsgFieldDelegate(PresenceIndices.value) { 0.0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.value) { 0.0 }
+        var value: Double by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2542,8 +2700,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate(PresenceIndices.key) { 0 }
-        var value: TestAllTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.key) { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal.DEFAULT }
+        var value: TestAllTypesProto2.NestedMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2613,8 +2773,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Boolean by MsgFieldDelegate(PresenceIndices.key) { false }
-        var value: Boolean by MsgFieldDelegate(PresenceIndices.value) { false }
+        internal val __keyDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.key) { false }
+        var key: Boolean by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.value) { false }
+        var value: Boolean by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2684,8 +2846,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: String by MsgFieldDelegate(PresenceIndices.value) { "" }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.value) { "" }
+        var value: String by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2755,8 +2919,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ByteString by MsgFieldDelegate(PresenceIndices.value) { ByteString() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.value) { ByteString() }
+        var value: ByteString by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2826,8 +2992,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: TestAllTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal.DEFAULT }
+        var value: TestAllTypesProto2.NestedMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2897,8 +3065,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.value) { ForeignMessageProto2Internal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.value) { ForeignMessageProto2Internal.DEFAULT }
+        var value: ForeignMessageProto2 by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2968,8 +3138,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: TestAllTypesProto2.NestedEnum by MsgFieldDelegate(PresenceIndices.value) { TestAllTypesProto2.NestedEnum.FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto2.NestedEnum> = MsgFieldDelegate(PresenceIndices.value) { TestAllTypesProto2.NestedEnum.FOO }
+        var value: TestAllTypesProto2.NestedEnum by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -3039,8 +3211,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate(PresenceIndices.key) { "" }
-        var value: ForeignEnumProto2 by MsgFieldDelegate(PresenceIndices.value) { ForeignEnumProto2.FOREIGN_FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.key) { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignEnumProto2> = MsgFieldDelegate(PresenceIndices.value) { ForeignEnumProto2.FOREIGN_FOO }
+        var value: ForeignEnumProto2 by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -3110,8 +3284,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var groupInt32: Int? by MsgFieldDelegate(PresenceIndices.groupInt32) { null }
-        override var groupUint32: UInt? by MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        internal val __groupInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.groupInt32) { null }
+        override var groupInt32: Int? by __groupInt32Delegate
+        internal val __groupUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        override var groupUint32: UInt? by __groupUint32Delegate
 
         private val _owner: DataInternal = this
 
@@ -3221,7 +3397,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.Data by lazy { DataInternal() }
+        }
     }
 
     class MultiWordGroupFieldInternal: TestAllTypesProto2.MultiWordGroupField.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -3239,8 +3417,10 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var groupInt32: Int? by MsgFieldDelegate(PresenceIndices.groupInt32) { null }
-        override var groupUint32: UInt? by MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        internal val __groupInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.groupInt32) { null }
+        override var groupInt32: Int? by __groupInt32Delegate
+        internal val __groupUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+        override var groupUint32: UInt? by __groupUint32Delegate
 
         private val _owner: MultiWordGroupFieldInternal = this
 
@@ -3350,7 +3530,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MultiWordGroupField by lazy { MultiWordGroupFieldInternal() }
+        }
     }
 
     class MessageSetCorrectInternal: TestAllTypesProto2.MessageSetCorrect.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -3447,7 +3629,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MessageSetCorrect by lazy { MessageSetCorrectInternal() }
+        }
     }
 
     class MessageSetCorrectExtension1Internal: TestAllTypesProto2.MessageSetCorrectExtension1.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -3464,7 +3648,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var str: String? by MsgFieldDelegate(PresenceIndices.str) { null }
+        internal val __strDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.str) { null }
+        override var str: String? by __strDelegate
 
         private val _owner: MessageSetCorrectExtension1Internal = this
 
@@ -3560,7 +3745,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MessageSetCorrectExtension1 by lazy { MessageSetCorrectExtension1Internal() }
+        }
     }
 
     class MessageSetCorrectExtension2Internal: TestAllTypesProto2.MessageSetCorrectExtension2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -3577,7 +3764,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var i: Int? by MsgFieldDelegate(PresenceIndices.i) { null }
+        internal val __iDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.i) { null }
+        override var i: Int? by __iDelegate
 
         private val _owner: MessageSetCorrectExtension2Internal = this
 
@@ -3673,7 +3861,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.MessageSetCorrectExtension2 by lazy { MessageSetCorrectExtension2Internal() }
+        }
     }
 
     class ExtensionWithOneofInternal: TestAllTypesProto2.ExtensionWithOneof.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -3778,7 +3968,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto2.ExtensionWithOneof by lazy { ExtensionWithOneofInternal() }
+        }
     }
 
     @InternalRpcApi
@@ -3813,7 +4005,9 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestAllTypesProto2 by lazy { TestAllTypesProto2Internal() }
+    }
 }
 
 class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -3830,7 +4024,8 @@ class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessag
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var c: Int? by MsgFieldDelegate(PresenceIndices.c) { null }
+    internal val __cDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.c) { null }
+    override var c: Int? by __cDelegate
 
     private val _owner: ForeignMessageProto2Internal = this
 
@@ -3926,7 +4121,9 @@ class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessag
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ForeignMessageProto2 by lazy { ForeignMessageProto2Internal() }
+    }
 }
 
 class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -3944,8 +4141,10 @@ class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var groupInt32: Int? by MsgFieldDelegate(PresenceIndices.groupInt32) { null }
-    override var groupUint32: UInt? by MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+    internal val __groupInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.groupInt32) { null }
+    override var groupInt32: Int? by __groupInt32Delegate
+    internal val __groupUint32Delegate: MsgFieldDelegate<UInt?> = MsgFieldDelegate(PresenceIndices.groupUint32) { null }
+    override var groupUint32: UInt? by __groupUint32Delegate
 
     private val _owner: GroupFieldInternal = this
 
@@ -4055,7 +4254,9 @@ class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: GroupField by lazy { GroupFieldInternal() }
+    }
 }
 
 class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMessage(fieldsWithPresence = 5) {
@@ -4076,12 +4277,18 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var optionalInt32: Int? by MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
-    override var optionalString: String? by MsgFieldDelegate(PresenceIndices.optionalString) { null }
-    override var nestedMessage: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.nestedMessage) { ForeignMessageProto2Internal() }
-    override var optionalgroup: UnknownToTestAllTypes.OptionalGroup by MsgFieldDelegate(PresenceIndices.optionalgroup) { OptionalGroupInternal() }
-    override var optionalBool: Boolean? by MsgFieldDelegate(PresenceIndices.optionalBool) { null }
-    override var repeatedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
+    internal val __optionalInt32Delegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.optionalInt32) { null }
+    override var optionalInt32: Int? by __optionalInt32Delegate
+    internal val __optionalStringDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.optionalString) { null }
+    override var optionalString: String? by __optionalStringDelegate
+    internal val __nestedMessageDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.nestedMessage) { ForeignMessageProto2Internal.DEFAULT }
+    override var nestedMessage: ForeignMessageProto2 by __nestedMessageDelegate
+    internal val __optionalgroupDelegate: MsgFieldDelegate<UnknownToTestAllTypes.OptionalGroup> = MsgFieldDelegate(PresenceIndices.optionalgroup) { OptionalGroupInternal.DEFAULT }
+    override var optionalgroup: UnknownToTestAllTypes.OptionalGroup by __optionalgroupDelegate
+    internal val __optionalBoolDelegate: MsgFieldDelegate<Boolean?> = MsgFieldDelegate(PresenceIndices.optionalBool) { null }
+    override var optionalBool: Boolean? by __optionalBoolDelegate
+    internal val __repeatedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32: List<Int> by __repeatedInt32Delegate
 
     private val _owner: UnknownToTestAllTypesInternal = this
 
@@ -4219,7 +4426,8 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int? by MsgFieldDelegate(PresenceIndices.a) { null }
+        internal val __aDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.a) { null }
+        override var a: Int? by __aDelegate
 
         private val _owner: OptionalGroupInternal = this
 
@@ -4315,7 +4523,9 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: UnknownToTestAllTypes.OptionalGroup by lazy { OptionalGroupInternal() }
+        }
     }
 
     @InternalRpcApi
@@ -4350,7 +4560,9 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: UnknownToTestAllTypes by lazy { UnknownToTestAllTypesInternal() }
+    }
 }
 
 class NullHypothesisProto2Internal: NullHypothesisProto2.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -4436,7 +4648,9 @@ class NullHypothesisProto2Internal: NullHypothesisProto2.Builder, InternalMessag
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: NullHypothesisProto2 by lazy { NullHypothesisProto2Internal() }
+    }
 }
 
 class EnumOnlyProto2Internal: EnumOnlyProto2.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -4522,7 +4736,9 @@ class EnumOnlyProto2Internal: EnumOnlyProto2.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: EnumOnlyProto2 by lazy { EnumOnlyProto2Internal() }
+    }
 }
 
 class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -4539,7 +4755,8 @@ class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var data: String? by MsgFieldDelegate(PresenceIndices.data) { null }
+    internal val __dataDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.data) { null }
+    override var data: String? by __dataDelegate
 
     private val _owner: OneStringProto2Internal = this
 
@@ -4635,7 +4852,9 @@ class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: OneStringProto2 by lazy { OneStringProto2Internal() }
+    }
 }
 
 class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -4653,9 +4872,12 @@ class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fiel
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var inline: Int? by MsgFieldDelegate(PresenceIndices.inline) { null }
-    override var concept: String? by MsgFieldDelegate(PresenceIndices.concept) { null }
-    override var requires: List<String> by MsgFieldDelegate { mutableListOf() }
+    internal val __inlineDelegate: MsgFieldDelegate<Int?> = MsgFieldDelegate(PresenceIndices.inline) { null }
+    override var inline: Int? by __inlineDelegate
+    internal val __conceptDelegate: MsgFieldDelegate<String?> = MsgFieldDelegate(PresenceIndices.concept) { null }
+    override var concept: String? by __conceptDelegate
+    internal val __requiresDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var requires: List<String> by __requiresDelegate
 
     private val _owner: ProtoWithKeywordsInternal = this
 
@@ -4769,7 +4991,9 @@ class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fiel
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ProtoWithKeywords by lazy { ProtoWithKeywordsInternal() }
+    }
 }
 
 class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, InternalMessage(fieldsWithPresence = 39) {
@@ -4828,45 +5052,84 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var requiredInt32: Int by MsgFieldDelegate(PresenceIndices.requiredInt32) { 0 }
-    override var requiredInt64: Long by MsgFieldDelegate(PresenceIndices.requiredInt64) { 0L }
-    override var requiredUint32: UInt by MsgFieldDelegate(PresenceIndices.requiredUint32) { 0u }
-    override var requiredUint64: ULong by MsgFieldDelegate(PresenceIndices.requiredUint64) { 0uL }
-    override var requiredSint32: Int by MsgFieldDelegate(PresenceIndices.requiredSint32) { 0 }
-    override var requiredSint64: Long by MsgFieldDelegate(PresenceIndices.requiredSint64) { 0L }
-    override var requiredFixed32: UInt by MsgFieldDelegate(PresenceIndices.requiredFixed32) { 0u }
-    override var requiredFixed64: ULong by MsgFieldDelegate(PresenceIndices.requiredFixed64) { 0uL }
-    override var requiredSfixed32: Int by MsgFieldDelegate(PresenceIndices.requiredSfixed32) { 0 }
-    override var requiredSfixed64: Long by MsgFieldDelegate(PresenceIndices.requiredSfixed64) { 0L }
-    override var requiredFloat: Float by MsgFieldDelegate(PresenceIndices.requiredFloat) { 0.0f }
-    override var requiredDouble: Double by MsgFieldDelegate(PresenceIndices.requiredDouble) { 0.0 }
-    override var requiredBool: Boolean by MsgFieldDelegate(PresenceIndices.requiredBool) { false }
-    override var requiredString: String by MsgFieldDelegate(PresenceIndices.requiredString) { "" }
-    override var requiredBytes: ByteString by MsgFieldDelegate(PresenceIndices.requiredBytes) { ByteString() }
-    override var requiredNestedMessage: TestAllRequiredTypesProto2.NestedMessage by MsgFieldDelegate(PresenceIndices.requiredNestedMessage) { NestedMessageInternal() }
-    override var requiredForeignMessage: ForeignMessageProto2 by MsgFieldDelegate(PresenceIndices.requiredForeignMessage) { ForeignMessageProto2Internal() }
-    override var requiredNestedEnum: TestAllRequiredTypesProto2.NestedEnum by MsgFieldDelegate(PresenceIndices.requiredNestedEnum) { TestAllRequiredTypesProto2.NestedEnum.FOO }
-    override var requiredForeignEnum: ForeignEnumProto2 by MsgFieldDelegate(PresenceIndices.requiredForeignEnum) { ForeignEnumProto2.FOREIGN_FOO }
-    override var requiredStringPiece: String by MsgFieldDelegate(PresenceIndices.requiredStringPiece) { "" }
-    override var requiredCord: String by MsgFieldDelegate(PresenceIndices.requiredCord) { "" }
-    override var recursiveMessage: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllRequiredTypesProto2Internal() }
-    override var optionalRecursiveMessage: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.optionalRecursiveMessage) { TestAllRequiredTypesProto2Internal() }
-    override var data: TestAllRequiredTypesProto2.Data by MsgFieldDelegate(PresenceIndices.data) { DataInternal() }
-    override var defaultInt32: Int by MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
-    override var defaultInt64: Long by MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
-    override var defaultUint32: UInt by MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
-    override var defaultUint64: ULong by MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
-    override var defaultSint32: Int by MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
-    override var defaultSint64: Long by MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
-    override var defaultFixed32: UInt by MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
-    override var defaultFixed64: ULong by MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
-    override var defaultSfixed32: Int by MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
-    override var defaultSfixed64: Long by MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
-    override var defaultFloat: Float by MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
-    override var defaultDouble: Double by MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
-    override var defaultBool: Boolean by MsgFieldDelegate(PresenceIndices.defaultBool) { true }
-    override var defaultString: String by MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
-    override var defaultBytes: ByteString by MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
+    internal val __requiredInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.requiredInt32) { 0 }
+    override var requiredInt32: Int by __requiredInt32Delegate
+    internal val __requiredInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.requiredInt64) { 0L }
+    override var requiredInt64: Long by __requiredInt64Delegate
+    internal val __requiredUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.requiredUint32) { 0u }
+    override var requiredUint32: UInt by __requiredUint32Delegate
+    internal val __requiredUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.requiredUint64) { 0uL }
+    override var requiredUint64: ULong by __requiredUint64Delegate
+    internal val __requiredSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.requiredSint32) { 0 }
+    override var requiredSint32: Int by __requiredSint32Delegate
+    internal val __requiredSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.requiredSint64) { 0L }
+    override var requiredSint64: Long by __requiredSint64Delegate
+    internal val __requiredFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.requiredFixed32) { 0u }
+    override var requiredFixed32: UInt by __requiredFixed32Delegate
+    internal val __requiredFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.requiredFixed64) { 0uL }
+    override var requiredFixed64: ULong by __requiredFixed64Delegate
+    internal val __requiredSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.requiredSfixed32) { 0 }
+    override var requiredSfixed32: Int by __requiredSfixed32Delegate
+    internal val __requiredSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.requiredSfixed64) { 0L }
+    override var requiredSfixed64: Long by __requiredSfixed64Delegate
+    internal val __requiredFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.requiredFloat) { 0.0f }
+    override var requiredFloat: Float by __requiredFloatDelegate
+    internal val __requiredDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.requiredDouble) { 0.0 }
+    override var requiredDouble: Double by __requiredDoubleDelegate
+    internal val __requiredBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.requiredBool) { false }
+    override var requiredBool: Boolean by __requiredBoolDelegate
+    internal val __requiredStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.requiredString) { "" }
+    override var requiredString: String by __requiredStringDelegate
+    internal val __requiredBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.requiredBytes) { ByteString() }
+    override var requiredBytes: ByteString by __requiredBytesDelegate
+    internal val __requiredNestedMessageDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2.NestedMessage> = MsgFieldDelegate(PresenceIndices.requiredNestedMessage) { NestedMessageInternal.DEFAULT }
+    override var requiredNestedMessage: TestAllRequiredTypesProto2.NestedMessage by __requiredNestedMessageDelegate
+    internal val __requiredForeignMessageDelegate: MsgFieldDelegate<ForeignMessageProto2> = MsgFieldDelegate(PresenceIndices.requiredForeignMessage) { ForeignMessageProto2Internal.DEFAULT }
+    override var requiredForeignMessage: ForeignMessageProto2 by __requiredForeignMessageDelegate
+    internal val __requiredNestedEnumDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2.NestedEnum> = MsgFieldDelegate(PresenceIndices.requiredNestedEnum) { TestAllRequiredTypesProto2.NestedEnum.FOO }
+    override var requiredNestedEnum: TestAllRequiredTypesProto2.NestedEnum by __requiredNestedEnumDelegate
+    internal val __requiredForeignEnumDelegate: MsgFieldDelegate<ForeignEnumProto2> = MsgFieldDelegate(PresenceIndices.requiredForeignEnum) { ForeignEnumProto2.FOREIGN_FOO }
+    override var requiredForeignEnum: ForeignEnumProto2 by __requiredForeignEnumDelegate
+    internal val __requiredStringPieceDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.requiredStringPiece) { "" }
+    override var requiredStringPiece: String by __requiredStringPieceDelegate
+    internal val __requiredCordDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.requiredCord) { "" }
+    override var requiredCord: String by __requiredCordDelegate
+    internal val __recursiveMessageDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllRequiredTypesProto2Internal.DEFAULT }
+    override var recursiveMessage: TestAllRequiredTypesProto2 by __recursiveMessageDelegate
+    internal val __optionalRecursiveMessageDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.optionalRecursiveMessage) { TestAllRequiredTypesProto2Internal.DEFAULT }
+    override var optionalRecursiveMessage: TestAllRequiredTypesProto2 by __optionalRecursiveMessageDelegate
+    internal val __dataDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2.Data> = MsgFieldDelegate(PresenceIndices.data) { DataInternal.DEFAULT }
+    override var data: TestAllRequiredTypesProto2.Data by __dataDelegate
+    internal val __defaultInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultInt32) { -123456789 }
+    override var defaultInt32: Int by __defaultInt32Delegate
+    internal val __defaultInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultInt64) { -9123456789123456789L }
+    override var defaultInt64: Long by __defaultInt64Delegate
+    internal val __defaultUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultUint32) { 2123456789u }
+    override var defaultUint32: UInt by __defaultUint32Delegate
+    internal val __defaultUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultUint64) { 10123456789123456789uL }
+    override var defaultUint64: ULong by __defaultUint64Delegate
+    internal val __defaultSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSint32) { -123456789 }
+    override var defaultSint32: Int by __defaultSint32Delegate
+    internal val __defaultSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSint64) { -9123456789123456789L }
+    override var defaultSint64: Long by __defaultSint64Delegate
+    internal val __defaultFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.defaultFixed32) { 2123456789u }
+    override var defaultFixed32: UInt by __defaultFixed32Delegate
+    internal val __defaultFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate(PresenceIndices.defaultFixed64) { 10123456789123456789uL }
+    override var defaultFixed64: ULong by __defaultFixed64Delegate
+    internal val __defaultSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.defaultSfixed32) { -123456789 }
+    override var defaultSfixed32: Int by __defaultSfixed32Delegate
+    internal val __defaultSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate(PresenceIndices.defaultSfixed64) { -9123456789123456789L }
+    override var defaultSfixed64: Long by __defaultSfixed64Delegate
+    internal val __defaultFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate(PresenceIndices.defaultFloat) { Float.fromBits(0x50061C46.toInt()) }
+    override var defaultFloat: Float by __defaultFloatDelegate
+    internal val __defaultDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate(PresenceIndices.defaultDouble) { Double.fromBits(0x44ADA56A4B0835C0L) }
+    override var defaultDouble: Double by __defaultDoubleDelegate
+    internal val __defaultBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate(PresenceIndices.defaultBool) { true }
+    override var defaultBool: Boolean by __defaultBoolDelegate
+    internal val __defaultStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.defaultString) { "Rosebud" }
+    override var defaultString: String by __defaultStringDelegate
+    internal val __defaultBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate(PresenceIndices.defaultBytes) { BytesDefaults.defaultBytes }
+    override var defaultBytes: ByteString by __defaultBytesDelegate
 
     private val _owner: TestAllRequiredTypesProto2Internal = this
 
@@ -5482,9 +5745,12 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int by MsgFieldDelegate(PresenceIndices.a) { 0 }
-        override var corecursive: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.corecursive) { TestAllRequiredTypesProto2Internal() }
-        override var optionalCorecursive: TestAllRequiredTypesProto2 by MsgFieldDelegate(PresenceIndices.optionalCorecursive) { TestAllRequiredTypesProto2Internal() }
+        internal val __aDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.a) { 0 }
+        override var a: Int by __aDelegate
+        internal val __corecursiveDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.corecursive) { TestAllRequiredTypesProto2Internal.DEFAULT }
+        override var corecursive: TestAllRequiredTypesProto2 by __corecursiveDelegate
+        internal val __optionalCorecursiveDelegate: MsgFieldDelegate<TestAllRequiredTypesProto2> = MsgFieldDelegate(PresenceIndices.optionalCorecursive) { TestAllRequiredTypesProto2Internal.DEFAULT }
+        override var optionalCorecursive: TestAllRequiredTypesProto2 by __optionalCorecursiveDelegate
 
         private val _owner: NestedMessageInternal = this
 
@@ -5608,7 +5874,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.NestedMessage by lazy { NestedMessageInternal() }
+        }
     }
 
     class DataInternal: TestAllRequiredTypesProto2.Data.Builder, InternalMessage(fieldsWithPresence = 2) {
@@ -5626,8 +5894,10 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var groupInt32: Int by MsgFieldDelegate(PresenceIndices.groupInt32) { 0 }
-        override var groupUint32: UInt by MsgFieldDelegate(PresenceIndices.groupUint32) { 0u }
+        internal val __groupInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.groupInt32) { 0 }
+        override var groupInt32: Int by __groupInt32Delegate
+        internal val __groupUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate(PresenceIndices.groupUint32) { 0u }
+        override var groupUint32: UInt by __groupUint32Delegate
 
         private val _owner: DataInternal = this
 
@@ -5737,7 +6007,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.Data by lazy { DataInternal() }
+        }
     }
 
     class MessageSetCorrectInternal: TestAllRequiredTypesProto2.MessageSetCorrect.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -5834,7 +6106,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.MessageSetCorrect by lazy { MessageSetCorrectInternal() }
+        }
     }
 
     class MessageSetCorrectExtension1Internal: TestAllRequiredTypesProto2.MessageSetCorrectExtension1.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -5851,7 +6125,8 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var str: String by MsgFieldDelegate(PresenceIndices.str) { "" }
+        internal val __strDelegate: MsgFieldDelegate<String> = MsgFieldDelegate(PresenceIndices.str) { "" }
+        override var str: String by __strDelegate
 
         private val _owner: MessageSetCorrectExtension1Internal = this
 
@@ -5947,7 +6222,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.MessageSetCorrectExtension1 by lazy { MessageSetCorrectExtension1Internal() }
+        }
     }
 
     class MessageSetCorrectExtension2Internal: TestAllRequiredTypesProto2.MessageSetCorrectExtension2.Builder, InternalMessage(fieldsWithPresence = 1) {
@@ -5964,7 +6241,8 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var i: Int by MsgFieldDelegate(PresenceIndices.i) { 0 }
+        internal val __iDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate(PresenceIndices.i) { 0 }
+        override var i: Int by __iDelegate
 
         private val _owner: MessageSetCorrectExtension2Internal = this
 
@@ -6060,7 +6338,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllRequiredTypesProto2.MessageSetCorrectExtension2 by lazy { MessageSetCorrectExtension2Internal() }
+        }
     }
 
     @InternalRpcApi
@@ -6095,7 +6375,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestAllRequiredTypesProto2 by lazy { TestAllRequiredTypesProto2Internal() }
+    }
 }
 
 class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6270,7 +6552,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A1 by lazy { A1Internal() }
+        }
     }
 
     class A2Internal: TestLargeOneof.A2.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6356,7 +6640,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A2 by lazy { A2Internal() }
+        }
     }
 
     class A3Internal: TestLargeOneof.A3.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6442,7 +6728,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A3 by lazy { A3Internal() }
+        }
     }
 
     class A4Internal: TestLargeOneof.A4.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6528,7 +6816,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A4 by lazy { A4Internal() }
+        }
     }
 
     class A5Internal: TestLargeOneof.A5.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -6614,7 +6904,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestLargeOneof.A5 by lazy { A5Internal() }
+        }
     }
 
     @InternalRpcApi
@@ -6649,7 +6941,9 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestLargeOneof by lazy { TestLargeOneofInternal() }
+    }
 }
 
 @InternalRpcApi
@@ -7553,18 +7847,12 @@ fun TestAllTypesProto2Internal.Companion.decodeWith(msg: TestAllTypesProto2Inter
                 msg.optionalBytes = decoder.readBytes()
             }
             tag.fieldNr == 18 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[15]) {
-                    msg.optionalNestedMessage = TestAllTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.optionalNestedMessage.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalNestedMessageDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 19 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[16]) {
-                    msg.optionalForeignMessage = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.optionalForeignMessage.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalForeignMessageDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 21 && tag.wireType == WireType.VARINT -> {
                 msg.optionalNestedEnum = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
@@ -7579,478 +7867,582 @@ fun TestAllTypesProto2Internal.Companion.decodeWith(msg: TestAllTypesProto2Inter
                 msg.optionalCord = decoder.readString()
             }
             tag.fieldNr == 27 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[21]) {
-                    msg.recursiveMessage = TestAllTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.recursiveMessage.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__recursiveMessageDelegate.getOrCreate(msg) { TestAllTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 31 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt32 += decoder.readPackedInt32()
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 31 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.repeatedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 32 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt64 += decoder.readPackedInt64()
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 32 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.repeatedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 33 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint32 += decoder.readPackedUInt32()
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 33 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.repeatedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 34 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint64 += decoder.readPackedUInt64()
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 34 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.repeatedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 35 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint32 += decoder.readPackedSInt32()
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 35 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.repeatedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 36 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint64 += decoder.readPackedSInt64()
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 36 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.repeatedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 37 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 37 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.repeatedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 38 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 38 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.repeatedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 39 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 39 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.repeatedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 40 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 40 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.repeatedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 41 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFloat += decoder.readPackedFloat()
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 41 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.repeatedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 42 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedDouble += decoder.readPackedDouble()
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 42 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.repeatedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 43 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedBool += decoder.readPackedBool()
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 43 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.repeatedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 44 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedString as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 45 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBytesDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBytes()
-                (msg.repeatedBytes as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 48 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedNestedMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2Internal.NestedMessageInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedNestedMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 49 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedForeignMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignMessageProto2Internal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
-                (msg.repeatedForeignMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 51 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) }
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 51 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.repeatedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 52 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedForeignEnum += decoder.readPackedEnum().map { ForeignEnumProto2.fromNumber(it) }
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { ForeignEnumProto2.fromNumber(it) })
             }
             tag.fieldNr == 52 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignEnumProto2.fromNumber(decoder.readEnum())
-                (msg.repeatedForeignEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 54 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringPieceDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedStringPiece as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 55 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedCordDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedCord as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 75 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt32 += decoder.readPackedInt32()
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 75 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.packedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 76 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt64 += decoder.readPackedInt64()
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 76 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.packedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 77 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint32 += decoder.readPackedUInt32()
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 77 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.packedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 78 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint64 += decoder.readPackedUInt64()
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 78 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.packedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 79 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint32 += decoder.readPackedSInt32()
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 79 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.packedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 80 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint64 += decoder.readPackedSInt64()
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 80 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.packedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 81 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 81 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.packedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 82 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 82 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.packedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 83 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 83 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.packedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 84 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 84 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.packedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 85 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFloat += decoder.readPackedFloat()
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 85 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.packedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 86 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedDouble += decoder.readPackedDouble()
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 86 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.packedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 87 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedBool += decoder.readPackedBool()
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 87 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.packedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 88 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) }
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 88 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.packedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 89 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt32 += decoder.readPackedInt32()
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 89 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.unpackedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 90 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt64 += decoder.readPackedInt64()
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 90 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.unpackedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 91 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint32 += decoder.readPackedUInt32()
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 91 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.unpackedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 92 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint64 += decoder.readPackedUInt64()
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 92 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.unpackedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 93 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint32 += decoder.readPackedSInt32()
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 93 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.unpackedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 94 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint64 += decoder.readPackedSInt64()
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 94 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.unpackedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 95 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 95 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.unpackedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 96 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 96 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.unpackedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 97 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 97 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.unpackedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 98 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 98 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.unpackedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 99 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFloat += decoder.readPackedFloat()
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 99 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.unpackedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 100 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedDouble += decoder.readPackedDouble()
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 100 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.unpackedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 101 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedBool += decoder.readPackedBool()
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 101 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.unpackedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 102 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) }
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto2.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 102 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.unpackedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 56 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32Int32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32Int32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32Int32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Int32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 57 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt64Int64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt64Int64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt64Int64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt64Int64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 58 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint32Uint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapUint32Uint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapUint32Uint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint32Uint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 59 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint64Uint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapUint64Uint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapUint64Uint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint64Uint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 60 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint32Sint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSint32Sint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSint32Sint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint32Sint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 61 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint64Sint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSint64Sint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSint64Sint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint64Sint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 62 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed32Fixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapFixed32Fixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapFixed32Fixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed32Fixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 63 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed64Fixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapFixed64Fixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapFixed64Fixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed64Fixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 64 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed32Sfixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSfixed32Sfixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSfixed32Sfixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed32Sfixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 65 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed64Sfixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapSfixed64Sfixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapSfixed64Sfixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed64Sfixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 104 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32BoolDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32BoolEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32BoolEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Bool as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 66 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32FloatDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32FloatEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32FloatEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Float as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 67 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32DoubleDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32DoubleEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32DoubleEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Double as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 103 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32NestedMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32NestedMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 68 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapBoolBoolDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapBoolBoolEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapBoolBoolEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapBoolBool as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 69 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringStringDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringStringEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringStringEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringString as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 70 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringBytesDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringBytesEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringBytesEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringBytes as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 71 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 72 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 73 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringNestedEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringNestedEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 74 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto2Internal.MapStringForeignEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MapStringForeignEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 201 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[22]) {
-                    msg.data = TestAllTypesProto2Internal.DataInternal()
-                }
-
-                decoder.readGroup(msg.data.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__dataDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.DataInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 204 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[23]) {
-                    msg.multiwordgroupfield = TestAllTypesProto2Internal.MultiWordGroupFieldInternal()
-                }
-
-                decoder.readGroup(msg.multiwordgroupfield.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.MultiWordGroupFieldInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__multiwordgroupfieldDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.MultiWordGroupFieldInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllTypesProto2Internal.MultiWordGroupFieldInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 241 && tag.wireType == WireType.VARINT -> {
                 msg.defaultInt32 = decoder.readInt32()
@@ -8152,11 +8544,8 @@ fun TestAllTypesProto2Internal.Companion.decodeWith(msg: TestAllTypesProto2Inter
                 msg.FieldName18__ = decoder.readInt32()
             }
             tag.fieldNr == 500 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[57]) {
-                    msg.messageSetCorrect = TestAllTypesProto2Internal.MessageSetCorrectInternal()
-                }
-
-                decoder.readMessage(msg.messageSetCorrect.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MessageSetCorrectInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__messageSetCorrectDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.MessageSetCorrectInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.MessageSetCorrectInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 111 && tag.wireType == WireType.VARINT -> {
                 msg.oneofField = TestAllTypesProto2.OneofField.OneofUint32(decoder.readUInt32())
@@ -9103,28 +9492,24 @@ fun UnknownToTestAllTypesInternal.Companion.decodeWith(msg: UnknownToTestAllType
                 msg.optionalString = decoder.readString()
             }
             tag.fieldNr == 1003 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[2]) {
-                    msg.nestedMessage = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.nestedMessage.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__nestedMessageDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 1004 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[3]) {
-                    msg.optionalgroup = UnknownToTestAllTypesInternal.OptionalGroupInternal()
-                }
-
-                decoder.readGroup(msg.optionalgroup.asInternal()) { msg, decoder -> UnknownToTestAllTypesInternal.OptionalGroupInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__optionalgroupDelegate.getOrCreate(msg) { UnknownToTestAllTypesInternal.OptionalGroupInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> UnknownToTestAllTypesInternal.OptionalGroupInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 1006 && tag.wireType == WireType.VARINT -> {
                 msg.optionalBool = decoder.readBool()
             }
             tag.fieldNr == 1011 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt32 += decoder.readPackedInt32()
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 1011 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.repeatedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -9400,8 +9785,9 @@ fun ProtoWithKeywordsInternal.Companion.decodeWith(msg: ProtoWithKeywordsInterna
                 msg.concept = decoder.readString()
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__requiresDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.requires as MutableList).add(elem)
+                target.add(elem)
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -9842,18 +10228,12 @@ fun TestAllRequiredTypesProto2Internal.Companion.decodeWith(msg: TestAllRequired
                 msg.requiredBytes = decoder.readBytes()
             }
             tag.fieldNr == 18 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[15]) {
-                    msg.requiredNestedMessage = TestAllRequiredTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.requiredNestedMessage.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__requiredNestedMessageDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 19 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[16]) {
-                    msg.requiredForeignMessage = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.requiredForeignMessage.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__requiredForeignMessageDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 21 && tag.wireType == WireType.VARINT -> {
                 msg.requiredNestedEnum = TestAllRequiredTypesProto2.NestedEnum.fromNumber(decoder.readEnum())
@@ -9868,25 +10248,16 @@ fun TestAllRequiredTypesProto2Internal.Companion.decodeWith(msg: TestAllRequired
                 msg.requiredCord = decoder.readString()
             }
             tag.fieldNr == 27 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[21]) {
-                    msg.recursiveMessage = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.recursiveMessage.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__recursiveMessageDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 28 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[22]) {
-                    msg.optionalRecursiveMessage = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.optionalRecursiveMessage.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalRecursiveMessageDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 201 && tag.wireType == WireType.START_GROUP -> {
-                if (!msg.presenceMask[23]) {
-                    msg.data = TestAllRequiredTypesProto2Internal.DataInternal()
-                }
-
-                decoder.readGroup(msg.data.asInternal()) { msg, decoder -> TestAllRequiredTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
+                val target = msg.__dataDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal.DataInternal() }
+                decoder.readGroup(target.asInternal()) { msg, decoder -> TestAllRequiredTypesProto2Internal.DataInternal.decodeWith(msg, decoder, config, tag) }
             }
             tag.fieldNr == 241 && tag.wireType == WireType.VARINT -> {
                 msg.defaultInt32 = decoder.readInt32()
@@ -10315,11 +10686,8 @@ fun TestAllTypesProto2Internal.NestedMessageInternal.Companion.decodeWith(msg: T
                 msg.a = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.corecursive = TestAllTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.corecursive.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__corecursiveDelegate.getOrCreate(msg) { TestAllTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -11386,11 +11754,8 @@ fun TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal.Companion.deco
                 msg.key = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = TestAllTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -11697,11 +12062,8 @@ fun TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal.Companion.dec
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = TestAllTypesProto2Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { TestAllTypesProto2Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto2Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -11780,11 +12142,8 @@ fun TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal.Companion.de
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.value = ForeignMessageProto2Internal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { ForeignMessageProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageProto2Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -12557,18 +12916,12 @@ fun TestAllRequiredTypesProto2Internal.NestedMessageInternal.Companion.decodeWit
                 msg.a = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.corecursive = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.corecursive.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__corecursiveDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 3 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[2]) {
-                    msg.optionalCorecursive = TestAllRequiredTypesProto2Internal()
-                }
-
-                decoder.readMessage(msg.optionalCorecursive.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalCorecursiveDelegate.getOrCreate(msg) { TestAllRequiredTypesProto2Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllRequiredTypesProto2Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -13286,7 +13639,7 @@ object TestMessagesProto2KtExtensions {
             name = "groupfield",
             extendee = com.google.protobuf_test_messages.proto2.TestAllTypesProto2::class,
             valueType = GroupField::class,
-            default = { GroupFieldInternal() },
+            default = { GroupFieldInternal.DEFAULT },
             asInternal = { it.asInternal() },
             encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
             decodeWith = { value, decoder, config -> GroupFieldInternal.decodeWith(value.asInternal(), decoder, config) },
@@ -13300,7 +13653,7 @@ object TestMessagesProto2KtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension1::class,
-                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension1Internal() },
+                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension1Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllTypesProto2Internal.MessageSetCorrectExtension1Internal.decodeWith(value.asInternal(), decoder, config) },
@@ -13314,7 +13667,7 @@ object TestMessagesProto2KtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension2::class,
-                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension2Internal() },
+                    default = { TestAllTypesProto2Internal.MessageSetCorrectExtension2Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllTypesProto2Internal.MessageSetCorrectExtension2Internal.decodeWith(value.asInternal(), decoder, config) },
@@ -13328,7 +13681,7 @@ object TestMessagesProto2KtExtensions {
                     name = "extensionWithOneof",
                     extendee = com.google.protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.proto2.TestAllTypesProto2.ExtensionWithOneof::class,
-                    default = { TestAllTypesProto2Internal.ExtensionWithOneofInternal() },
+                    default = { TestAllTypesProto2Internal.ExtensionWithOneofInternal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllTypesProto2Internal.ExtensionWithOneofInternal.decodeWith(value.asInternal(), decoder, config) },
@@ -13344,7 +13697,7 @@ object TestMessagesProto2KtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.proto2.TestAllRequiredTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.proto2.TestAllRequiredTypesProto2.MessageSetCorrectExtension1::class,
-                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension1Internal() },
+                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension1Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension1Internal.decodeWith(value.asInternal(), decoder, config) },
@@ -13358,7 +13711,7 @@ object TestMessagesProto2KtExtensions {
                     name = "messageSetExtension",
                     extendee = com.google.protobuf_test_messages.proto2.TestAllRequiredTypesProto2.MessageSetCorrect::class,
                     valueType = com.google.protobuf_test_messages.proto2.TestAllRequiredTypesProto2.MessageSetCorrectExtension2::class,
-                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension2Internal() },
+                    default = { TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension2Internal.DEFAULT },
                     asInternal = { it.asInternal() },
                     encodeWith = { value, encoder, config -> value.asInternal().encodeWith(encoder, config) },
                     decodeWith = { value, decoder, config -> TestAllRequiredTypesProto2Internal.MessageSetCorrectExtension2Internal.decodeWith(value.asInternal(), decoder, config) },

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto3/_rpc_internal/TestMessagesProto3.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto3/_rpc_internal/TestMessagesProto3.kt
@@ -127,149 +127,292 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var optionalInt32: Int by MsgFieldDelegate { 0 }
-    override var optionalInt64: Long by MsgFieldDelegate { 0L }
-    override var optionalUint32: UInt by MsgFieldDelegate { 0u }
-    override var optionalUint64: ULong by MsgFieldDelegate { 0uL }
-    override var optionalSint32: Int by MsgFieldDelegate { 0 }
-    override var optionalSint64: Long by MsgFieldDelegate { 0L }
-    override var optionalFixed32: UInt by MsgFieldDelegate { 0u }
-    override var optionalFixed64: ULong by MsgFieldDelegate { 0uL }
-    override var optionalSfixed32: Int by MsgFieldDelegate { 0 }
-    override var optionalSfixed64: Long by MsgFieldDelegate { 0L }
-    override var optionalFloat: Float by MsgFieldDelegate { 0.0f }
-    override var optionalDouble: Double by MsgFieldDelegate { 0.0 }
-    override var optionalBool: Boolean by MsgFieldDelegate { false }
-    override var optionalString: String by MsgFieldDelegate { "" }
-    override var optionalBytes: ByteString by MsgFieldDelegate { ByteString() }
-    override var optionalNestedMessage: TestAllTypesProto3.NestedMessage by MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal() }
-    override var optionalForeignMessage: ForeignMessage by MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageInternal() }
-    override var optionalNestedEnum: TestAllTypesProto3.NestedEnum by MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
-    override var optionalForeignEnum: ForeignEnum by MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
-    override var optionalAliasedEnum: TestAllTypesProto3.AliasedEnum by MsgFieldDelegate { TestAllTypesProto3.AliasedEnum.ALIAS_FOO }
-    override var optionalStringPiece: String by MsgFieldDelegate { "" }
-    override var optionalCord: String by MsgFieldDelegate { "" }
-    override var recursiveMessage: TestAllTypesProto3 by MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto3Internal() }
-    override var repeatedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedString: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBytes: List<ByteString> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedMessage: List<TestAllTypesProto3.NestedMessage> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignMessage: List<ForeignMessage> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedNestedEnum: List<TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedForeignEnum: List<ForeignEnum> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStringPiece: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedCord: List<String> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var packedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var packedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var packedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var packedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var packedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var packedNestedEnum: List<TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedInt64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedUint64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSint64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed32: List<UInt> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFixed64: List<ULong> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed32: List<Int> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedSfixed64: List<Long> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedFloat: List<Float> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedDouble: List<Double> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedBool: List<Boolean> by MsgFieldDelegate { mutableListOf() }
-    override var unpackedNestedEnum: List<TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableListOf() }
-    override var mapInt32Int32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt64Int64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint32Uint32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapUint64Uint64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint32Sint32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSint64Sint64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed32Fixed32: Map<UInt, UInt> by MsgFieldDelegate { mutableMapOf() }
-    override var mapFixed64Fixed64: Map<ULong, ULong> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed32Sfixed32: Map<Int, Int> by MsgFieldDelegate { mutableMapOf() }
-    override var mapSfixed64Sfixed64: Map<Long, Long> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Float: Map<Int, Float> by MsgFieldDelegate { mutableMapOf() }
-    override var mapInt32Double: Map<Int, Double> by MsgFieldDelegate { mutableMapOf() }
-    override var mapBoolBool: Map<Boolean, Boolean> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringString: Map<String, String> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringBytes: Map<String, ByteString> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedMessage: Map<String, TestAllTypesProto3.NestedMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignMessage: Map<String, ForeignMessage> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringNestedEnum: Map<String, TestAllTypesProto3.NestedEnum> by MsgFieldDelegate { mutableMapOf() }
-    override var mapStringForeignEnum: Map<String, ForeignEnum> by MsgFieldDelegate { mutableMapOf() }
-    override var optionalBoolWrapper: BoolValue by MsgFieldDelegate(PresenceIndices.optionalBoolWrapper) { BoolValueInternal() }
-    override var optionalInt32Wrapper: Int32Value by MsgFieldDelegate(PresenceIndices.optionalInt32Wrapper) { Int32ValueInternal() }
-    override var optionalInt64Wrapper: Int64Value by MsgFieldDelegate(PresenceIndices.optionalInt64Wrapper) { Int64ValueInternal() }
-    override var optionalUint32Wrapper: UInt32Value by MsgFieldDelegate(PresenceIndices.optionalUint32Wrapper) { UInt32ValueInternal() }
-    override var optionalUint64Wrapper: UInt64Value by MsgFieldDelegate(PresenceIndices.optionalUint64Wrapper) { UInt64ValueInternal() }
-    override var optionalFloatWrapper: FloatValue by MsgFieldDelegate(PresenceIndices.optionalFloatWrapper) { FloatValueInternal() }
-    override var optionalDoubleWrapper: DoubleValue by MsgFieldDelegate(PresenceIndices.optionalDoubleWrapper) { DoubleValueInternal() }
-    override var optionalStringWrapper: StringValue by MsgFieldDelegate(PresenceIndices.optionalStringWrapper) { StringValueInternal() }
-    override var optionalBytesWrapper: BytesValue by MsgFieldDelegate(PresenceIndices.optionalBytesWrapper) { BytesValueInternal() }
-    override var repeatedBoolWrapper: List<BoolValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt32Wrapper: List<Int32Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedInt64Wrapper: List<Int64Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint32Wrapper: List<UInt32Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedUint64Wrapper: List<UInt64Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFloatWrapper: List<FloatValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedDoubleWrapper: List<DoubleValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStringWrapper: List<StringValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedBytesWrapper: List<BytesValue> by MsgFieldDelegate { mutableListOf() }
-    override var optionalDuration: Duration by MsgFieldDelegate(PresenceIndices.optionalDuration) { DurationInternal() }
-    override var optionalTimestamp: Timestamp by MsgFieldDelegate(PresenceIndices.optionalTimestamp) { TimestampInternal() }
-    override var optionalFieldMask: FieldMask by MsgFieldDelegate(PresenceIndices.optionalFieldMask) { FieldMaskInternal() }
-    override var optionalStruct: Struct by MsgFieldDelegate(PresenceIndices.optionalStruct) { StructInternal() }
-    override var optionalAny: com.google.protobuf.kotlin.Any by MsgFieldDelegate(PresenceIndices.optionalAny) { AnyInternal() }
-    override var optionalValue: Value by MsgFieldDelegate(PresenceIndices.optionalValue) { ValueInternal() }
-    override var optionalNullValue: NullValue by MsgFieldDelegate { NullValue.NULL_VALUE }
-    override var optionalEmpty: Empty by MsgFieldDelegate(PresenceIndices.optionalEmpty) { EmptyInternal() }
-    override var repeatedDuration: List<Duration> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedTimestamp: List<Timestamp> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedFieldmask: List<FieldMask> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedStruct: List<Struct> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedAny: List<com.google.protobuf.kotlin.Any> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedValue: List<Value> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedListValue: List<ListValue> by MsgFieldDelegate { mutableListOf() }
-    override var repeatedEmpty: List<Empty> by MsgFieldDelegate { mutableListOf() }
-    override var fieldname1: Int by MsgFieldDelegate { 0 }
-    override var fieldName2: Int by MsgFieldDelegate { 0 }
-    override var FieldName3: Int by MsgFieldDelegate { 0 }
-    override var field_Name4_: Int by MsgFieldDelegate { 0 }
-    override var field0name5: Int by MsgFieldDelegate { 0 }
-    override var field_0Name6: Int by MsgFieldDelegate { 0 }
-    override var fieldName7: Int by MsgFieldDelegate { 0 }
-    override var FieldName8: Int by MsgFieldDelegate { 0 }
-    override var field_Name9: Int by MsgFieldDelegate { 0 }
-    override var Field_Name10: Int by MsgFieldDelegate { 0 }
-    override var FIELD_NAME11: Int by MsgFieldDelegate { 0 }
-    override var FIELDName12: Int by MsgFieldDelegate { 0 }
-    override var _FieldName13: Int by MsgFieldDelegate { 0 }
-    override var __FieldName14: Int by MsgFieldDelegate { 0 }
-    override var field_Name15: Int by MsgFieldDelegate { 0 }
-    override var field__Name16: Int by MsgFieldDelegate { 0 }
-    override var fieldName17__: Int by MsgFieldDelegate { 0 }
-    override var FieldName18__: Int by MsgFieldDelegate { 0 }
+    internal val __optionalInt32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var optionalInt32: Int by __optionalInt32Delegate
+    internal val __optionalInt64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    override var optionalInt64: Long by __optionalInt64Delegate
+    internal val __optionalUint32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+    override var optionalUint32: UInt by __optionalUint32Delegate
+    internal val __optionalUint64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+    override var optionalUint64: ULong by __optionalUint64Delegate
+    internal val __optionalSint32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var optionalSint32: Int by __optionalSint32Delegate
+    internal val __optionalSint64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    override var optionalSint64: Long by __optionalSint64Delegate
+    internal val __optionalFixed32Delegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+    override var optionalFixed32: UInt by __optionalFixed32Delegate
+    internal val __optionalFixed64Delegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+    override var optionalFixed64: ULong by __optionalFixed64Delegate
+    internal val __optionalSfixed32Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var optionalSfixed32: Int by __optionalSfixed32Delegate
+    internal val __optionalSfixed64Delegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+    override var optionalSfixed64: Long by __optionalSfixed64Delegate
+    internal val __optionalFloatDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate { 0.0f }
+    override var optionalFloat: Float by __optionalFloatDelegate
+    internal val __optionalDoubleDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate { 0.0 }
+    override var optionalDouble: Double by __optionalDoubleDelegate
+    internal val __optionalBoolDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+    override var optionalBool: Boolean by __optionalBoolDelegate
+    internal val __optionalStringDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var optionalString: String by __optionalStringDelegate
+    internal val __optionalBytesDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate { ByteString() }
+    override var optionalBytes: ByteString by __optionalBytesDelegate
+    internal val __optionalNestedMessageDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedMessage> = MsgFieldDelegate(PresenceIndices.optionalNestedMessage) { NestedMessageInternal.DEFAULT }
+    override var optionalNestedMessage: TestAllTypesProto3.NestedMessage by __optionalNestedMessageDelegate
+    internal val __optionalForeignMessageDelegate: MsgFieldDelegate<ForeignMessage> = MsgFieldDelegate(PresenceIndices.optionalForeignMessage) { ForeignMessageInternal.DEFAULT }
+    override var optionalForeignMessage: ForeignMessage by __optionalForeignMessageDelegate
+    internal val __optionalNestedEnumDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedEnum> = MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
+    override var optionalNestedEnum: TestAllTypesProto3.NestedEnum by __optionalNestedEnumDelegate
+    internal val __optionalForeignEnumDelegate: MsgFieldDelegate<ForeignEnum> = MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
+    override var optionalForeignEnum: ForeignEnum by __optionalForeignEnumDelegate
+    internal val __optionalAliasedEnumDelegate: MsgFieldDelegate<TestAllTypesProto3.AliasedEnum> = MsgFieldDelegate { TestAllTypesProto3.AliasedEnum.ALIAS_FOO }
+    override var optionalAliasedEnum: TestAllTypesProto3.AliasedEnum by __optionalAliasedEnumDelegate
+    internal val __optionalStringPieceDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var optionalStringPiece: String by __optionalStringPieceDelegate
+    internal val __optionalCordDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+    override var optionalCord: String by __optionalCordDelegate
+    internal val __recursiveMessageDelegate: MsgFieldDelegate<TestAllTypesProto3> = MsgFieldDelegate(PresenceIndices.recursiveMessage) { TestAllTypesProto3Internal.DEFAULT }
+    override var recursiveMessage: TestAllTypesProto3 by __recursiveMessageDelegate
+    internal val __repeatedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32: List<Int> by __repeatedInt32Delegate
+    internal val __repeatedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt64: List<Long> by __repeatedInt64Delegate
+    internal val __repeatedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint32: List<UInt> by __repeatedUint32Delegate
+    internal val __repeatedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint64: List<ULong> by __repeatedUint64Delegate
+    internal val __repeatedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint32: List<Int> by __repeatedSint32Delegate
+    internal val __repeatedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSint64: List<Long> by __repeatedSint64Delegate
+    internal val __repeatedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed32: List<UInt> by __repeatedFixed32Delegate
+    internal val __repeatedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFixed64: List<ULong> by __repeatedFixed64Delegate
+    internal val __repeatedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed32: List<Int> by __repeatedSfixed32Delegate
+    internal val __repeatedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var repeatedSfixed64: List<Long> by __repeatedSfixed64Delegate
+    internal val __repeatedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFloat: List<Float> by __repeatedFloatDelegate
+    internal val __repeatedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDouble: List<Double> by __repeatedDoubleDelegate
+    internal val __repeatedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBool: List<Boolean> by __repeatedBoolDelegate
+    internal val __repeatedStringDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedString: List<String> by __repeatedStringDelegate
+    internal val __repeatedBytesDelegate: MsgFieldDelegate<List<ByteString>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBytes: List<ByteString> by __repeatedBytesDelegate
+    internal val __repeatedNestedMessageDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedMessage>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedMessage: List<TestAllTypesProto3.NestedMessage> by __repeatedNestedMessageDelegate
+    internal val __repeatedForeignMessageDelegate: MsgFieldDelegate<List<ForeignMessage>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignMessage: List<ForeignMessage> by __repeatedForeignMessageDelegate
+    internal val __repeatedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var repeatedNestedEnum: List<TestAllTypesProto3.NestedEnum> by __repeatedNestedEnumDelegate
+    internal val __repeatedForeignEnumDelegate: MsgFieldDelegate<List<ForeignEnum>> = MsgFieldDelegate { emptyList() }
+    override var repeatedForeignEnum: List<ForeignEnum> by __repeatedForeignEnumDelegate
+    internal val __repeatedStringPieceDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStringPiece: List<String> by __repeatedStringPieceDelegate
+    internal val __repeatedCordDelegate: MsgFieldDelegate<List<String>> = MsgFieldDelegate { emptyList() }
+    override var repeatedCord: List<String> by __repeatedCordDelegate
+    internal val __packedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedInt32: List<Int> by __packedInt32Delegate
+    internal val __packedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedInt64: List<Long> by __packedInt64Delegate
+    internal val __packedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedUint32: List<UInt> by __packedUint32Delegate
+    internal val __packedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedUint64: List<ULong> by __packedUint64Delegate
+    internal val __packedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSint32: List<Int> by __packedSint32Delegate
+    internal val __packedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSint64: List<Long> by __packedSint64Delegate
+    internal val __packedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed32: List<UInt> by __packedFixed32Delegate
+    internal val __packedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var packedFixed64: List<ULong> by __packedFixed64Delegate
+    internal val __packedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed32: List<Int> by __packedSfixed32Delegate
+    internal val __packedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var packedSfixed64: List<Long> by __packedSfixed64Delegate
+    internal val __packedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var packedFloat: List<Float> by __packedFloatDelegate
+    internal val __packedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var packedDouble: List<Double> by __packedDoubleDelegate
+    internal val __packedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var packedBool: List<Boolean> by __packedBoolDelegate
+    internal val __packedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var packedNestedEnum: List<TestAllTypesProto3.NestedEnum> by __packedNestedEnumDelegate
+    internal val __unpackedInt32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt32: List<Int> by __unpackedInt32Delegate
+    internal val __unpackedInt64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedInt64: List<Long> by __unpackedInt64Delegate
+    internal val __unpackedUint32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint32: List<UInt> by __unpackedUint32Delegate
+    internal val __unpackedUint64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedUint64: List<ULong> by __unpackedUint64Delegate
+    internal val __unpackedSint32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint32: List<Int> by __unpackedSint32Delegate
+    internal val __unpackedSint64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSint64: List<Long> by __unpackedSint64Delegate
+    internal val __unpackedFixed32Delegate: MsgFieldDelegate<List<UInt>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed32: List<UInt> by __unpackedFixed32Delegate
+    internal val __unpackedFixed64Delegate: MsgFieldDelegate<List<ULong>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFixed64: List<ULong> by __unpackedFixed64Delegate
+    internal val __unpackedSfixed32Delegate: MsgFieldDelegate<List<Int>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed32: List<Int> by __unpackedSfixed32Delegate
+    internal val __unpackedSfixed64Delegate: MsgFieldDelegate<List<Long>> = MsgFieldDelegate { emptyList() }
+    override var unpackedSfixed64: List<Long> by __unpackedSfixed64Delegate
+    internal val __unpackedFloatDelegate: MsgFieldDelegate<List<Float>> = MsgFieldDelegate { emptyList() }
+    override var unpackedFloat: List<Float> by __unpackedFloatDelegate
+    internal val __unpackedDoubleDelegate: MsgFieldDelegate<List<Double>> = MsgFieldDelegate { emptyList() }
+    override var unpackedDouble: List<Double> by __unpackedDoubleDelegate
+    internal val __unpackedBoolDelegate: MsgFieldDelegate<List<Boolean>> = MsgFieldDelegate { emptyList() }
+    override var unpackedBool: List<Boolean> by __unpackedBoolDelegate
+    internal val __unpackedNestedEnumDelegate: MsgFieldDelegate<List<TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyList() }
+    override var unpackedNestedEnum: List<TestAllTypesProto3.NestedEnum> by __unpackedNestedEnumDelegate
+    internal val __mapInt32Int32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Int32: Map<Int, Int> by __mapInt32Int32Delegate
+    internal val __mapInt64Int64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt64Int64: Map<Long, Long> by __mapInt64Int64Delegate
+    internal val __mapUint32Uint32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint32Uint32: Map<UInt, UInt> by __mapUint32Uint32Delegate
+    internal val __mapUint64Uint64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapUint64Uint64: Map<ULong, ULong> by __mapUint64Uint64Delegate
+    internal val __mapSint32Sint32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint32Sint32: Map<Int, Int> by __mapSint32Sint32Delegate
+    internal val __mapSint64Sint64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSint64Sint64: Map<Long, Long> by __mapSint64Sint64Delegate
+    internal val __mapFixed32Fixed32Delegate: MsgFieldDelegate<Map<UInt, UInt>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed32Fixed32: Map<UInt, UInt> by __mapFixed32Fixed32Delegate
+    internal val __mapFixed64Fixed64Delegate: MsgFieldDelegate<Map<ULong, ULong>> = MsgFieldDelegate { emptyMap() }
+    override var mapFixed64Fixed64: Map<ULong, ULong> by __mapFixed64Fixed64Delegate
+    internal val __mapSfixed32Sfixed32Delegate: MsgFieldDelegate<Map<Int, Int>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed32Sfixed32: Map<Int, Int> by __mapSfixed32Sfixed32Delegate
+    internal val __mapSfixed64Sfixed64Delegate: MsgFieldDelegate<Map<Long, Long>> = MsgFieldDelegate { emptyMap() }
+    override var mapSfixed64Sfixed64: Map<Long, Long> by __mapSfixed64Sfixed64Delegate
+    internal val __mapInt32FloatDelegate: MsgFieldDelegate<Map<Int, Float>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Float: Map<Int, Float> by __mapInt32FloatDelegate
+    internal val __mapInt32DoubleDelegate: MsgFieldDelegate<Map<Int, Double>> = MsgFieldDelegate { emptyMap() }
+    override var mapInt32Double: Map<Int, Double> by __mapInt32DoubleDelegate
+    internal val __mapBoolBoolDelegate: MsgFieldDelegate<Map<Boolean, Boolean>> = MsgFieldDelegate { emptyMap() }
+    override var mapBoolBool: Map<Boolean, Boolean> by __mapBoolBoolDelegate
+    internal val __mapStringStringDelegate: MsgFieldDelegate<Map<String, String>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringString: Map<String, String> by __mapStringStringDelegate
+    internal val __mapStringBytesDelegate: MsgFieldDelegate<Map<String, ByteString>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringBytes: Map<String, ByteString> by __mapStringBytesDelegate
+    internal val __mapStringNestedMessageDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto3.NestedMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedMessage: Map<String, TestAllTypesProto3.NestedMessage> by __mapStringNestedMessageDelegate
+    internal val __mapStringForeignMessageDelegate: MsgFieldDelegate<Map<String, ForeignMessage>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignMessage: Map<String, ForeignMessage> by __mapStringForeignMessageDelegate
+    internal val __mapStringNestedEnumDelegate: MsgFieldDelegate<Map<String, TestAllTypesProto3.NestedEnum>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringNestedEnum: Map<String, TestAllTypesProto3.NestedEnum> by __mapStringNestedEnumDelegate
+    internal val __mapStringForeignEnumDelegate: MsgFieldDelegate<Map<String, ForeignEnum>> = MsgFieldDelegate { emptyMap() }
+    override var mapStringForeignEnum: Map<String, ForeignEnum> by __mapStringForeignEnumDelegate
+    internal val __optionalBoolWrapperDelegate: MsgFieldDelegate<BoolValue> = MsgFieldDelegate(PresenceIndices.optionalBoolWrapper) { BoolValueInternal.DEFAULT }
+    override var optionalBoolWrapper: BoolValue by __optionalBoolWrapperDelegate
+    internal val __optionalInt32WrapperDelegate: MsgFieldDelegate<Int32Value> = MsgFieldDelegate(PresenceIndices.optionalInt32Wrapper) { Int32ValueInternal.DEFAULT }
+    override var optionalInt32Wrapper: Int32Value by __optionalInt32WrapperDelegate
+    internal val __optionalInt64WrapperDelegate: MsgFieldDelegate<Int64Value> = MsgFieldDelegate(PresenceIndices.optionalInt64Wrapper) { Int64ValueInternal.DEFAULT }
+    override var optionalInt64Wrapper: Int64Value by __optionalInt64WrapperDelegate
+    internal val __optionalUint32WrapperDelegate: MsgFieldDelegate<UInt32Value> = MsgFieldDelegate(PresenceIndices.optionalUint32Wrapper) { UInt32ValueInternal.DEFAULT }
+    override var optionalUint32Wrapper: UInt32Value by __optionalUint32WrapperDelegate
+    internal val __optionalUint64WrapperDelegate: MsgFieldDelegate<UInt64Value> = MsgFieldDelegate(PresenceIndices.optionalUint64Wrapper) { UInt64ValueInternal.DEFAULT }
+    override var optionalUint64Wrapper: UInt64Value by __optionalUint64WrapperDelegate
+    internal val __optionalFloatWrapperDelegate: MsgFieldDelegate<FloatValue> = MsgFieldDelegate(PresenceIndices.optionalFloatWrapper) { FloatValueInternal.DEFAULT }
+    override var optionalFloatWrapper: FloatValue by __optionalFloatWrapperDelegate
+    internal val __optionalDoubleWrapperDelegate: MsgFieldDelegate<DoubleValue> = MsgFieldDelegate(PresenceIndices.optionalDoubleWrapper) { DoubleValueInternal.DEFAULT }
+    override var optionalDoubleWrapper: DoubleValue by __optionalDoubleWrapperDelegate
+    internal val __optionalStringWrapperDelegate: MsgFieldDelegate<StringValue> = MsgFieldDelegate(PresenceIndices.optionalStringWrapper) { StringValueInternal.DEFAULT }
+    override var optionalStringWrapper: StringValue by __optionalStringWrapperDelegate
+    internal val __optionalBytesWrapperDelegate: MsgFieldDelegate<BytesValue> = MsgFieldDelegate(PresenceIndices.optionalBytesWrapper) { BytesValueInternal.DEFAULT }
+    override var optionalBytesWrapper: BytesValue by __optionalBytesWrapperDelegate
+    internal val __repeatedBoolWrapperDelegate: MsgFieldDelegate<List<BoolValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBoolWrapper: List<BoolValue> by __repeatedBoolWrapperDelegate
+    internal val __repeatedInt32WrapperDelegate: MsgFieldDelegate<List<Int32Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt32Wrapper: List<Int32Value> by __repeatedInt32WrapperDelegate
+    internal val __repeatedInt64WrapperDelegate: MsgFieldDelegate<List<Int64Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedInt64Wrapper: List<Int64Value> by __repeatedInt64WrapperDelegate
+    internal val __repeatedUint32WrapperDelegate: MsgFieldDelegate<List<UInt32Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint32Wrapper: List<UInt32Value> by __repeatedUint32WrapperDelegate
+    internal val __repeatedUint64WrapperDelegate: MsgFieldDelegate<List<UInt64Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedUint64Wrapper: List<UInt64Value> by __repeatedUint64WrapperDelegate
+    internal val __repeatedFloatWrapperDelegate: MsgFieldDelegate<List<FloatValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFloatWrapper: List<FloatValue> by __repeatedFloatWrapperDelegate
+    internal val __repeatedDoubleWrapperDelegate: MsgFieldDelegate<List<DoubleValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDoubleWrapper: List<DoubleValue> by __repeatedDoubleWrapperDelegate
+    internal val __repeatedStringWrapperDelegate: MsgFieldDelegate<List<StringValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStringWrapper: List<StringValue> by __repeatedStringWrapperDelegate
+    internal val __repeatedBytesWrapperDelegate: MsgFieldDelegate<List<BytesValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedBytesWrapper: List<BytesValue> by __repeatedBytesWrapperDelegate
+    internal val __optionalDurationDelegate: MsgFieldDelegate<Duration> = MsgFieldDelegate(PresenceIndices.optionalDuration) { DurationInternal.DEFAULT }
+    override var optionalDuration: Duration by __optionalDurationDelegate
+    internal val __optionalTimestampDelegate: MsgFieldDelegate<Timestamp> = MsgFieldDelegate(PresenceIndices.optionalTimestamp) { TimestampInternal.DEFAULT }
+    override var optionalTimestamp: Timestamp by __optionalTimestampDelegate
+    internal val __optionalFieldMaskDelegate: MsgFieldDelegate<FieldMask> = MsgFieldDelegate(PresenceIndices.optionalFieldMask) { FieldMaskInternal.DEFAULT }
+    override var optionalFieldMask: FieldMask by __optionalFieldMaskDelegate
+    internal val __optionalStructDelegate: MsgFieldDelegate<Struct> = MsgFieldDelegate(PresenceIndices.optionalStruct) { StructInternal.DEFAULT }
+    override var optionalStruct: Struct by __optionalStructDelegate
+    internal val __optionalAnyDelegate: MsgFieldDelegate<com.google.protobuf.kotlin.Any> = MsgFieldDelegate(PresenceIndices.optionalAny) { AnyInternal.DEFAULT }
+    override var optionalAny: com.google.protobuf.kotlin.Any by __optionalAnyDelegate
+    internal val __optionalValueDelegate: MsgFieldDelegate<Value> = MsgFieldDelegate(PresenceIndices.optionalValue) { ValueInternal.DEFAULT }
+    override var optionalValue: Value by __optionalValueDelegate
+    internal val __optionalNullValueDelegate: MsgFieldDelegate<NullValue> = MsgFieldDelegate { NullValue.NULL_VALUE }
+    override var optionalNullValue: NullValue by __optionalNullValueDelegate
+    internal val __optionalEmptyDelegate: MsgFieldDelegate<Empty> = MsgFieldDelegate(PresenceIndices.optionalEmpty) { EmptyInternal.DEFAULT }
+    override var optionalEmpty: Empty by __optionalEmptyDelegate
+    internal val __repeatedDurationDelegate: MsgFieldDelegate<List<Duration>> = MsgFieldDelegate { emptyList() }
+    override var repeatedDuration: List<Duration> by __repeatedDurationDelegate
+    internal val __repeatedTimestampDelegate: MsgFieldDelegate<List<Timestamp>> = MsgFieldDelegate { emptyList() }
+    override var repeatedTimestamp: List<Timestamp> by __repeatedTimestampDelegate
+    internal val __repeatedFieldmaskDelegate: MsgFieldDelegate<List<FieldMask>> = MsgFieldDelegate { emptyList() }
+    override var repeatedFieldmask: List<FieldMask> by __repeatedFieldmaskDelegate
+    internal val __repeatedStructDelegate: MsgFieldDelegate<List<Struct>> = MsgFieldDelegate { emptyList() }
+    override var repeatedStruct: List<Struct> by __repeatedStructDelegate
+    internal val __repeatedAnyDelegate: MsgFieldDelegate<List<com.google.protobuf.kotlin.Any>> = MsgFieldDelegate { emptyList() }
+    override var repeatedAny: List<com.google.protobuf.kotlin.Any> by __repeatedAnyDelegate
+    internal val __repeatedValueDelegate: MsgFieldDelegate<List<Value>> = MsgFieldDelegate { emptyList() }
+    override var repeatedValue: List<Value> by __repeatedValueDelegate
+    internal val __repeatedListValueDelegate: MsgFieldDelegate<List<ListValue>> = MsgFieldDelegate { emptyList() }
+    override var repeatedListValue: List<ListValue> by __repeatedListValueDelegate
+    internal val __repeatedEmptyDelegate: MsgFieldDelegate<List<Empty>> = MsgFieldDelegate { emptyList() }
+    override var repeatedEmpty: List<Empty> by __repeatedEmptyDelegate
+    internal val __fieldname1Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldname1: Int by __fieldname1Delegate
+    internal val __fieldName2Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldName2: Int by __fieldName2Delegate
+    internal val __FieldName3Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FieldName3: Int by __FieldName3Delegate
+    internal val __field_Name4_Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_Name4_: Int by __field_Name4_Delegate
+    internal val __field0name5Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field0name5: Int by __field0name5Delegate
+    internal val __field_0Name6Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_0Name6: Int by __field_0Name6Delegate
+    internal val __fieldName7Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldName7: Int by __fieldName7Delegate
+    internal val __FieldName8Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FieldName8: Int by __FieldName8Delegate
+    internal val __field_Name9Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_Name9: Int by __field_Name9Delegate
+    internal val __Field_Name10Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var Field_Name10: Int by __Field_Name10Delegate
+    internal val __FIELD_NAME11Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FIELD_NAME11: Int by __FIELD_NAME11Delegate
+    internal val __FIELDName12Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FIELDName12: Int by __FIELDName12Delegate
+    internal val ___FieldName13Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var _FieldName13: Int by ___FieldName13Delegate
+    internal val ____FieldName14Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var __FieldName14: Int by ____FieldName14Delegate
+    internal val __field_Name15Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field_Name15: Int by __field_Name15Delegate
+    internal val __field__Name16Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var field__Name16: Int by __field__Name16Delegate
+    internal val __fieldName17__Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var fieldName17__: Int by __fieldName17__Delegate
+    internal val __FieldName18__Delegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var FieldName18__: Int by __FieldName18__Delegate
     override var oneofField: TestAllTypesProto3.OneofField? = null
 
     private val _owner: TestAllTypesProto3Internal = this
@@ -1169,8 +1312,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        override var a: Int by MsgFieldDelegate { 0 }
-        override var corecursive: TestAllTypesProto3 by MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto3Internal() }
+        internal val __aDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        override var a: Int by __aDelegate
+        internal val __corecursiveDelegate: MsgFieldDelegate<TestAllTypesProto3> = MsgFieldDelegate(PresenceIndices.corecursive) { TestAllTypesProto3Internal.DEFAULT }
+        override var corecursive: TestAllTypesProto3 by __corecursiveDelegate
 
         private val _owner: NestedMessageInternal = this
 
@@ -1270,7 +1415,9 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         }
 
         @InternalRpcApi
-        companion object
+        companion object {
+            val DEFAULT: TestAllTypesProto3.NestedMessage by lazy { NestedMessageInternal() }
+        }
     }
 
     class MapInt32Int32EntryInternal: InternalMessage(fieldsWithPresence = 0) {
@@ -1283,8 +1430,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Int by MsgFieldDelegate { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1338,8 +1487,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate { 0L }
-        var value: Long by MsgFieldDelegate { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1393,8 +1544,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate { 0u }
-        var value: UInt by MsgFieldDelegate { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1448,8 +1601,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate { 0uL }
-        var value: ULong by MsgFieldDelegate { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1503,8 +1658,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Int by MsgFieldDelegate { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1558,8 +1715,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate { 0L }
-        var value: Long by MsgFieldDelegate { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1613,8 +1772,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: UInt by MsgFieldDelegate { 0u }
-        var value: UInt by MsgFieldDelegate { 0u }
+        internal val __keyDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var key: UInt by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<UInt> = MsgFieldDelegate { 0u }
+        var value: UInt by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1668,8 +1829,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: ULong by MsgFieldDelegate { 0uL }
-        var value: ULong by MsgFieldDelegate { 0uL }
+        internal val __keyDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var key: ULong by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ULong> = MsgFieldDelegate { 0uL }
+        var value: ULong by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1723,8 +1886,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Int by MsgFieldDelegate { 0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var value: Int by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1778,8 +1943,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Long by MsgFieldDelegate { 0L }
-        var value: Long by MsgFieldDelegate { 0L }
+        internal val __keyDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var key: Long by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Long> = MsgFieldDelegate { 0L }
+        var value: Long by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1833,8 +2000,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Float by MsgFieldDelegate { 0.0f }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Float> = MsgFieldDelegate { 0.0f }
+        var value: Float by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1888,8 +2057,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Int by MsgFieldDelegate { 0 }
-        var value: Double by MsgFieldDelegate { 0.0 }
+        internal val __keyDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+        var key: Int by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Double> = MsgFieldDelegate { 0.0 }
+        var value: Double by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1943,8 +2114,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: Boolean by MsgFieldDelegate { false }
-        var value: Boolean by MsgFieldDelegate { false }
+        internal val __keyDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+        var key: Boolean by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<Boolean> = MsgFieldDelegate { false }
+        var value: Boolean by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -1998,8 +2171,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: String by MsgFieldDelegate { "" }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var value: String by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2053,8 +2228,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: ByteString by MsgFieldDelegate { ByteString() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ByteString> = MsgFieldDelegate { ByteString() }
+        var value: ByteString by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2112,8 +2289,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: TestAllTypesProto3.NestedMessage by MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedMessage> = MsgFieldDelegate(PresenceIndices.value) { NestedMessageInternal.DEFAULT }
+        var value: TestAllTypesProto3.NestedMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2177,8 +2356,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: ForeignMessage by MsgFieldDelegate(PresenceIndices.value) { ForeignMessageInternal() }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignMessage> = MsgFieldDelegate(PresenceIndices.value) { ForeignMessageInternal.DEFAULT }
+        var value: ForeignMessage by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2238,8 +2419,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: TestAllTypesProto3.NestedEnum by MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<TestAllTypesProto3.NestedEnum> = MsgFieldDelegate { TestAllTypesProto3.NestedEnum.FOO }
+        var value: TestAllTypesProto3.NestedEnum by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2293,8 +2476,10 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
         @InternalRpcApi
         internal var _unknownFieldsEncoder: WireEncoder? = null
 
-        var key: String by MsgFieldDelegate { "" }
-        var value: ForeignEnum by MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
+        internal val __keyDelegate: MsgFieldDelegate<String> = MsgFieldDelegate { "" }
+        var key: String by __keyDelegate
+        internal val __valueDelegate: MsgFieldDelegate<ForeignEnum> = MsgFieldDelegate { ForeignEnum.FOREIGN_FOO }
+        var value: ForeignEnum by __valueDelegate
 
         override fun hashCode(): Int {
             checkRequiredFields()
@@ -2370,7 +2555,9 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: TestAllTypesProto3 by lazy { TestAllTypesProto3Internal() }
+    }
 }
 
 class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -2383,7 +2570,8 @@ class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWith
     @InternalRpcApi
     internal var _unknownFieldsEncoder: WireEncoder? = null
 
-    override var c: Int by MsgFieldDelegate { 0 }
+    internal val __cDelegate: MsgFieldDelegate<Int> = MsgFieldDelegate { 0 }
+    override var c: Int by __cDelegate
 
     override fun hashCode(): Int {
         checkRequiredFields()
@@ -2461,7 +2649,9 @@ class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: ForeignMessage by lazy { ForeignMessageInternal() }
+    }
 }
 
 class NullHypothesisProto3Internal: NullHypothesisProto3.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -2547,7 +2737,9 @@ class NullHypothesisProto3Internal: NullHypothesisProto3.Builder, InternalMessag
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: NullHypothesisProto3 by lazy { NullHypothesisProto3Internal() }
+    }
 }
 
 class EnumOnlyProto3Internal: EnumOnlyProto3.Builder, InternalMessage(fieldsWithPresence = 0) {
@@ -2633,7 +2825,9 @@ class EnumOnlyProto3Internal: EnumOnlyProto3.Builder, InternalMessage(fieldsWith
     }
 
     @InternalRpcApi
-    companion object
+    companion object {
+        val DEFAULT: EnumOnlyProto3 by lazy { EnumOnlyProto3Internal() }
+    }
 }
 
 @InternalRpcApi
@@ -3703,18 +3897,12 @@ fun TestAllTypesProto3Internal.Companion.decodeWith(msg: TestAllTypesProto3Inter
                 msg.optionalBytes = decoder.readBytes()
             }
             tag.fieldNr == 18 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.optionalNestedMessage = TestAllTypesProto3Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.optionalNestedMessage.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalNestedMessageDelegate.getOrCreate(msg) { TestAllTypesProto3Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 19 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[1]) {
-                    msg.optionalForeignMessage = ForeignMessageInternal()
-                }
-
-                decoder.readMessage(msg.optionalForeignMessage.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalForeignMessageDelegate.getOrCreate(msg) { ForeignMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 21 && tag.wireType == WireType.VARINT -> {
                 msg.optionalNestedEnum = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
@@ -3732,652 +3920,729 @@ fun TestAllTypesProto3Internal.Companion.decodeWith(msg: TestAllTypesProto3Inter
                 msg.optionalCord = decoder.readString()
             }
             tag.fieldNr == 27 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[2]) {
-                    msg.recursiveMessage = TestAllTypesProto3Internal()
-                }
-
-                decoder.readMessage(msg.recursiveMessage.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__recursiveMessageDelegate.getOrCreate(msg) { TestAllTypesProto3Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 31 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt32 += decoder.readPackedInt32()
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 31 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.repeatedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 32 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedInt64 += decoder.readPackedInt64()
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 32 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.repeatedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 33 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint32 += decoder.readPackedUInt32()
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 33 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.repeatedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 34 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedUint64 += decoder.readPackedUInt64()
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 34 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.repeatedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 35 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint32 += decoder.readPackedSInt32()
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 35 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.repeatedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 36 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSint64 += decoder.readPackedSInt64()
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 36 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.repeatedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 37 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 37 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.repeatedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 38 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 38 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.repeatedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 39 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 39 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.repeatedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 40 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 40 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.repeatedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 41 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedFloat += decoder.readPackedFloat()
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 41 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__repeatedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.repeatedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 42 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedDouble += decoder.readPackedDouble()
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 42 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__repeatedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.repeatedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 43 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedBool += decoder.readPackedBool()
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 43 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.repeatedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 44 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedString as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 45 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBytesDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBytes()
-                (msg.repeatedBytes as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 48 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedNestedMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3Internal.NestedMessageInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedNestedMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 49 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedForeignMessageDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignMessageInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedForeignMessage as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 51 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) }
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 51 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.repeatedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 52 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.repeatedForeignEnum += decoder.readPackedEnum().map { ForeignEnum.fromNumber(it) }
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { ForeignEnum.fromNumber(it) })
             }
             tag.fieldNr == 52 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__repeatedForeignEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ForeignEnum.fromNumber(decoder.readEnum())
-                (msg.repeatedForeignEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 54 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringPieceDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedStringPiece as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 55 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedCordDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readString()
-                (msg.repeatedCord as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 75 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt32 += decoder.readPackedInt32()
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 75 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.packedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 76 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedInt64 += decoder.readPackedInt64()
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 76 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.packedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 77 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint32 += decoder.readPackedUInt32()
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 77 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.packedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 78 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedUint64 += decoder.readPackedUInt64()
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 78 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.packedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 79 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint32 += decoder.readPackedSInt32()
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 79 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.packedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 80 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSint64 += decoder.readPackedSInt64()
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 80 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.packedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 81 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 81 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.packedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 82 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 82 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.packedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 83 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 83 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.packedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 84 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 84 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.packedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 85 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedFloat += decoder.readPackedFloat()
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 85 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__packedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.packedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 86 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedDouble += decoder.readPackedDouble()
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 86 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__packedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.packedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 87 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedBool += decoder.readPackedBool()
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 87 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.packedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 88 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.packedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) }
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 88 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__packedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.packedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 89 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt32 += decoder.readPackedInt32()
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt32())
             }
             tag.fieldNr == 89 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt32()
-                (msg.unpackedInt32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 90 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedInt64 += decoder.readPackedInt64()
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedInt64())
             }
             tag.fieldNr == 90 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedInt64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readInt64()
-                (msg.unpackedInt64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 91 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint32 += decoder.readPackedUInt32()
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt32())
             }
             tag.fieldNr == 91 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt32()
-                (msg.unpackedUint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 92 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedUint64 += decoder.readPackedUInt64()
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedUInt64())
             }
             tag.fieldNr == 92 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedUint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readUInt64()
-                (msg.unpackedUint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 93 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint32 += decoder.readPackedSInt32()
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt32())
             }
             tag.fieldNr == 93 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt32()
-                (msg.unpackedSint32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 94 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSint64 += decoder.readPackedSInt64()
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSInt64())
             }
             tag.fieldNr == 94 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedSint64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSInt64()
-                (msg.unpackedSint64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 95 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed32 += decoder.readPackedFixed32()
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed32())
             }
             tag.fieldNr == 95 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed32()
-                (msg.unpackedFixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 96 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFixed64 += decoder.readPackedFixed64()
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFixed64())
             }
             tag.fieldNr == 96 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedFixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFixed64()
-                (msg.unpackedFixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 97 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed32 += decoder.readPackedSFixed32()
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed32())
             }
             tag.fieldNr == 97 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedSfixed32Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed32()
-                (msg.unpackedSfixed32 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 98 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedSfixed64 += decoder.readPackedSFixed64()
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedSFixed64())
             }
             tag.fieldNr == 98 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedSfixed64Delegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readSFixed64()
-                (msg.unpackedSfixed64 as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 99 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedFloat += decoder.readPackedFloat()
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedFloat())
             }
             tag.fieldNr == 99 && tag.wireType == WireType.FIXED32 -> {
+                val target = msg.__unpackedFloatDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readFloat()
-                (msg.unpackedFloat as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 100 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedDouble += decoder.readPackedDouble()
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedDouble())
             }
             tag.fieldNr == 100 && tag.wireType == WireType.FIXED64 -> {
+                val target = msg.__unpackedDoubleDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readDouble()
-                (msg.unpackedDouble as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 101 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedBool += decoder.readPackedBool()
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedBool())
             }
             tag.fieldNr == 101 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedBoolDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = decoder.readBool()
-                (msg.unpackedBool as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 102 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                msg.unpackedNestedEnum += decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) }
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
+                target.addAll(decoder.readPackedEnum().map { TestAllTypesProto3.NestedEnum.fromNumber(it) })
             }
             tag.fieldNr == 102 && tag.wireType == WireType.VARINT -> {
+                val target = msg.__unpackedNestedEnumDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TestAllTypesProto3.NestedEnum.fromNumber(decoder.readEnum())
-                (msg.unpackedNestedEnum as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 56 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32Int32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt32Int32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt32Int32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Int32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 57 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt64Int64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt64Int64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt64Int64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt64Int64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 58 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint32Uint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapUint32Uint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapUint32Uint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint32Uint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 59 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapUint64Uint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapUint64Uint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapUint64Uint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapUint64Uint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 60 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint32Sint32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSint32Sint32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSint32Sint32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint32Sint32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 61 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSint64Sint64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSint64Sint64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSint64Sint64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSint64Sint64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 62 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed32Fixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapFixed32Fixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapFixed32Fixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed32Fixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 63 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapFixed64Fixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapFixed64Fixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapFixed64Fixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapFixed64Fixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 64 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed32Sfixed32Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSfixed32Sfixed32EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSfixed32Sfixed32EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed32Sfixed32 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 65 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapSfixed64Sfixed64Delegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapSfixed64Sfixed64EntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapSfixed64Sfixed64EntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapSfixed64Sfixed64 as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 66 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32FloatDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt32FloatEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt32FloatEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Float as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 67 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapInt32DoubleDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapInt32DoubleEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapInt32DoubleEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapInt32Double as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 68 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapBoolBoolDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapBoolBoolEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapBoolBoolEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapBoolBool as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 69 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringStringDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringStringEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringStringEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringString as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 70 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringBytesDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringBytesEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringBytesEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringBytes as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 71 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 72 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignMessageDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignMessage as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 73 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringNestedEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringNestedEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringNestedEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringNestedEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 74 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__mapStringForeignEnumDelegate.getOrCreate(msg) { mutableMapOf() } as MutableMap
                 with(TestAllTypesProto3Internal.MapStringForeignEnumEntryInternal()) {
                     decoder.readMessage(this.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.MapStringForeignEnumEntryInternal.decodeWith(msg, decoder, config) })
-                    (msg.mapStringForeignEnum as MutableMap)[key] = value
+                    target[key] = value
                 }
             }
             tag.fieldNr == 201 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[3]) {
-                    msg.optionalBoolWrapper = BoolValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalBoolWrapper.asInternal(), { msg, decoder -> BoolValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalBoolWrapperDelegate.getOrCreate(msg) { BoolValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> BoolValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 202 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[4]) {
-                    msg.optionalInt32Wrapper = Int32ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalInt32Wrapper.asInternal(), { msg, decoder -> Int32ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalInt32WrapperDelegate.getOrCreate(msg) { Int32ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> Int32ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 203 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[5]) {
-                    msg.optionalInt64Wrapper = Int64ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalInt64Wrapper.asInternal(), { msg, decoder -> Int64ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalInt64WrapperDelegate.getOrCreate(msg) { Int64ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> Int64ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 204 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[6]) {
-                    msg.optionalUint32Wrapper = UInt32ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalUint32Wrapper.asInternal(), { msg, decoder -> UInt32ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalUint32WrapperDelegate.getOrCreate(msg) { UInt32ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> UInt32ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 205 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[7]) {
-                    msg.optionalUint64Wrapper = UInt64ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalUint64Wrapper.asInternal(), { msg, decoder -> UInt64ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalUint64WrapperDelegate.getOrCreate(msg) { UInt64ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> UInt64ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 206 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[8]) {
-                    msg.optionalFloatWrapper = FloatValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalFloatWrapper.asInternal(), { msg, decoder -> FloatValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalFloatWrapperDelegate.getOrCreate(msg) { FloatValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> FloatValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 207 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[9]) {
-                    msg.optionalDoubleWrapper = DoubleValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalDoubleWrapper.asInternal(), { msg, decoder -> DoubleValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalDoubleWrapperDelegate.getOrCreate(msg) { DoubleValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> DoubleValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 208 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[10]) {
-                    msg.optionalStringWrapper = StringValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalStringWrapper.asInternal(), { msg, decoder -> StringValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalStringWrapperDelegate.getOrCreate(msg) { StringValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> StringValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 209 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[11]) {
-                    msg.optionalBytesWrapper = BytesValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalBytesWrapper.asInternal(), { msg, decoder -> BytesValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalBytesWrapperDelegate.getOrCreate(msg) { BytesValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> BytesValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 211 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBoolWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = BoolValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> BoolValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedBoolWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 212 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedInt32WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = Int32ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> Int32ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedInt32Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 213 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedInt64WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = Int64ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> Int64ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedInt64Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 214 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedUint32WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = UInt32ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> UInt32ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedUint32Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 215 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedUint64WrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = UInt64ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> UInt64ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedUint64Wrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 216 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedFloatWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = FloatValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> FloatValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedFloatWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 217 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedDoubleWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = DoubleValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> DoubleValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedDoubleWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 218 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStringWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = StringValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> StringValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedStringWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 219 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedBytesWrapperDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = BytesValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> BytesValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedBytesWrapper as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 301 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[12]) {
-                    msg.optionalDuration = DurationInternal()
-                }
-
-                decoder.readMessage(msg.optionalDuration.asInternal(), { msg, decoder -> DurationInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalDurationDelegate.getOrCreate(msg) { DurationInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> DurationInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 302 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[13]) {
-                    msg.optionalTimestamp = TimestampInternal()
-                }
-
-                decoder.readMessage(msg.optionalTimestamp.asInternal(), { msg, decoder -> TimestampInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalTimestampDelegate.getOrCreate(msg) { TimestampInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TimestampInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 303 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[14]) {
-                    msg.optionalFieldMask = FieldMaskInternal()
-                }
-
-                decoder.readMessage(msg.optionalFieldMask.asInternal(), { msg, decoder -> FieldMaskInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalFieldMaskDelegate.getOrCreate(msg) { FieldMaskInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> FieldMaskInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 304 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[15]) {
-                    msg.optionalStruct = StructInternal()
-                }
-
-                decoder.readMessage(msg.optionalStruct.asInternal(), { msg, decoder -> StructInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalStructDelegate.getOrCreate(msg) { StructInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> StructInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 305 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[16]) {
-                    msg.optionalAny = AnyInternal()
-                }
-
-                decoder.readMessage(msg.optionalAny.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalAnyDelegate.getOrCreate(msg) { AnyInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 306 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[17]) {
-                    msg.optionalValue = ValueInternal()
-                }
-
-                decoder.readMessage(msg.optionalValue.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalValueDelegate.getOrCreate(msg) { ValueInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 307 && tag.wireType == WireType.VARINT -> {
                 msg.optionalNullValue = NullValue.fromNumber(decoder.readEnum())
             }
             tag.fieldNr == 308 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[18]) {
-                    msg.optionalEmpty = EmptyInternal()
-                }
-
-                decoder.readMessage(msg.optionalEmpty.asInternal(), { msg, decoder -> EmptyInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__optionalEmptyDelegate.getOrCreate(msg) { EmptyInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> EmptyInternal.decodeWith(msg, decoder, config) })
             }
             tag.fieldNr == 311 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedDurationDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = DurationInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> DurationInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedDuration as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 312 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedTimestampDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = TimestampInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> TimestampInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedTimestamp as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 313 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedFieldmaskDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = FieldMaskInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> FieldMaskInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedFieldmask as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 324 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedStructDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = StructInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> StructInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedStruct as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 315 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedAnyDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = AnyInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> AnyInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedAny as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 316 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedValueDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedValue as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 317 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedListValueDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = ListValueInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> ListValueInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedListValue as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 318 && tag.wireType == WireType.LENGTH_DELIMITED -> {
+                val target = msg.__repeatedEmptyDelegate.getOrCreate(msg) { mutableListOf() } as MutableList
                 val elem = EmptyInternal()
                 decoder.readMessage(elem.asInternal(), { msg, decoder -> EmptyInternal.decodeWith(msg, decoder, config) })
-                (msg.repeatedEmpty as MutableList).add(elem)
+                target.add(elem)
             }
             tag.fieldNr == 401 && tag.wireType == WireType.VARINT -> {
                 msg.fieldname1 = decoder.readInt32()
@@ -5432,11 +5697,8 @@ fun TestAllTypesProto3Internal.NestedMessageInternal.Companion.decodeWith(msg: T
                 msg.a = decoder.readInt32()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.corecursive = TestAllTypesProto3Internal()
-                }
-
-                decoder.readMessage(msg.corecursive.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
+                val target = msg.__corecursiveDelegate.getOrCreate(msg) { TestAllTypesProto3Internal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -6655,11 +6917,8 @@ fun TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal.Companion.dec
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.value = TestAllTypesProto3Internal.NestedMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { TestAllTypesProto3Internal.NestedMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> TestAllTypesProto3Internal.NestedMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {
@@ -6738,11 +6997,8 @@ fun TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal.Companion.de
                 msg.key = decoder.readString()
             }
             tag.fieldNr == 2 && tag.wireType == WireType.LENGTH_DELIMITED -> {
-                if (!msg.presenceMask[0]) {
-                    msg.value = ForeignMessageInternal()
-                }
-
-                decoder.readMessage(msg.value.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
+                val target = msg.__valueDelegate.getOrCreate(msg) { ForeignMessageInternal() }
+                decoder.readMessage(target.asInternal(), { msg, decoder -> ForeignMessageInternal.decodeWith(msg, decoder, config) })
             }
             else -> {
                 if (tag.wireType == WireType.END_GROUP) {


### PR DESCRIPTION
**Subsystem**
Protobuf

**Issue**
[KRPC-520](https://youtrack.jetbrains.com/issue/KRPC-520) pb: Use static defaults for generated protobuf messages

**Problem Description**
Currently default instances are created on every access, potentially decreasing performance.

**Solution**
Now that bytes fields are generated as `ByteString` properties, default instances are actually immutable (as long as the public API is used). This means that we can create a static default instance for each message and reuse it. 

This PR generates the `MyMessageInternal.DEFAULT` value that is returned by the `MsgFieldDelegate` and `InternalExtensionDescriptor`. 
During decoding of messages, it is necessary to access the `MsgFieldDelegate` itself for messages, lists and maps. Therefore the delegate is stored as `__fieldDelegate` next to the `field` property. This will also be necessary for the `clearField` function generation when refactoring the optional field behavior.
