### PR TITLE
Add test retries plugin

### DIFF
--- a/gradle-conventions/build.gradle.kts
+++ b/gradle-conventions/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(libs.compat.patrouille.gradle.plugin)
 
     implementation(libs.kover.gradle.plugin)
+    implementation(libs.test.retry.gradle.plugin)
 
     // https://stackoverflow.com/questions/76713758/use-version-catalog-inside-precompiled-gradle-plugin
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/gradle-conventions/src/main/kotlin/conventions-common.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/conventions-common.gradle.kts
@@ -3,6 +3,7 @@
  */
 
 import io.gitlab.arturbosch.detekt.Detekt
+import org.gradle.api.tasks.testing.Test
 import util.other.libs
 
 plugins {
@@ -10,6 +11,7 @@ plugins {
     id("conventions-publishing")
     id("conventions-kotlin-version")
     id("conventions-dokka-public")
+    id("org.gradle.test-retry")
 }
 
 val globalRootDir: String by extra
@@ -49,5 +51,13 @@ afterEvaluate {
         setDependsOn(dependsOn.filterNot {
             it is TaskProvider<*> && it.name.contains("detekt")
         })
+    }
+}
+
+// https://blog.jetbrains.com/teamcity/2025/12/how-to-tame-flaky-tests/
+tasks.withType<Test>().configureEach {
+    retry {
+        maxRetries = providers.systemProperty("retryCount").orNull?.toInt() ?: 0
+        failOnPassedAfterRetry = false
     }
 }

--- a/versions-root/libs.versions.toml
+++ b/versions-root/libs.versions.toml
@@ -36,6 +36,7 @@ grpc-kotlin = "1.5.0"
 protobuf = "4.34.0"
 buf-tool = "1.66.0"
 agp = "8.4.0"
+test-retry = "1.5.9"
 
 [libraries]
 # kotlinx.rpc – references to the included builds
@@ -139,6 +140,7 @@ gradle-publish-gradle-plugin = { module = "com.gradle.publish:plugin-publish-plu
 compat-patrouille-gradle-plugin = { module = "com.gradleup.compat.patrouille:compat-patrouille-gradle-plugin", version.ref = "compat-patrouille" }
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 android-gradle-plugin-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
+test-retry-gradle-plugin = { module = "org.gradle:test-retry-gradle-plugin", version.ref = "test-retry" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin-lang" }


### PR DESCRIPTION
**Subsystem**
Gradle, Tests

**Problem Description**
We occasionally have flaky tests

**Solution**
TC has a built-in flaky test detector, which we can use if we setup retries
https://www.jetbrains.com/help/teamcity/investigating-and-muting-build-failures.html#Flaky+Tests
