### PR TITLE
pb: Add `this` qualifier for fields in generated `hashCode` methods

### DIFF
--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Any.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Any.kt
@@ -44,8 +44,8 @@ public class AnyInternal: Any.Builder, InternalMessage(fieldsWithPresence = 0) {
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = typeUrl.hashCode()
-        result = 31 * result + value.hashCode()
+        var result = this.typeUrl.hashCode()
+        result = 31 * result + this.value.hashCode()
         return result
     }
 

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Api.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Api.kt
@@ -75,13 +75,13 @@ public class ApiInternal: Api.Builder, InternalMessage(fieldsWithPresence = 1) {
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + methods.hashCode()
-        result = 31 * result + options.hashCode()
-        result = 31 * result + version.hashCode()
-        result = 31 * result + if (presenceMask[0]) sourceContext.hashCode() else 0
-        result = 31 * result + mixins.hashCode()
-        result = 31 * result + syntax.hashCode()
+        var result = this.name.hashCode()
+        result = 31 * result + this.methods.hashCode()
+        result = 31 * result + this.options.hashCode()
+        result = 31 * result + this.version.hashCode()
+        result = 31 * result + if (presenceMask[0]) this.sourceContext.hashCode() else 0
+        result = 31 * result + this.mixins.hashCode()
+        result = 31 * result + this.syntax.hashCode()
         return result
     }
 
@@ -214,13 +214,13 @@ public class MethodInternal: Method.Builder, InternalMessage(fieldsWithPresence 
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + requestTypeUrl.hashCode()
-        result = 31 * result + requestStreaming.hashCode()
-        result = 31 * result + responseTypeUrl.hashCode()
-        result = 31 * result + responseStreaming.hashCode()
-        result = 31 * result + options.hashCode()
-        result = 31 * result + syntax.hashCode()
+        var result = this.name.hashCode()
+        result = 31 * result + this.requestTypeUrl.hashCode()
+        result = 31 * result + this.requestStreaming.hashCode()
+        result = 31 * result + this.responseTypeUrl.hashCode()
+        result = 31 * result + this.responseStreaming.hashCode()
+        result = 31 * result + this.options.hashCode()
+        result = 31 * result + this.syntax.hashCode()
         return result
     }
 
@@ -334,8 +334,8 @@ public class MixinInternal: Mixin.Builder, InternalMessage(fieldsWithPresence = 
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + root.hashCode()
+        var result = this.name.hashCode()
+        result = 31 * result + this.root.hashCode()
         return result
     }
 

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Duration.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Duration.kt
@@ -46,8 +46,8 @@ public class DurationInternal: Duration.Builder, InternalMessage(fieldsWithPrese
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = seconds.hashCode()
-        result = 31 * result + nanos.hashCode()
+        var result = this.seconds.hashCode()
+        result = 31 * result + this.nanos.hashCode()
         return result
     }
 

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/FieldMask.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/FieldMask.kt
@@ -48,7 +48,7 @@ public class FieldMaskInternal: FieldMask.Builder, InternalMessage(fieldsWithPre
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = paths.hashCode()
+        var result = this.paths.hashCode()
         return result
     }
 

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/SourceContext.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/SourceContext.kt
@@ -41,7 +41,7 @@ public class SourceContextInternal: SourceContext.Builder, InternalMessage(field
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = fileName.hashCode()
+        var result = this.fileName.hashCode()
         return result
     }
 

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Struct.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Struct.kt
@@ -48,7 +48,7 @@ public class StructInternal: Struct.Builder, InternalMessage(fieldsWithPresence 
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = fields.hashCode()
+        var result = this.fields.hashCode()
         return result
     }
 
@@ -111,8 +111,8 @@ public class StructInternal: Struct.Builder, InternalMessage(fieldsWithPresence 
 
         public override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + if (presenceMask[0]) value.hashCode() else 0
+            var result = this.key.hashCode()
+            result = 31 * result + if (presenceMask[0]) this.value.hashCode() else 0
             return result
         }
 
@@ -208,7 +208,7 @@ public class ValueInternal: Value.Builder, InternalMessage(fieldsWithPresence = 
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = (kind?.oneOfHashCode() ?: 0)
+        var result = (this.kind?.oneOfHashCode() ?: 0)
         return result
     }
 
@@ -351,7 +351,7 @@ public class ListValueInternal: ListValue.Builder, InternalMessage(fieldsWithPre
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = values.hashCode()
+        var result = this.values.hashCode()
         return result
     }
 
@@ -498,7 +498,7 @@ public fun StructInternal.Companion.decodeWith(msg: StructInternal, decoder: Wir
 private fun StructInternal.computeSize(): Int {
     var __result = 0
     if (this.fields.isNotEmpty()) {
-        __result += fields.entries.sumOf { kEntry ->
+        __result += this.fields.entries.sumOf { kEntry ->
             StructInternal.FieldsEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Timestamp.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Timestamp.kt
@@ -46,8 +46,8 @@ public class TimestampInternal: Timestamp.Builder, InternalMessage(fieldsWithPre
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = seconds.hashCode()
-        result = 31 * result + nanos.hashCode()
+        var result = this.seconds.hashCode()
+        result = 31 * result + this.nanos.hashCode()
         return result
     }
 

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Type.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Type.kt
@@ -74,13 +74,13 @@ public class TypeInternal: Type.Builder, InternalMessage(fieldsWithPresence = 1)
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + fields.hashCode()
-        result = 31 * result + oneofs.hashCode()
-        result = 31 * result + options.hashCode()
-        result = 31 * result + if (presenceMask[0]) sourceContext.hashCode() else 0
-        result = 31 * result + syntax.hashCode()
-        result = 31 * result + edition.hashCode()
+        var result = this.name.hashCode()
+        result = 31 * result + this.fields.hashCode()
+        result = 31 * result + this.oneofs.hashCode()
+        result = 31 * result + this.options.hashCode()
+        result = 31 * result + if (presenceMask[0]) this.sourceContext.hashCode() else 0
+        result = 31 * result + this.syntax.hashCode()
+        result = 31 * result + this.edition.hashCode()
         return result
     }
 
@@ -219,16 +219,16 @@ public class FieldInternal: Field.Builder, InternalMessage(fieldsWithPresence = 
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = kind.hashCode()
-        result = 31 * result + cardinality.hashCode()
-        result = 31 * result + number.hashCode()
-        result = 31 * result + name.hashCode()
-        result = 31 * result + typeUrl.hashCode()
-        result = 31 * result + oneofIndex.hashCode()
-        result = 31 * result + packed.hashCode()
-        result = 31 * result + options.hashCode()
-        result = 31 * result + jsonName.hashCode()
-        result = 31 * result + defaultValue.hashCode()
+        var result = this.kind.hashCode()
+        result = 31 * result + this.cardinality.hashCode()
+        result = 31 * result + this.number.hashCode()
+        result = 31 * result + this.name.hashCode()
+        result = 31 * result + this.typeUrl.hashCode()
+        result = 31 * result + this.oneofIndex.hashCode()
+        result = 31 * result + this.packed.hashCode()
+        result = 31 * result + this.options.hashCode()
+        result = 31 * result + this.jsonName.hashCode()
+        result = 31 * result + this.defaultValue.hashCode()
         return result
     }
 
@@ -372,12 +372,12 @@ public class EnumInternal: Enum.Builder, InternalMessage(fieldsWithPresence = 1)
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + enumvalue.hashCode()
-        result = 31 * result + options.hashCode()
-        result = 31 * result + if (presenceMask[0]) sourceContext.hashCode() else 0
-        result = 31 * result + syntax.hashCode()
-        result = 31 * result + edition.hashCode()
+        var result = this.name.hashCode()
+        result = 31 * result + this.enumvalue.hashCode()
+        result = 31 * result + this.options.hashCode()
+        result = 31 * result + if (presenceMask[0]) this.sourceContext.hashCode() else 0
+        result = 31 * result + this.syntax.hashCode()
+        result = 31 * result + this.edition.hashCode()
         return result
     }
 
@@ -499,9 +499,9 @@ public class EnumValueInternal: EnumValue.Builder, InternalMessage(fieldsWithPre
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + number.hashCode()
-        result = 31 * result + options.hashCode()
+        var result = this.name.hashCode()
+        result = 31 * result + this.number.hashCode()
+        result = 31 * result + this.options.hashCode()
         return result
     }
 
@@ -616,8 +616,8 @@ public class OptionInternal: Option.Builder, InternalMessage(fieldsWithPresence 
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + if (presenceMask[0]) value.hashCode() else 0
+        var result = this.name.hashCode()
+        result = 31 * result + if (presenceMask[0]) this.value.hashCode() else 0
         return result
     }
 

--- a/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Wrappers.kt
+++ b/protobuf/protobuf-wkt/src/commonMain/generated-code/kotlin-multiplatform/com/google/protobuf/kotlin/_rpc_internal/Wrappers.kt
@@ -49,7 +49,7 @@ public class DoubleValueInternal: DoubleValue.Builder, InternalMessage(fieldsWit
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.toBits().hashCode()
+        var result = this.value.toBits().hashCode()
         return result
     }
 
@@ -143,7 +143,7 @@ public class FloatValueInternal: FloatValue.Builder, InternalMessage(fieldsWithP
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.toBits().hashCode()
+        var result = this.value.toBits().hashCode()
         return result
     }
 
@@ -237,7 +237,7 @@ public class Int64ValueInternal: Int64Value.Builder, InternalMessage(fieldsWithP
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.hashCode()
+        var result = this.value.hashCode()
         return result
     }
 
@@ -331,7 +331,7 @@ public class UInt64ValueInternal: UInt64Value.Builder, InternalMessage(fieldsWit
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.hashCode()
+        var result = this.value.hashCode()
         return result
     }
 
@@ -425,7 +425,7 @@ public class Int32ValueInternal: Int32Value.Builder, InternalMessage(fieldsWithP
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.hashCode()
+        var result = this.value.hashCode()
         return result
     }
 
@@ -519,7 +519,7 @@ public class UInt32ValueInternal: UInt32Value.Builder, InternalMessage(fieldsWit
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.hashCode()
+        var result = this.value.hashCode()
         return result
     }
 
@@ -613,7 +613,7 @@ public class BoolValueInternal: BoolValue.Builder, InternalMessage(fieldsWithPre
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.hashCode()
+        var result = this.value.hashCode()
         return result
     }
 
@@ -707,7 +707,7 @@ public class StringValueInternal: StringValue.Builder, InternalMessage(fieldsWit
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.hashCode()
+        var result = this.value.hashCode()
         return result
     }
 
@@ -801,7 +801,7 @@ public class BytesValueInternal: BytesValue.Builder, InternalMessage(fieldsWithP
 
     public override fun hashCode(): Int {
         checkRequiredFields()
-        var result = value.hashCode()
+        var result = this.value.hashCode()
         return result
     }
 

--- a/protoc-gen/protobuf/src/main/kotlin/kotlinx/rpc/protoc/gen/ModelToProtobufKotlinCommonGenerator.kt
+++ b/protoc-gen/protobuf/src/main/kotlin/kotlinx/rpc/protoc/gen/ModelToProtobufKotlinCommonGenerator.kt
@@ -380,33 +380,34 @@ class ModelToProtobufKotlinCommonGenerator(
     }
 
     private fun FieldDeclaration.hashExprForHashCode(): ScopedFormattedString {
+        val thisField = "this.$name"
         return when (val t = type) {
             is FieldType.IntegralType -> {
                 when (t) {
                     FieldType.IntegralType.FLOAT -> {
-                        if (nullable) "(${name}?.toBits()?.hashCode() ?: 0)" else "${name}.toBits().hashCode()"
+                        if (nullable) "($thisField?.toBits()?.hashCode() ?: 0)" else "$thisField.toBits().hashCode()"
                     }
 
                     FieldType.IntegralType.DOUBLE -> {
-                        if (nullable) "(${name}?.toBits()?.hashCode() ?: 0)" else "${name}.toBits().hashCode()"
+                        if (nullable) "($thisField?.toBits()?.hashCode() ?: 0)" else "$thisField.toBits().hashCode()"
                     }
 
                     else -> {
-                        if (nullable) "(${name}?.hashCode() ?: 0)" else "${name}.hashCode()"
+                        if (nullable) "($thisField?.hashCode() ?: 0)" else "$thisField.hashCode()"
                     }
                 }
             }
 
             is FieldType.OneOf -> {
-                if (nullable) "(${name}?.oneOfHashCode() ?: 0)" else "${name}.oneOfHashCode() + "
+                if (nullable) "($thisField?.oneOfHashCode() ?: 0)" else "$thisField.oneOfHashCode() + "
             }
 
             is FieldType.List -> {
-                if (nullable) "(${name}?.hashCode() ?: 0)" else "${name}.hashCode()"
+                if (nullable) "($thisField?.hashCode() ?: 0)" else "$thisField.hashCode()"
             }
 
             is FieldType.Message, is FieldType.Enum, is FieldType.Map -> {
-                if (nullable) "(${name}?.hashCode() ?: 0)" else "${name}.hashCode()"
+                if (nullable) "($thisField?.hashCode() ?: 0)" else "$thisField.hashCode()"
             }
         }.let {
             if (presenceIdx != null) {
@@ -1868,7 +1869,7 @@ class ModelToProtobufKotlinCommonGenerator(
             }
 
             is FieldType.Map -> {
-                scope("__result += ${field.name}.entries.sumOf".scoped(), paramDecl = "kEntry ->".scoped()) {
+                scope(variable.wrapIn { "__result += $it.entries.sumOf" }, paramDecl = "kEntry ->".scoped()) {
                     generateMapConstruction(field.type as FieldType.Map, "kEntry.key".scoped(), "kEntry.value".scoped())
                     code(
                         tagSize.merge(int32SizeCall("it".scoped())) { tagSize, int32SizeCall ->

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf/conformance/_rpc_internal/Conformance.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf/conformance/_rpc_internal/Conformance.kt
@@ -48,9 +48,9 @@ class TestStatusInternal: TestStatus.Builder, InternalMessage(fieldsWithPresence
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = name.hashCode()
-        result = 31 * result + failureMessage.hashCode()
-        result = 31 * result + matchedName.hashCode()
+        var result = this.name.hashCode()
+        result = 31 * result + this.failureMessage.hashCode()
+        result = 31 * result + this.matchedName.hashCode()
         return result
     }
 
@@ -150,7 +150,7 @@ class FailureSetInternal: FailureSet.Builder, InternalMessage(fieldsWithPresence
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = test.hashCode()
+        var result = this.test.hashCode()
         return result
     }
 
@@ -266,12 +266,12 @@ class ConformanceRequestInternal: ConformanceRequest.Builder, InternalMessage(fi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = requestedOutputFormat.hashCode()
-        result = 31 * result + messageType.hashCode()
-        result = 31 * result + testCategory.hashCode()
-        result = 31 * result + if (presenceMask[0]) jspbEncodingOptions.hashCode() else 0
-        result = 31 * result + printUnknownFields.hashCode()
-        result = 31 * result + (payload?.oneOfHashCode() ?: 0)
+        var result = this.requestedOutputFormat.hashCode()
+        result = 31 * result + this.messageType.hashCode()
+        result = 31 * result + this.testCategory.hashCode()
+        result = 31 * result + if (presenceMask[0]) this.jspbEncodingOptions.hashCode() else 0
+        result = 31 * result + this.printUnknownFields.hashCode()
+        result = 31 * result + (this.payload?.oneOfHashCode() ?: 0)
         return result
     }
 
@@ -404,7 +404,7 @@ class ConformanceResponseInternal: ConformanceResponse.Builder, InternalMessage(
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = (result?.oneOfHashCode() ?: 0)
+        var result = (this.result?.oneOfHashCode() ?: 0)
         return result
     }
 
@@ -519,7 +519,7 @@ class JspbEncodingConfigInternal: JspbEncodingConfig.Builder, InternalMessage(fi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = useJspbArrayAnyFormat.hashCode()
+        var result = this.useJspbArrayAnyFormat.hashCode()
         return result
     }
 

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/edition2023/_rpc_internal/TestMessagesEdition2023.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/edition2023/_rpc_internal/TestMessagesEdition2023.kt
@@ -86,7 +86,7 @@ class ComplexMessageInternal: ComplexMessage.Builder, InternalMessage(fieldsWith
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (d?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.d?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -454,99 +454,99 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (optionalInt32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (optionalInt64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[2]) (optionalUint32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[3]) (optionalUint64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[4]) (optionalSint32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[5]) (optionalSint64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[6]) (optionalFixed32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[7]) (optionalFixed64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[8]) (optionalSfixed32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[9]) (optionalSfixed64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[10]) (optionalFloat?.toBits()?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[11]) (optionalDouble?.toBits()?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[12]) (optionalBool?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[13]) (optionalString?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[14]) (optionalBytes?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[15]) optionalNestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[16]) optionalForeignMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[17]) (optionalNestedEnum?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[18]) (optionalForeignEnum?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[19]) (optionalStringPiece?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[20]) (optionalCord?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[21]) recursiveMessage.hashCode() else 0
-        result = 31 * result + repeatedInt32.hashCode()
-        result = 31 * result + repeatedInt64.hashCode()
-        result = 31 * result + repeatedUint32.hashCode()
-        result = 31 * result + repeatedUint64.hashCode()
-        result = 31 * result + repeatedSint32.hashCode()
-        result = 31 * result + repeatedSint64.hashCode()
-        result = 31 * result + repeatedFixed32.hashCode()
-        result = 31 * result + repeatedFixed64.hashCode()
-        result = 31 * result + repeatedSfixed32.hashCode()
-        result = 31 * result + repeatedSfixed64.hashCode()
-        result = 31 * result + repeatedFloat.hashCode()
-        result = 31 * result + repeatedDouble.hashCode()
-        result = 31 * result + repeatedBool.hashCode()
-        result = 31 * result + repeatedString.hashCode()
-        result = 31 * result + repeatedBytes.hashCode()
-        result = 31 * result + repeatedNestedMessage.hashCode()
-        result = 31 * result + repeatedForeignMessage.hashCode()
-        result = 31 * result + repeatedNestedEnum.hashCode()
-        result = 31 * result + repeatedForeignEnum.hashCode()
-        result = 31 * result + repeatedStringPiece.hashCode()
-        result = 31 * result + repeatedCord.hashCode()
-        result = 31 * result + packedInt32.hashCode()
-        result = 31 * result + packedInt64.hashCode()
-        result = 31 * result + packedUint32.hashCode()
-        result = 31 * result + packedUint64.hashCode()
-        result = 31 * result + packedSint32.hashCode()
-        result = 31 * result + packedSint64.hashCode()
-        result = 31 * result + packedFixed32.hashCode()
-        result = 31 * result + packedFixed64.hashCode()
-        result = 31 * result + packedSfixed32.hashCode()
-        result = 31 * result + packedSfixed64.hashCode()
-        result = 31 * result + packedFloat.hashCode()
-        result = 31 * result + packedDouble.hashCode()
-        result = 31 * result + packedBool.hashCode()
-        result = 31 * result + packedNestedEnum.hashCode()
-        result = 31 * result + unpackedInt32.hashCode()
-        result = 31 * result + unpackedInt64.hashCode()
-        result = 31 * result + unpackedUint32.hashCode()
-        result = 31 * result + unpackedUint64.hashCode()
-        result = 31 * result + unpackedSint32.hashCode()
-        result = 31 * result + unpackedSint64.hashCode()
-        result = 31 * result + unpackedFixed32.hashCode()
-        result = 31 * result + unpackedFixed64.hashCode()
-        result = 31 * result + unpackedSfixed32.hashCode()
-        result = 31 * result + unpackedSfixed64.hashCode()
-        result = 31 * result + unpackedFloat.hashCode()
-        result = 31 * result + unpackedDouble.hashCode()
-        result = 31 * result + unpackedBool.hashCode()
-        result = 31 * result + unpackedNestedEnum.hashCode()
-        result = 31 * result + mapInt32Int32.hashCode()
-        result = 31 * result + mapInt64Int64.hashCode()
-        result = 31 * result + mapUint32Uint32.hashCode()
-        result = 31 * result + mapUint64Uint64.hashCode()
-        result = 31 * result + mapSint32Sint32.hashCode()
-        result = 31 * result + mapSint64Sint64.hashCode()
-        result = 31 * result + mapFixed32Fixed32.hashCode()
-        result = 31 * result + mapFixed64Fixed64.hashCode()
-        result = 31 * result + mapSfixed32Sfixed32.hashCode()
-        result = 31 * result + mapSfixed64Sfixed64.hashCode()
-        result = 31 * result + mapInt32Float.hashCode()
-        result = 31 * result + mapInt32Double.hashCode()
-        result = 31 * result + mapBoolBool.hashCode()
-        result = 31 * result + mapStringString.hashCode()
-        result = 31 * result + mapStringBytes.hashCode()
-        result = 31 * result + mapStringNestedMessage.hashCode()
-        result = 31 * result + mapStringForeignMessage.hashCode()
-        result = 31 * result + mapStringNestedEnum.hashCode()
-        result = 31 * result + mapStringForeignEnum.hashCode()
-        result = 31 * result + if (presenceMask[22]) groupliketype.hashCode() else 0
-        result = 31 * result + if (presenceMask[23]) delimitedField.hashCode() else 0
-        result = 31 * result + (oneofField?.oneOfHashCode() ?: 0)
+        var result = if (presenceMask[0]) (this.optionalInt32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.optionalInt64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[2]) (this.optionalUint32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[3]) (this.optionalUint64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[4]) (this.optionalSint32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[5]) (this.optionalSint64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[6]) (this.optionalFixed32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[7]) (this.optionalFixed64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[8]) (this.optionalSfixed32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[9]) (this.optionalSfixed64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[10]) (this.optionalFloat?.toBits()?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[11]) (this.optionalDouble?.toBits()?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[12]) (this.optionalBool?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[13]) (this.optionalString?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[14]) (this.optionalBytes?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[15]) this.optionalNestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[16]) this.optionalForeignMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[17]) (this.optionalNestedEnum?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[18]) (this.optionalForeignEnum?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[19]) (this.optionalStringPiece?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[20]) (this.optionalCord?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[21]) this.recursiveMessage.hashCode() else 0
+        result = 31 * result + this.repeatedInt32.hashCode()
+        result = 31 * result + this.repeatedInt64.hashCode()
+        result = 31 * result + this.repeatedUint32.hashCode()
+        result = 31 * result + this.repeatedUint64.hashCode()
+        result = 31 * result + this.repeatedSint32.hashCode()
+        result = 31 * result + this.repeatedSint64.hashCode()
+        result = 31 * result + this.repeatedFixed32.hashCode()
+        result = 31 * result + this.repeatedFixed64.hashCode()
+        result = 31 * result + this.repeatedSfixed32.hashCode()
+        result = 31 * result + this.repeatedSfixed64.hashCode()
+        result = 31 * result + this.repeatedFloat.hashCode()
+        result = 31 * result + this.repeatedDouble.hashCode()
+        result = 31 * result + this.repeatedBool.hashCode()
+        result = 31 * result + this.repeatedString.hashCode()
+        result = 31 * result + this.repeatedBytes.hashCode()
+        result = 31 * result + this.repeatedNestedMessage.hashCode()
+        result = 31 * result + this.repeatedForeignMessage.hashCode()
+        result = 31 * result + this.repeatedNestedEnum.hashCode()
+        result = 31 * result + this.repeatedForeignEnum.hashCode()
+        result = 31 * result + this.repeatedStringPiece.hashCode()
+        result = 31 * result + this.repeatedCord.hashCode()
+        result = 31 * result + this.packedInt32.hashCode()
+        result = 31 * result + this.packedInt64.hashCode()
+        result = 31 * result + this.packedUint32.hashCode()
+        result = 31 * result + this.packedUint64.hashCode()
+        result = 31 * result + this.packedSint32.hashCode()
+        result = 31 * result + this.packedSint64.hashCode()
+        result = 31 * result + this.packedFixed32.hashCode()
+        result = 31 * result + this.packedFixed64.hashCode()
+        result = 31 * result + this.packedSfixed32.hashCode()
+        result = 31 * result + this.packedSfixed64.hashCode()
+        result = 31 * result + this.packedFloat.hashCode()
+        result = 31 * result + this.packedDouble.hashCode()
+        result = 31 * result + this.packedBool.hashCode()
+        result = 31 * result + this.packedNestedEnum.hashCode()
+        result = 31 * result + this.unpackedInt32.hashCode()
+        result = 31 * result + this.unpackedInt64.hashCode()
+        result = 31 * result + this.unpackedUint32.hashCode()
+        result = 31 * result + this.unpackedUint64.hashCode()
+        result = 31 * result + this.unpackedSint32.hashCode()
+        result = 31 * result + this.unpackedSint64.hashCode()
+        result = 31 * result + this.unpackedFixed32.hashCode()
+        result = 31 * result + this.unpackedFixed64.hashCode()
+        result = 31 * result + this.unpackedSfixed32.hashCode()
+        result = 31 * result + this.unpackedSfixed64.hashCode()
+        result = 31 * result + this.unpackedFloat.hashCode()
+        result = 31 * result + this.unpackedDouble.hashCode()
+        result = 31 * result + this.unpackedBool.hashCode()
+        result = 31 * result + this.unpackedNestedEnum.hashCode()
+        result = 31 * result + this.mapInt32Int32.hashCode()
+        result = 31 * result + this.mapInt64Int64.hashCode()
+        result = 31 * result + this.mapUint32Uint32.hashCode()
+        result = 31 * result + this.mapUint64Uint64.hashCode()
+        result = 31 * result + this.mapSint32Sint32.hashCode()
+        result = 31 * result + this.mapSint64Sint64.hashCode()
+        result = 31 * result + this.mapFixed32Fixed32.hashCode()
+        result = 31 * result + this.mapFixed64Fixed64.hashCode()
+        result = 31 * result + this.mapSfixed32Sfixed32.hashCode()
+        result = 31 * result + this.mapSfixed64Sfixed64.hashCode()
+        result = 31 * result + this.mapInt32Float.hashCode()
+        result = 31 * result + this.mapInt32Double.hashCode()
+        result = 31 * result + this.mapBoolBool.hashCode()
+        result = 31 * result + this.mapStringString.hashCode()
+        result = 31 * result + this.mapStringBytes.hashCode()
+        result = 31 * result + this.mapStringNestedMessage.hashCode()
+        result = 31 * result + this.mapStringForeignMessage.hashCode()
+        result = 31 * result + this.mapStringNestedEnum.hashCode()
+        result = 31 * result + this.mapStringForeignEnum.hashCode()
+        result = 31 * result + if (presenceMask[22]) this.groupliketype.hashCode() else 0
+        result = 31 * result + if (presenceMask[23]) this.delimitedField.hashCode() else 0
+        result = 31 * result + (this.oneofField?.oneOfHashCode() ?: 0)
         result = 31 * result + extensionsHashCode()
         return result
     }
@@ -1158,8 +1158,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (a?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) corecursive.hashCode() else 0
+            var result = if (presenceMask[0]) (this.a?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) this.corecursive.hashCode() else 0
             return result
         }
 
@@ -1280,8 +1280,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1353,8 +1353,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1426,8 +1426,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1499,8 +1499,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1572,8 +1572,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1645,8 +1645,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1718,8 +1718,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1791,8 +1791,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1864,8 +1864,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1937,8 +1937,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2010,8 +2010,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.toBits().hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.toBits().hashCode() else 0
             return result
         }
 
@@ -2083,8 +2083,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.toBits().hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.toBits().hashCode() else 0
             return result
         }
 
@@ -2156,8 +2156,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2229,8 +2229,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2302,8 +2302,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2375,8 +2375,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2448,8 +2448,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2521,8 +2521,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2594,8 +2594,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2678,8 +2678,8 @@ class TestAllTypesEdition2023Internal: TestAllTypesEdition2023.Builder, Internal
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (groupInt32?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) (groupUint32?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.groupInt32?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) (this.groupUint32?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -2843,7 +2843,7 @@ class ForeignMessageEdition2023Internal: ForeignMessageEdition2023.Builder, Inte
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (c?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.c?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -2959,7 +2959,7 @@ class GroupLikeTypeInternal: GroupLikeType.Builder, InternalMessage(fieldsWithPr
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (c?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.c?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -4746,7 +4746,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Int32.isNotEmpty()) {
-        __result += mapInt32Int32.entries.sumOf { kEntry ->
+        __result += this.mapInt32Int32.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapInt32Int32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4756,7 +4756,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapInt64Int64.isNotEmpty()) {
-        __result += mapInt64Int64.entries.sumOf { kEntry ->
+        __result += this.mapInt64Int64.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapInt64Int64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4766,7 +4766,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapUint32Uint32.isNotEmpty()) {
-        __result += mapUint32Uint32.entries.sumOf { kEntry ->
+        __result += this.mapUint32Uint32.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapUint32Uint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4776,7 +4776,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapUint64Uint64.isNotEmpty()) {
-        __result += mapUint64Uint64.entries.sumOf { kEntry ->
+        __result += this.mapUint64Uint64.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapUint64Uint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4786,7 +4786,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapSint32Sint32.isNotEmpty()) {
-        __result += mapSint32Sint32.entries.sumOf { kEntry ->
+        __result += this.mapSint32Sint32.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapSint32Sint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4796,7 +4796,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapSint64Sint64.isNotEmpty()) {
-        __result += mapSint64Sint64.entries.sumOf { kEntry ->
+        __result += this.mapSint64Sint64.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapSint64Sint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4806,7 +4806,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapFixed32Fixed32.isNotEmpty()) {
-        __result += mapFixed32Fixed32.entries.sumOf { kEntry ->
+        __result += this.mapFixed32Fixed32.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapFixed32Fixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4816,7 +4816,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapFixed64Fixed64.isNotEmpty()) {
-        __result += mapFixed64Fixed64.entries.sumOf { kEntry ->
+        __result += this.mapFixed64Fixed64.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapFixed64Fixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4826,7 +4826,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed32Sfixed32.isNotEmpty()) {
-        __result += mapSfixed32Sfixed32.entries.sumOf { kEntry ->
+        __result += this.mapSfixed32Sfixed32.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapSfixed32Sfixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4836,7 +4836,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed64Sfixed64.isNotEmpty()) {
-        __result += mapSfixed64Sfixed64.entries.sumOf { kEntry ->
+        __result += this.mapSfixed64Sfixed64.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapSfixed64Sfixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4846,7 +4846,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Float.isNotEmpty()) {
-        __result += mapInt32Float.entries.sumOf { kEntry ->
+        __result += this.mapInt32Float.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapInt32FloatEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4856,7 +4856,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Double.isNotEmpty()) {
-        __result += mapInt32Double.entries.sumOf { kEntry ->
+        __result += this.mapInt32Double.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapInt32DoubleEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4866,7 +4866,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapBoolBool.isNotEmpty()) {
-        __result += mapBoolBool.entries.sumOf { kEntry ->
+        __result += this.mapBoolBool.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapBoolBoolEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4876,7 +4876,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapStringString.isNotEmpty()) {
-        __result += mapStringString.entries.sumOf { kEntry ->
+        __result += this.mapStringString.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapStringStringEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4886,7 +4886,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapStringBytes.isNotEmpty()) {
-        __result += mapStringBytes.entries.sumOf { kEntry ->
+        __result += this.mapStringBytes.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapStringBytesEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4896,7 +4896,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedMessage.isNotEmpty()) {
-        __result += mapStringNestedMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedMessage.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapStringNestedMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4906,7 +4906,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignMessage.isNotEmpty()) {
-        __result += mapStringForeignMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignMessage.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapStringForeignMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4916,7 +4916,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedEnum.isNotEmpty()) {
-        __result += mapStringNestedEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedEnum.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapStringNestedEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -4926,7 +4926,7 @@ private fun TestAllTypesEdition2023Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignEnum.isNotEmpty()) {
-        __result += mapStringForeignEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignEnum.entries.sumOf { kEntry ->
             TestAllTypesEdition2023Internal.MapStringForeignEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto2/_rpc_internal/TestMessagesProto2Editions.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto2/_rpc_internal/TestMessagesProto2Editions.kt
@@ -516,135 +516,135 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (optionalInt32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (optionalInt64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[2]) (optionalUint32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[3]) (optionalUint64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[4]) (optionalSint32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[5]) (optionalSint64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[6]) (optionalFixed32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[7]) (optionalFixed64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[8]) (optionalSfixed32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[9]) (optionalSfixed64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[10]) (optionalFloat?.toBits()?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[11]) (optionalDouble?.toBits()?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[12]) (optionalBool?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[13]) (optionalString?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[14]) (optionalBytes?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[15]) optionalNestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[16]) optionalForeignMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[17]) (optionalNestedEnum?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[18]) (optionalForeignEnum?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[19]) (optionalStringPiece?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[20]) (optionalCord?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[21]) recursiveMessage.hashCode() else 0
-        result = 31 * result + repeatedInt32.hashCode()
-        result = 31 * result + repeatedInt64.hashCode()
-        result = 31 * result + repeatedUint32.hashCode()
-        result = 31 * result + repeatedUint64.hashCode()
-        result = 31 * result + repeatedSint32.hashCode()
-        result = 31 * result + repeatedSint64.hashCode()
-        result = 31 * result + repeatedFixed32.hashCode()
-        result = 31 * result + repeatedFixed64.hashCode()
-        result = 31 * result + repeatedSfixed32.hashCode()
-        result = 31 * result + repeatedSfixed64.hashCode()
-        result = 31 * result + repeatedFloat.hashCode()
-        result = 31 * result + repeatedDouble.hashCode()
-        result = 31 * result + repeatedBool.hashCode()
-        result = 31 * result + repeatedString.hashCode()
-        result = 31 * result + repeatedBytes.hashCode()
-        result = 31 * result + repeatedNestedMessage.hashCode()
-        result = 31 * result + repeatedForeignMessage.hashCode()
-        result = 31 * result + repeatedNestedEnum.hashCode()
-        result = 31 * result + repeatedForeignEnum.hashCode()
-        result = 31 * result + repeatedStringPiece.hashCode()
-        result = 31 * result + repeatedCord.hashCode()
-        result = 31 * result + packedInt32.hashCode()
-        result = 31 * result + packedInt64.hashCode()
-        result = 31 * result + packedUint32.hashCode()
-        result = 31 * result + packedUint64.hashCode()
-        result = 31 * result + packedSint32.hashCode()
-        result = 31 * result + packedSint64.hashCode()
-        result = 31 * result + packedFixed32.hashCode()
-        result = 31 * result + packedFixed64.hashCode()
-        result = 31 * result + packedSfixed32.hashCode()
-        result = 31 * result + packedSfixed64.hashCode()
-        result = 31 * result + packedFloat.hashCode()
-        result = 31 * result + packedDouble.hashCode()
-        result = 31 * result + packedBool.hashCode()
-        result = 31 * result + packedNestedEnum.hashCode()
-        result = 31 * result + unpackedInt32.hashCode()
-        result = 31 * result + unpackedInt64.hashCode()
-        result = 31 * result + unpackedUint32.hashCode()
-        result = 31 * result + unpackedUint64.hashCode()
-        result = 31 * result + unpackedSint32.hashCode()
-        result = 31 * result + unpackedSint64.hashCode()
-        result = 31 * result + unpackedFixed32.hashCode()
-        result = 31 * result + unpackedFixed64.hashCode()
-        result = 31 * result + unpackedSfixed32.hashCode()
-        result = 31 * result + unpackedSfixed64.hashCode()
-        result = 31 * result + unpackedFloat.hashCode()
-        result = 31 * result + unpackedDouble.hashCode()
-        result = 31 * result + unpackedBool.hashCode()
-        result = 31 * result + unpackedNestedEnum.hashCode()
-        result = 31 * result + mapInt32Int32.hashCode()
-        result = 31 * result + mapInt64Int64.hashCode()
-        result = 31 * result + mapUint32Uint32.hashCode()
-        result = 31 * result + mapUint64Uint64.hashCode()
-        result = 31 * result + mapSint32Sint32.hashCode()
-        result = 31 * result + mapSint64Sint64.hashCode()
-        result = 31 * result + mapFixed32Fixed32.hashCode()
-        result = 31 * result + mapFixed64Fixed64.hashCode()
-        result = 31 * result + mapSfixed32Sfixed32.hashCode()
-        result = 31 * result + mapSfixed64Sfixed64.hashCode()
-        result = 31 * result + mapInt32Bool.hashCode()
-        result = 31 * result + mapInt32Float.hashCode()
-        result = 31 * result + mapInt32Double.hashCode()
-        result = 31 * result + mapInt32NestedMessage.hashCode()
-        result = 31 * result + mapBoolBool.hashCode()
-        result = 31 * result + mapStringString.hashCode()
-        result = 31 * result + mapStringBytes.hashCode()
-        result = 31 * result + mapStringNestedMessage.hashCode()
-        result = 31 * result + mapStringForeignMessage.hashCode()
-        result = 31 * result + mapStringNestedEnum.hashCode()
-        result = 31 * result + mapStringForeignEnum.hashCode()
-        result = 31 * result + if (presenceMask[22]) data.hashCode() else 0
-        result = 31 * result + if (presenceMask[23]) multiwordgroupfield.hashCode() else 0
-        result = 31 * result + if (presenceMask[24]) defaultInt32.hashCode() else 0
-        result = 31 * result + if (presenceMask[25]) defaultInt64.hashCode() else 0
-        result = 31 * result + if (presenceMask[26]) defaultUint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[27]) defaultUint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[28]) defaultSint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[29]) defaultSint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[30]) defaultFixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[31]) defaultFixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[32]) defaultSfixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[33]) defaultSfixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[34]) defaultFloat.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[35]) defaultDouble.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[36]) defaultBool.hashCode() else 0
-        result = 31 * result + if (presenceMask[37]) defaultString.hashCode() else 0
-        result = 31 * result + if (presenceMask[38]) defaultBytes.hashCode() else 0
-        result = 31 * result + if (presenceMask[39]) (fieldname1?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[40]) (fieldName2?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[41]) (FieldName3?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[42]) (field_Name4_?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[43]) (field0name5?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[44]) (field_0Name6?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[45]) (fieldName7?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[46]) (FieldName8?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[47]) (field_Name9?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[48]) (Field_Name10?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[49]) (FIELD_NAME11?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[50]) (FIELDName12?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[51]) (_FieldName13?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[52]) (__FieldName14?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[53]) (field_Name15?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[54]) (field__Name16?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[55]) (fieldName17__?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[56]) (FieldName18__?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[57]) messageSetCorrect.hashCode() else 0
-        result = 31 * result + (oneofField?.oneOfHashCode() ?: 0)
+        var result = if (presenceMask[0]) (this.optionalInt32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.optionalInt64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[2]) (this.optionalUint32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[3]) (this.optionalUint64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[4]) (this.optionalSint32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[5]) (this.optionalSint64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[6]) (this.optionalFixed32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[7]) (this.optionalFixed64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[8]) (this.optionalSfixed32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[9]) (this.optionalSfixed64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[10]) (this.optionalFloat?.toBits()?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[11]) (this.optionalDouble?.toBits()?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[12]) (this.optionalBool?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[13]) (this.optionalString?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[14]) (this.optionalBytes?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[15]) this.optionalNestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[16]) this.optionalForeignMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[17]) (this.optionalNestedEnum?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[18]) (this.optionalForeignEnum?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[19]) (this.optionalStringPiece?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[20]) (this.optionalCord?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[21]) this.recursiveMessage.hashCode() else 0
+        result = 31 * result + this.repeatedInt32.hashCode()
+        result = 31 * result + this.repeatedInt64.hashCode()
+        result = 31 * result + this.repeatedUint32.hashCode()
+        result = 31 * result + this.repeatedUint64.hashCode()
+        result = 31 * result + this.repeatedSint32.hashCode()
+        result = 31 * result + this.repeatedSint64.hashCode()
+        result = 31 * result + this.repeatedFixed32.hashCode()
+        result = 31 * result + this.repeatedFixed64.hashCode()
+        result = 31 * result + this.repeatedSfixed32.hashCode()
+        result = 31 * result + this.repeatedSfixed64.hashCode()
+        result = 31 * result + this.repeatedFloat.hashCode()
+        result = 31 * result + this.repeatedDouble.hashCode()
+        result = 31 * result + this.repeatedBool.hashCode()
+        result = 31 * result + this.repeatedString.hashCode()
+        result = 31 * result + this.repeatedBytes.hashCode()
+        result = 31 * result + this.repeatedNestedMessage.hashCode()
+        result = 31 * result + this.repeatedForeignMessage.hashCode()
+        result = 31 * result + this.repeatedNestedEnum.hashCode()
+        result = 31 * result + this.repeatedForeignEnum.hashCode()
+        result = 31 * result + this.repeatedStringPiece.hashCode()
+        result = 31 * result + this.repeatedCord.hashCode()
+        result = 31 * result + this.packedInt32.hashCode()
+        result = 31 * result + this.packedInt64.hashCode()
+        result = 31 * result + this.packedUint32.hashCode()
+        result = 31 * result + this.packedUint64.hashCode()
+        result = 31 * result + this.packedSint32.hashCode()
+        result = 31 * result + this.packedSint64.hashCode()
+        result = 31 * result + this.packedFixed32.hashCode()
+        result = 31 * result + this.packedFixed64.hashCode()
+        result = 31 * result + this.packedSfixed32.hashCode()
+        result = 31 * result + this.packedSfixed64.hashCode()
+        result = 31 * result + this.packedFloat.hashCode()
+        result = 31 * result + this.packedDouble.hashCode()
+        result = 31 * result + this.packedBool.hashCode()
+        result = 31 * result + this.packedNestedEnum.hashCode()
+        result = 31 * result + this.unpackedInt32.hashCode()
+        result = 31 * result + this.unpackedInt64.hashCode()
+        result = 31 * result + this.unpackedUint32.hashCode()
+        result = 31 * result + this.unpackedUint64.hashCode()
+        result = 31 * result + this.unpackedSint32.hashCode()
+        result = 31 * result + this.unpackedSint64.hashCode()
+        result = 31 * result + this.unpackedFixed32.hashCode()
+        result = 31 * result + this.unpackedFixed64.hashCode()
+        result = 31 * result + this.unpackedSfixed32.hashCode()
+        result = 31 * result + this.unpackedSfixed64.hashCode()
+        result = 31 * result + this.unpackedFloat.hashCode()
+        result = 31 * result + this.unpackedDouble.hashCode()
+        result = 31 * result + this.unpackedBool.hashCode()
+        result = 31 * result + this.unpackedNestedEnum.hashCode()
+        result = 31 * result + this.mapInt32Int32.hashCode()
+        result = 31 * result + this.mapInt64Int64.hashCode()
+        result = 31 * result + this.mapUint32Uint32.hashCode()
+        result = 31 * result + this.mapUint64Uint64.hashCode()
+        result = 31 * result + this.mapSint32Sint32.hashCode()
+        result = 31 * result + this.mapSint64Sint64.hashCode()
+        result = 31 * result + this.mapFixed32Fixed32.hashCode()
+        result = 31 * result + this.mapFixed64Fixed64.hashCode()
+        result = 31 * result + this.mapSfixed32Sfixed32.hashCode()
+        result = 31 * result + this.mapSfixed64Sfixed64.hashCode()
+        result = 31 * result + this.mapInt32Bool.hashCode()
+        result = 31 * result + this.mapInt32Float.hashCode()
+        result = 31 * result + this.mapInt32Double.hashCode()
+        result = 31 * result + this.mapInt32NestedMessage.hashCode()
+        result = 31 * result + this.mapBoolBool.hashCode()
+        result = 31 * result + this.mapStringString.hashCode()
+        result = 31 * result + this.mapStringBytes.hashCode()
+        result = 31 * result + this.mapStringNestedMessage.hashCode()
+        result = 31 * result + this.mapStringForeignMessage.hashCode()
+        result = 31 * result + this.mapStringNestedEnum.hashCode()
+        result = 31 * result + this.mapStringForeignEnum.hashCode()
+        result = 31 * result + if (presenceMask[22]) this.data.hashCode() else 0
+        result = 31 * result + if (presenceMask[23]) this.multiwordgroupfield.hashCode() else 0
+        result = 31 * result + if (presenceMask[24]) this.defaultInt32.hashCode() else 0
+        result = 31 * result + if (presenceMask[25]) this.defaultInt64.hashCode() else 0
+        result = 31 * result + if (presenceMask[26]) this.defaultUint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[27]) this.defaultUint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[28]) this.defaultSint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[29]) this.defaultSint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[30]) this.defaultFixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[31]) this.defaultFixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[32]) this.defaultSfixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[33]) this.defaultSfixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[34]) this.defaultFloat.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[35]) this.defaultDouble.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[36]) this.defaultBool.hashCode() else 0
+        result = 31 * result + if (presenceMask[37]) this.defaultString.hashCode() else 0
+        result = 31 * result + if (presenceMask[38]) this.defaultBytes.hashCode() else 0
+        result = 31 * result + if (presenceMask[39]) (this.fieldname1?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[40]) (this.fieldName2?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[41]) (this.FieldName3?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[42]) (this.field_Name4_?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[43]) (this.field0name5?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[44]) (this.field_0Name6?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[45]) (this.fieldName7?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[46]) (this.FieldName8?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[47]) (this.field_Name9?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[48]) (this.Field_Name10?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[49]) (this.FIELD_NAME11?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[50]) (this.FIELDName12?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[51]) (this._FieldName13?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[52]) (this.__FieldName14?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[53]) (this.field_Name15?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[54]) (this.field__Name16?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[55]) (this.fieldName17__?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[56]) (this.FieldName18__?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[57]) this.messageSetCorrect.hashCode() else 0
+        result = 31 * result + (this.oneofField?.oneOfHashCode() ?: 0)
         result = 31 * result + extensionsHashCode()
         return result
     }
@@ -1636,8 +1636,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (a?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) corecursive.hashCode() else 0
+            var result = if (presenceMask[0]) (this.a?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) this.corecursive.hashCode() else 0
             return result
         }
 
@@ -1758,8 +1758,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1831,8 +1831,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1904,8 +1904,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1977,8 +1977,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2050,8 +2050,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2123,8 +2123,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2196,8 +2196,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2269,8 +2269,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2342,8 +2342,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2415,8 +2415,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2488,8 +2488,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2561,8 +2561,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.toBits().hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.toBits().hashCode() else 0
             return result
         }
 
@@ -2634,8 +2634,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.toBits().hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.toBits().hashCode() else 0
             return result
         }
 
@@ -2707,8 +2707,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2780,8 +2780,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2853,8 +2853,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2926,8 +2926,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2999,8 +2999,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3072,8 +3072,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3145,8 +3145,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3218,8 +3218,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3302,8 +3302,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (groupInt32?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) (groupUint32?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.groupInt32?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) (this.groupUint32?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3435,8 +3435,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (groupInt32?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) (groupUint32?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.groupInt32?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) (this.groupUint32?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3662,7 +3662,7 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (str?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.str?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3778,7 +3778,7 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (i?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.i?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3880,7 +3880,7 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = (oneofField?.oneOfHashCode() ?: 0)
+            var result = (this.oneofField?.oneOfHashCode() ?: 0)
             return result
         }
 
@@ -4038,7 +4038,7 @@ class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessag
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (c?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.c?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -4159,8 +4159,8 @@ class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (groupInt32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (groupUint32?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.groupInt32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.groupUint32?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -4309,12 +4309,12 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (optionalInt32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (optionalString?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[2]) nestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[3]) optionalgroup.hashCode() else 0
-        result = 31 * result + if (presenceMask[4]) (optionalBool?.hashCode() ?: 0) else 0
-        result = 31 * result + repeatedInt32.hashCode()
+        var result = if (presenceMask[0]) (this.optionalInt32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.optionalString?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[2]) this.nestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[3]) this.optionalgroup.hashCode() else 0
+        result = 31 * result + if (presenceMask[4]) (this.optionalBool?.hashCode() ?: 0) else 0
+        result = 31 * result + this.repeatedInt32.hashCode()
         return result
     }
 
@@ -4440,7 +4440,7 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (a?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.a?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -4769,7 +4769,7 @@ class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (data?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.data?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -4892,9 +4892,9 @@ class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fiel
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (inline?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (concept?.hashCode() ?: 0) else 0
-        result = 31 * result + requires.hashCode()
+        var result = if (presenceMask[0]) (this.inline?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.concept?.hashCode() ?: 0) else 0
+        result = 31 * result + this.requires.hashCode()
         return result
     }
 
@@ -5218,45 +5218,45 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) requiredInt32.hashCode() else 0
-        result = 31 * result + if (presenceMask[1]) requiredInt64.hashCode() else 0
-        result = 31 * result + if (presenceMask[2]) requiredUint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[3]) requiredUint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[4]) requiredSint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[5]) requiredSint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[6]) requiredFixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[7]) requiredFixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[8]) requiredSfixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[9]) requiredSfixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[10]) requiredFloat.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[11]) requiredDouble.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[12]) requiredBool.hashCode() else 0
-        result = 31 * result + if (presenceMask[13]) requiredString.hashCode() else 0
-        result = 31 * result + if (presenceMask[14]) requiredBytes.hashCode() else 0
-        result = 31 * result + if (presenceMask[15]) requiredNestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[16]) requiredForeignMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[17]) requiredNestedEnum.hashCode() else 0
-        result = 31 * result + if (presenceMask[18]) requiredForeignEnum.hashCode() else 0
-        result = 31 * result + if (presenceMask[19]) requiredStringPiece.hashCode() else 0
-        result = 31 * result + if (presenceMask[20]) requiredCord.hashCode() else 0
-        result = 31 * result + if (presenceMask[21]) recursiveMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[22]) optionalRecursiveMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[23]) data.hashCode() else 0
-        result = 31 * result + if (presenceMask[24]) defaultInt32.hashCode() else 0
-        result = 31 * result + if (presenceMask[25]) defaultInt64.hashCode() else 0
-        result = 31 * result + if (presenceMask[26]) defaultUint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[27]) defaultUint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[28]) defaultSint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[29]) defaultSint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[30]) defaultFixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[31]) defaultFixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[32]) defaultSfixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[33]) defaultSfixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[34]) defaultFloat.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[35]) defaultDouble.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[36]) defaultBool.hashCode() else 0
-        result = 31 * result + if (presenceMask[37]) defaultString.hashCode() else 0
-        result = 31 * result + if (presenceMask[38]) defaultBytes.hashCode() else 0
+        var result = if (presenceMask[0]) this.requiredInt32.hashCode() else 0
+        result = 31 * result + if (presenceMask[1]) this.requiredInt64.hashCode() else 0
+        result = 31 * result + if (presenceMask[2]) this.requiredUint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[3]) this.requiredUint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[4]) this.requiredSint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[5]) this.requiredSint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[6]) this.requiredFixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[7]) this.requiredFixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[8]) this.requiredSfixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[9]) this.requiredSfixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[10]) this.requiredFloat.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[11]) this.requiredDouble.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[12]) this.requiredBool.hashCode() else 0
+        result = 31 * result + if (presenceMask[13]) this.requiredString.hashCode() else 0
+        result = 31 * result + if (presenceMask[14]) this.requiredBytes.hashCode() else 0
+        result = 31 * result + if (presenceMask[15]) this.requiredNestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[16]) this.requiredForeignMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[17]) this.requiredNestedEnum.hashCode() else 0
+        result = 31 * result + if (presenceMask[18]) this.requiredForeignEnum.hashCode() else 0
+        result = 31 * result + if (presenceMask[19]) this.requiredStringPiece.hashCode() else 0
+        result = 31 * result + if (presenceMask[20]) this.requiredCord.hashCode() else 0
+        result = 31 * result + if (presenceMask[21]) this.recursiveMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[22]) this.optionalRecursiveMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[23]) this.data.hashCode() else 0
+        result = 31 * result + if (presenceMask[24]) this.defaultInt32.hashCode() else 0
+        result = 31 * result + if (presenceMask[25]) this.defaultInt64.hashCode() else 0
+        result = 31 * result + if (presenceMask[26]) this.defaultUint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[27]) this.defaultUint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[28]) this.defaultSint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[29]) this.defaultSint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[30]) this.defaultFixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[31]) this.defaultFixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[32]) this.defaultSfixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[33]) this.defaultSfixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[34]) this.defaultFloat.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[35]) this.defaultDouble.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[36]) this.defaultBool.hashCode() else 0
+        result = 31 * result + if (presenceMask[37]) this.defaultString.hashCode() else 0
+        result = 31 * result + if (presenceMask[38]) this.defaultBytes.hashCode() else 0
         result = 31 * result + extensionsHashCode()
         return result
     }
@@ -5767,9 +5767,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) a.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) corecursive.hashCode() else 0
-            result = 31 * result + if (presenceMask[2]) optionalCorecursive.hashCode() else 0
+            var result = if (presenceMask[0]) this.a.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.corecursive.hashCode() else 0
+            result = 31 * result + if (presenceMask[2]) this.optionalCorecursive.hashCode() else 0
             return result
         }
 
@@ -5912,8 +5912,8 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) groupInt32.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) groupUint32.hashCode() else 0
+            var result = if (presenceMask[0]) this.groupInt32.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.groupUint32.hashCode() else 0
             return result
         }
 
@@ -6139,7 +6139,7 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) str.hashCode() else 0
+            var result = if (presenceMask[0]) this.str.hashCode() else 0
             return result
         }
 
@@ -6255,7 +6255,7 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) i.hashCode() else 0
+            var result = if (presenceMask[0]) this.i.hashCode() else 0
             return result
         }
 
@@ -6394,7 +6394,7 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = (largeOneof?.oneOfHashCode() ?: 0)
+        var result = (this.largeOneof?.oneOfHashCode() ?: 0)
         return result
     }
 
@@ -8895,7 +8895,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Int32.isNotEmpty()) {
-        __result += mapInt32Int32.entries.sumOf { kEntry ->
+        __result += this.mapInt32Int32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32Int32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8905,7 +8905,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt64Int64.isNotEmpty()) {
-        __result += mapInt64Int64.entries.sumOf { kEntry ->
+        __result += this.mapInt64Int64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt64Int64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8915,7 +8915,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapUint32Uint32.isNotEmpty()) {
-        __result += mapUint32Uint32.entries.sumOf { kEntry ->
+        __result += this.mapUint32Uint32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapUint32Uint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8925,7 +8925,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapUint64Uint64.isNotEmpty()) {
-        __result += mapUint64Uint64.entries.sumOf { kEntry ->
+        __result += this.mapUint64Uint64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapUint64Uint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8935,7 +8935,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSint32Sint32.isNotEmpty()) {
-        __result += mapSint32Sint32.entries.sumOf { kEntry ->
+        __result += this.mapSint32Sint32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSint32Sint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8945,7 +8945,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSint64Sint64.isNotEmpty()) {
-        __result += mapSint64Sint64.entries.sumOf { kEntry ->
+        __result += this.mapSint64Sint64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSint64Sint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8955,7 +8955,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapFixed32Fixed32.isNotEmpty()) {
-        __result += mapFixed32Fixed32.entries.sumOf { kEntry ->
+        __result += this.mapFixed32Fixed32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapFixed32Fixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8965,7 +8965,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapFixed64Fixed64.isNotEmpty()) {
-        __result += mapFixed64Fixed64.entries.sumOf { kEntry ->
+        __result += this.mapFixed64Fixed64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapFixed64Fixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8975,7 +8975,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed32Sfixed32.isNotEmpty()) {
-        __result += mapSfixed32Sfixed32.entries.sumOf { kEntry ->
+        __result += this.mapSfixed32Sfixed32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSfixed32Sfixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8985,7 +8985,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed64Sfixed64.isNotEmpty()) {
-        __result += mapSfixed64Sfixed64.entries.sumOf { kEntry ->
+        __result += this.mapSfixed64Sfixed64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSfixed64Sfixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8995,7 +8995,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Bool.isNotEmpty()) {
-        __result += mapInt32Bool.entries.sumOf { kEntry ->
+        __result += this.mapInt32Bool.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32BoolEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9005,7 +9005,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Float.isNotEmpty()) {
-        __result += mapInt32Float.entries.sumOf { kEntry ->
+        __result += this.mapInt32Float.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32FloatEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9015,7 +9015,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Double.isNotEmpty()) {
-        __result += mapInt32Double.entries.sumOf { kEntry ->
+        __result += this.mapInt32Double.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32DoubleEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9025,7 +9025,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32NestedMessage.isNotEmpty()) {
-        __result += mapInt32NestedMessage.entries.sumOf { kEntry ->
+        __result += this.mapInt32NestedMessage.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9035,7 +9035,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapBoolBool.isNotEmpty()) {
-        __result += mapBoolBool.entries.sumOf { kEntry ->
+        __result += this.mapBoolBool.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapBoolBoolEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9045,7 +9045,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringString.isNotEmpty()) {
-        __result += mapStringString.entries.sumOf { kEntry ->
+        __result += this.mapStringString.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringStringEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9055,7 +9055,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringBytes.isNotEmpty()) {
-        __result += mapStringBytes.entries.sumOf { kEntry ->
+        __result += this.mapStringBytes.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringBytesEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9065,7 +9065,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedMessage.isNotEmpty()) {
-        __result += mapStringNestedMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedMessage.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9075,7 +9075,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignMessage.isNotEmpty()) {
-        __result += mapStringForeignMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignMessage.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9085,7 +9085,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedEnum.isNotEmpty()) {
-        __result += mapStringNestedEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedEnum.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringNestedEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9095,7 +9095,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignEnum.isNotEmpty()) {
-        __result += mapStringForeignEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignEnum.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringForeignEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto3/_rpc_internal/TestMessagesProto3Editions.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/editions/proto3/_rpc_internal/TestMessagesProto3Editions.kt
@@ -462,150 +462,150 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = optionalInt32.hashCode()
-        result = 31 * result + optionalInt64.hashCode()
-        result = 31 * result + optionalUint32.hashCode()
-        result = 31 * result + optionalUint64.hashCode()
-        result = 31 * result + optionalSint32.hashCode()
-        result = 31 * result + optionalSint64.hashCode()
-        result = 31 * result + optionalFixed32.hashCode()
-        result = 31 * result + optionalFixed64.hashCode()
-        result = 31 * result + optionalSfixed32.hashCode()
-        result = 31 * result + optionalSfixed64.hashCode()
-        result = 31 * result + optionalFloat.toBits().hashCode()
-        result = 31 * result + optionalDouble.toBits().hashCode()
-        result = 31 * result + optionalBool.hashCode()
-        result = 31 * result + optionalString.hashCode()
-        result = 31 * result + optionalBytes.hashCode()
-        result = 31 * result + if (presenceMask[0]) optionalNestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[1]) optionalForeignMessage.hashCode() else 0
-        result = 31 * result + optionalNestedEnum.hashCode()
-        result = 31 * result + optionalForeignEnum.hashCode()
-        result = 31 * result + optionalAliasedEnum.hashCode()
-        result = 31 * result + optionalStringPiece.hashCode()
-        result = 31 * result + optionalCord.hashCode()
-        result = 31 * result + if (presenceMask[2]) recursiveMessage.hashCode() else 0
-        result = 31 * result + repeatedInt32.hashCode()
-        result = 31 * result + repeatedInt64.hashCode()
-        result = 31 * result + repeatedUint32.hashCode()
-        result = 31 * result + repeatedUint64.hashCode()
-        result = 31 * result + repeatedSint32.hashCode()
-        result = 31 * result + repeatedSint64.hashCode()
-        result = 31 * result + repeatedFixed32.hashCode()
-        result = 31 * result + repeatedFixed64.hashCode()
-        result = 31 * result + repeatedSfixed32.hashCode()
-        result = 31 * result + repeatedSfixed64.hashCode()
-        result = 31 * result + repeatedFloat.hashCode()
-        result = 31 * result + repeatedDouble.hashCode()
-        result = 31 * result + repeatedBool.hashCode()
-        result = 31 * result + repeatedString.hashCode()
-        result = 31 * result + repeatedBytes.hashCode()
-        result = 31 * result + repeatedNestedMessage.hashCode()
-        result = 31 * result + repeatedForeignMessage.hashCode()
-        result = 31 * result + repeatedNestedEnum.hashCode()
-        result = 31 * result + repeatedForeignEnum.hashCode()
-        result = 31 * result + repeatedStringPiece.hashCode()
-        result = 31 * result + repeatedCord.hashCode()
-        result = 31 * result + packedInt32.hashCode()
-        result = 31 * result + packedInt64.hashCode()
-        result = 31 * result + packedUint32.hashCode()
-        result = 31 * result + packedUint64.hashCode()
-        result = 31 * result + packedSint32.hashCode()
-        result = 31 * result + packedSint64.hashCode()
-        result = 31 * result + packedFixed32.hashCode()
-        result = 31 * result + packedFixed64.hashCode()
-        result = 31 * result + packedSfixed32.hashCode()
-        result = 31 * result + packedSfixed64.hashCode()
-        result = 31 * result + packedFloat.hashCode()
-        result = 31 * result + packedDouble.hashCode()
-        result = 31 * result + packedBool.hashCode()
-        result = 31 * result + packedNestedEnum.hashCode()
-        result = 31 * result + unpackedInt32.hashCode()
-        result = 31 * result + unpackedInt64.hashCode()
-        result = 31 * result + unpackedUint32.hashCode()
-        result = 31 * result + unpackedUint64.hashCode()
-        result = 31 * result + unpackedSint32.hashCode()
-        result = 31 * result + unpackedSint64.hashCode()
-        result = 31 * result + unpackedFixed32.hashCode()
-        result = 31 * result + unpackedFixed64.hashCode()
-        result = 31 * result + unpackedSfixed32.hashCode()
-        result = 31 * result + unpackedSfixed64.hashCode()
-        result = 31 * result + unpackedFloat.hashCode()
-        result = 31 * result + unpackedDouble.hashCode()
-        result = 31 * result + unpackedBool.hashCode()
-        result = 31 * result + unpackedNestedEnum.hashCode()
-        result = 31 * result + mapInt32Int32.hashCode()
-        result = 31 * result + mapInt64Int64.hashCode()
-        result = 31 * result + mapUint32Uint32.hashCode()
-        result = 31 * result + mapUint64Uint64.hashCode()
-        result = 31 * result + mapSint32Sint32.hashCode()
-        result = 31 * result + mapSint64Sint64.hashCode()
-        result = 31 * result + mapFixed32Fixed32.hashCode()
-        result = 31 * result + mapFixed64Fixed64.hashCode()
-        result = 31 * result + mapSfixed32Sfixed32.hashCode()
-        result = 31 * result + mapSfixed64Sfixed64.hashCode()
-        result = 31 * result + mapInt32Float.hashCode()
-        result = 31 * result + mapInt32Double.hashCode()
-        result = 31 * result + mapBoolBool.hashCode()
-        result = 31 * result + mapStringString.hashCode()
-        result = 31 * result + mapStringBytes.hashCode()
-        result = 31 * result + mapStringNestedMessage.hashCode()
-        result = 31 * result + mapStringForeignMessage.hashCode()
-        result = 31 * result + mapStringNestedEnum.hashCode()
-        result = 31 * result + mapStringForeignEnum.hashCode()
-        result = 31 * result + if (presenceMask[3]) optionalBoolWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[4]) optionalInt32Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[5]) optionalInt64Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[6]) optionalUint32Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[7]) optionalUint64Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[8]) optionalFloatWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[9]) optionalDoubleWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[10]) optionalStringWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[11]) optionalBytesWrapper.hashCode() else 0
-        result = 31 * result + repeatedBoolWrapper.hashCode()
-        result = 31 * result + repeatedInt32Wrapper.hashCode()
-        result = 31 * result + repeatedInt64Wrapper.hashCode()
-        result = 31 * result + repeatedUint32Wrapper.hashCode()
-        result = 31 * result + repeatedUint64Wrapper.hashCode()
-        result = 31 * result + repeatedFloatWrapper.hashCode()
-        result = 31 * result + repeatedDoubleWrapper.hashCode()
-        result = 31 * result + repeatedStringWrapper.hashCode()
-        result = 31 * result + repeatedBytesWrapper.hashCode()
-        result = 31 * result + if (presenceMask[12]) optionalDuration.hashCode() else 0
-        result = 31 * result + if (presenceMask[13]) optionalTimestamp.hashCode() else 0
-        result = 31 * result + if (presenceMask[14]) optionalFieldMask.hashCode() else 0
-        result = 31 * result + if (presenceMask[15]) optionalStruct.hashCode() else 0
-        result = 31 * result + if (presenceMask[16]) optionalAny.hashCode() else 0
-        result = 31 * result + if (presenceMask[17]) optionalValue.hashCode() else 0
-        result = 31 * result + optionalNullValue.hashCode()
-        result = 31 * result + if (presenceMask[18]) optionalEmpty.hashCode() else 0
-        result = 31 * result + repeatedDuration.hashCode()
-        result = 31 * result + repeatedTimestamp.hashCode()
-        result = 31 * result + repeatedFieldmask.hashCode()
-        result = 31 * result + repeatedStruct.hashCode()
-        result = 31 * result + repeatedAny.hashCode()
-        result = 31 * result + repeatedValue.hashCode()
-        result = 31 * result + repeatedListValue.hashCode()
-        result = 31 * result + repeatedEmpty.hashCode()
-        result = 31 * result + fieldname1.hashCode()
-        result = 31 * result + fieldName2.hashCode()
-        result = 31 * result + FieldName3.hashCode()
-        result = 31 * result + field_Name4_.hashCode()
-        result = 31 * result + field0name5.hashCode()
-        result = 31 * result + field_0Name6.hashCode()
-        result = 31 * result + fieldName7.hashCode()
-        result = 31 * result + FieldName8.hashCode()
-        result = 31 * result + field_Name9.hashCode()
-        result = 31 * result + Field_Name10.hashCode()
-        result = 31 * result + FIELD_NAME11.hashCode()
-        result = 31 * result + FIELDName12.hashCode()
-        result = 31 * result + _FieldName13.hashCode()
-        result = 31 * result + __FieldName14.hashCode()
-        result = 31 * result + field_Name15.hashCode()
-        result = 31 * result + field__Name16.hashCode()
-        result = 31 * result + fieldName17__.hashCode()
-        result = 31 * result + FieldName18__.hashCode()
-        result = 31 * result + (oneofField?.oneOfHashCode() ?: 0)
+        var result = this.optionalInt32.hashCode()
+        result = 31 * result + this.optionalInt64.hashCode()
+        result = 31 * result + this.optionalUint32.hashCode()
+        result = 31 * result + this.optionalUint64.hashCode()
+        result = 31 * result + this.optionalSint32.hashCode()
+        result = 31 * result + this.optionalSint64.hashCode()
+        result = 31 * result + this.optionalFixed32.hashCode()
+        result = 31 * result + this.optionalFixed64.hashCode()
+        result = 31 * result + this.optionalSfixed32.hashCode()
+        result = 31 * result + this.optionalSfixed64.hashCode()
+        result = 31 * result + this.optionalFloat.toBits().hashCode()
+        result = 31 * result + this.optionalDouble.toBits().hashCode()
+        result = 31 * result + this.optionalBool.hashCode()
+        result = 31 * result + this.optionalString.hashCode()
+        result = 31 * result + this.optionalBytes.hashCode()
+        result = 31 * result + if (presenceMask[0]) this.optionalNestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[1]) this.optionalForeignMessage.hashCode() else 0
+        result = 31 * result + this.optionalNestedEnum.hashCode()
+        result = 31 * result + this.optionalForeignEnum.hashCode()
+        result = 31 * result + this.optionalAliasedEnum.hashCode()
+        result = 31 * result + this.optionalStringPiece.hashCode()
+        result = 31 * result + this.optionalCord.hashCode()
+        result = 31 * result + if (presenceMask[2]) this.recursiveMessage.hashCode() else 0
+        result = 31 * result + this.repeatedInt32.hashCode()
+        result = 31 * result + this.repeatedInt64.hashCode()
+        result = 31 * result + this.repeatedUint32.hashCode()
+        result = 31 * result + this.repeatedUint64.hashCode()
+        result = 31 * result + this.repeatedSint32.hashCode()
+        result = 31 * result + this.repeatedSint64.hashCode()
+        result = 31 * result + this.repeatedFixed32.hashCode()
+        result = 31 * result + this.repeatedFixed64.hashCode()
+        result = 31 * result + this.repeatedSfixed32.hashCode()
+        result = 31 * result + this.repeatedSfixed64.hashCode()
+        result = 31 * result + this.repeatedFloat.hashCode()
+        result = 31 * result + this.repeatedDouble.hashCode()
+        result = 31 * result + this.repeatedBool.hashCode()
+        result = 31 * result + this.repeatedString.hashCode()
+        result = 31 * result + this.repeatedBytes.hashCode()
+        result = 31 * result + this.repeatedNestedMessage.hashCode()
+        result = 31 * result + this.repeatedForeignMessage.hashCode()
+        result = 31 * result + this.repeatedNestedEnum.hashCode()
+        result = 31 * result + this.repeatedForeignEnum.hashCode()
+        result = 31 * result + this.repeatedStringPiece.hashCode()
+        result = 31 * result + this.repeatedCord.hashCode()
+        result = 31 * result + this.packedInt32.hashCode()
+        result = 31 * result + this.packedInt64.hashCode()
+        result = 31 * result + this.packedUint32.hashCode()
+        result = 31 * result + this.packedUint64.hashCode()
+        result = 31 * result + this.packedSint32.hashCode()
+        result = 31 * result + this.packedSint64.hashCode()
+        result = 31 * result + this.packedFixed32.hashCode()
+        result = 31 * result + this.packedFixed64.hashCode()
+        result = 31 * result + this.packedSfixed32.hashCode()
+        result = 31 * result + this.packedSfixed64.hashCode()
+        result = 31 * result + this.packedFloat.hashCode()
+        result = 31 * result + this.packedDouble.hashCode()
+        result = 31 * result + this.packedBool.hashCode()
+        result = 31 * result + this.packedNestedEnum.hashCode()
+        result = 31 * result + this.unpackedInt32.hashCode()
+        result = 31 * result + this.unpackedInt64.hashCode()
+        result = 31 * result + this.unpackedUint32.hashCode()
+        result = 31 * result + this.unpackedUint64.hashCode()
+        result = 31 * result + this.unpackedSint32.hashCode()
+        result = 31 * result + this.unpackedSint64.hashCode()
+        result = 31 * result + this.unpackedFixed32.hashCode()
+        result = 31 * result + this.unpackedFixed64.hashCode()
+        result = 31 * result + this.unpackedSfixed32.hashCode()
+        result = 31 * result + this.unpackedSfixed64.hashCode()
+        result = 31 * result + this.unpackedFloat.hashCode()
+        result = 31 * result + this.unpackedDouble.hashCode()
+        result = 31 * result + this.unpackedBool.hashCode()
+        result = 31 * result + this.unpackedNestedEnum.hashCode()
+        result = 31 * result + this.mapInt32Int32.hashCode()
+        result = 31 * result + this.mapInt64Int64.hashCode()
+        result = 31 * result + this.mapUint32Uint32.hashCode()
+        result = 31 * result + this.mapUint64Uint64.hashCode()
+        result = 31 * result + this.mapSint32Sint32.hashCode()
+        result = 31 * result + this.mapSint64Sint64.hashCode()
+        result = 31 * result + this.mapFixed32Fixed32.hashCode()
+        result = 31 * result + this.mapFixed64Fixed64.hashCode()
+        result = 31 * result + this.mapSfixed32Sfixed32.hashCode()
+        result = 31 * result + this.mapSfixed64Sfixed64.hashCode()
+        result = 31 * result + this.mapInt32Float.hashCode()
+        result = 31 * result + this.mapInt32Double.hashCode()
+        result = 31 * result + this.mapBoolBool.hashCode()
+        result = 31 * result + this.mapStringString.hashCode()
+        result = 31 * result + this.mapStringBytes.hashCode()
+        result = 31 * result + this.mapStringNestedMessage.hashCode()
+        result = 31 * result + this.mapStringForeignMessage.hashCode()
+        result = 31 * result + this.mapStringNestedEnum.hashCode()
+        result = 31 * result + this.mapStringForeignEnum.hashCode()
+        result = 31 * result + if (presenceMask[3]) this.optionalBoolWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[4]) this.optionalInt32Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[5]) this.optionalInt64Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[6]) this.optionalUint32Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[7]) this.optionalUint64Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[8]) this.optionalFloatWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[9]) this.optionalDoubleWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[10]) this.optionalStringWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[11]) this.optionalBytesWrapper.hashCode() else 0
+        result = 31 * result + this.repeatedBoolWrapper.hashCode()
+        result = 31 * result + this.repeatedInt32Wrapper.hashCode()
+        result = 31 * result + this.repeatedInt64Wrapper.hashCode()
+        result = 31 * result + this.repeatedUint32Wrapper.hashCode()
+        result = 31 * result + this.repeatedUint64Wrapper.hashCode()
+        result = 31 * result + this.repeatedFloatWrapper.hashCode()
+        result = 31 * result + this.repeatedDoubleWrapper.hashCode()
+        result = 31 * result + this.repeatedStringWrapper.hashCode()
+        result = 31 * result + this.repeatedBytesWrapper.hashCode()
+        result = 31 * result + if (presenceMask[12]) this.optionalDuration.hashCode() else 0
+        result = 31 * result + if (presenceMask[13]) this.optionalTimestamp.hashCode() else 0
+        result = 31 * result + if (presenceMask[14]) this.optionalFieldMask.hashCode() else 0
+        result = 31 * result + if (presenceMask[15]) this.optionalStruct.hashCode() else 0
+        result = 31 * result + if (presenceMask[16]) this.optionalAny.hashCode() else 0
+        result = 31 * result + if (presenceMask[17]) this.optionalValue.hashCode() else 0
+        result = 31 * result + this.optionalNullValue.hashCode()
+        result = 31 * result + if (presenceMask[18]) this.optionalEmpty.hashCode() else 0
+        result = 31 * result + this.repeatedDuration.hashCode()
+        result = 31 * result + this.repeatedTimestamp.hashCode()
+        result = 31 * result + this.repeatedFieldmask.hashCode()
+        result = 31 * result + this.repeatedStruct.hashCode()
+        result = 31 * result + this.repeatedAny.hashCode()
+        result = 31 * result + this.repeatedValue.hashCode()
+        result = 31 * result + this.repeatedListValue.hashCode()
+        result = 31 * result + this.repeatedEmpty.hashCode()
+        result = 31 * result + this.fieldname1.hashCode()
+        result = 31 * result + this.fieldName2.hashCode()
+        result = 31 * result + this.FieldName3.hashCode()
+        result = 31 * result + this.field_Name4_.hashCode()
+        result = 31 * result + this.field0name5.hashCode()
+        result = 31 * result + this.field_0Name6.hashCode()
+        result = 31 * result + this.fieldName7.hashCode()
+        result = 31 * result + this.FieldName8.hashCode()
+        result = 31 * result + this.field_Name9.hashCode()
+        result = 31 * result + this.Field_Name10.hashCode()
+        result = 31 * result + this.FIELD_NAME11.hashCode()
+        result = 31 * result + this.FIELDName12.hashCode()
+        result = 31 * result + this._FieldName13.hashCode()
+        result = 31 * result + this.__FieldName14.hashCode()
+        result = 31 * result + this.field_Name15.hashCode()
+        result = 31 * result + this.field__Name16.hashCode()
+        result = 31 * result + this.fieldName17__.hashCode()
+        result = 31 * result + this.FieldName18__.hashCode()
+        result = 31 * result + (this.oneofField?.oneOfHashCode() ?: 0)
         return result
     }
 
@@ -1328,8 +1328,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = a.hashCode()
-            result = 31 * result + if (presenceMask[0]) corecursive.hashCode() else 0
+            var result = this.a.hashCode()
+            result = 31 * result + if (presenceMask[0]) this.corecursive.hashCode() else 0
             return result
         }
 
@@ -1437,8 +1437,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1494,8 +1494,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1551,8 +1551,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1608,8 +1608,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1665,8 +1665,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1722,8 +1722,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1779,8 +1779,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1836,8 +1836,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1893,8 +1893,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1950,8 +1950,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2007,8 +2007,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.toBits().hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.toBits().hashCode()
             return result
         }
 
@@ -2064,8 +2064,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.toBits().hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.toBits().hashCode()
             return result
         }
 
@@ -2121,8 +2121,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2178,8 +2178,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2235,8 +2235,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2296,8 +2296,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + if (presenceMask[0]) value.hashCode() else 0
+            var result = this.key.hashCode()
+            result = 31 * result + if (presenceMask[0]) this.value.hashCode() else 0
             return result
         }
 
@@ -2363,8 +2363,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + if (presenceMask[0]) value.hashCode() else 0
+            var result = this.key.hashCode()
+            result = 31 * result + if (presenceMask[0]) this.value.hashCode() else 0
             return result
         }
 
@@ -2426,8 +2426,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2483,8 +2483,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2575,7 +2575,7 @@ class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWith
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = c.hashCode()
+        var result = this.c.hashCode()
         return result
     }
 
@@ -5045,7 +5045,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Int32.isNotEmpty()) {
-        __result += mapInt32Int32.entries.sumOf { kEntry ->
+        __result += this.mapInt32Int32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt32Int32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5055,7 +5055,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt64Int64.isNotEmpty()) {
-        __result += mapInt64Int64.entries.sumOf { kEntry ->
+        __result += this.mapInt64Int64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt64Int64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5065,7 +5065,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapUint32Uint32.isNotEmpty()) {
-        __result += mapUint32Uint32.entries.sumOf { kEntry ->
+        __result += this.mapUint32Uint32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapUint32Uint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5075,7 +5075,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapUint64Uint64.isNotEmpty()) {
-        __result += mapUint64Uint64.entries.sumOf { kEntry ->
+        __result += this.mapUint64Uint64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapUint64Uint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5085,7 +5085,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSint32Sint32.isNotEmpty()) {
-        __result += mapSint32Sint32.entries.sumOf { kEntry ->
+        __result += this.mapSint32Sint32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSint32Sint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5095,7 +5095,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSint64Sint64.isNotEmpty()) {
-        __result += mapSint64Sint64.entries.sumOf { kEntry ->
+        __result += this.mapSint64Sint64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSint64Sint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5105,7 +5105,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapFixed32Fixed32.isNotEmpty()) {
-        __result += mapFixed32Fixed32.entries.sumOf { kEntry ->
+        __result += this.mapFixed32Fixed32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapFixed32Fixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5115,7 +5115,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapFixed64Fixed64.isNotEmpty()) {
-        __result += mapFixed64Fixed64.entries.sumOf { kEntry ->
+        __result += this.mapFixed64Fixed64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapFixed64Fixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5125,7 +5125,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed32Sfixed32.isNotEmpty()) {
-        __result += mapSfixed32Sfixed32.entries.sumOf { kEntry ->
+        __result += this.mapSfixed32Sfixed32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSfixed32Sfixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5135,7 +5135,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed64Sfixed64.isNotEmpty()) {
-        __result += mapSfixed64Sfixed64.entries.sumOf { kEntry ->
+        __result += this.mapSfixed64Sfixed64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSfixed64Sfixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5145,7 +5145,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Float.isNotEmpty()) {
-        __result += mapInt32Float.entries.sumOf { kEntry ->
+        __result += this.mapInt32Float.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt32FloatEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5155,7 +5155,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Double.isNotEmpty()) {
-        __result += mapInt32Double.entries.sumOf { kEntry ->
+        __result += this.mapInt32Double.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt32DoubleEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5165,7 +5165,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapBoolBool.isNotEmpty()) {
-        __result += mapBoolBool.entries.sumOf { kEntry ->
+        __result += this.mapBoolBool.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapBoolBoolEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5175,7 +5175,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringString.isNotEmpty()) {
-        __result += mapStringString.entries.sumOf { kEntry ->
+        __result += this.mapStringString.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringStringEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5185,7 +5185,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringBytes.isNotEmpty()) {
-        __result += mapStringBytes.entries.sumOf { kEntry ->
+        __result += this.mapStringBytes.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringBytesEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5195,7 +5195,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedMessage.isNotEmpty()) {
-        __result += mapStringNestedMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedMessage.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5205,7 +5205,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignMessage.isNotEmpty()) {
-        __result += mapStringForeignMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignMessage.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5215,7 +5215,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedEnum.isNotEmpty()) {
-        __result += mapStringNestedEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedEnum.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringNestedEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5225,7 +5225,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignEnum.isNotEmpty()) {
-        __result += mapStringForeignEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignEnum.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringForeignEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto2/_rpc_internal/TestMessagesProto2.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto2/_rpc_internal/TestMessagesProto2.kt
@@ -516,135 +516,135 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (optionalInt32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (optionalInt64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[2]) (optionalUint32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[3]) (optionalUint64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[4]) (optionalSint32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[5]) (optionalSint64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[6]) (optionalFixed32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[7]) (optionalFixed64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[8]) (optionalSfixed32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[9]) (optionalSfixed64?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[10]) (optionalFloat?.toBits()?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[11]) (optionalDouble?.toBits()?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[12]) (optionalBool?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[13]) (optionalString?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[14]) (optionalBytes?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[15]) optionalNestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[16]) optionalForeignMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[17]) (optionalNestedEnum?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[18]) (optionalForeignEnum?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[19]) (optionalStringPiece?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[20]) (optionalCord?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[21]) recursiveMessage.hashCode() else 0
-        result = 31 * result + repeatedInt32.hashCode()
-        result = 31 * result + repeatedInt64.hashCode()
-        result = 31 * result + repeatedUint32.hashCode()
-        result = 31 * result + repeatedUint64.hashCode()
-        result = 31 * result + repeatedSint32.hashCode()
-        result = 31 * result + repeatedSint64.hashCode()
-        result = 31 * result + repeatedFixed32.hashCode()
-        result = 31 * result + repeatedFixed64.hashCode()
-        result = 31 * result + repeatedSfixed32.hashCode()
-        result = 31 * result + repeatedSfixed64.hashCode()
-        result = 31 * result + repeatedFloat.hashCode()
-        result = 31 * result + repeatedDouble.hashCode()
-        result = 31 * result + repeatedBool.hashCode()
-        result = 31 * result + repeatedString.hashCode()
-        result = 31 * result + repeatedBytes.hashCode()
-        result = 31 * result + repeatedNestedMessage.hashCode()
-        result = 31 * result + repeatedForeignMessage.hashCode()
-        result = 31 * result + repeatedNestedEnum.hashCode()
-        result = 31 * result + repeatedForeignEnum.hashCode()
-        result = 31 * result + repeatedStringPiece.hashCode()
-        result = 31 * result + repeatedCord.hashCode()
-        result = 31 * result + packedInt32.hashCode()
-        result = 31 * result + packedInt64.hashCode()
-        result = 31 * result + packedUint32.hashCode()
-        result = 31 * result + packedUint64.hashCode()
-        result = 31 * result + packedSint32.hashCode()
-        result = 31 * result + packedSint64.hashCode()
-        result = 31 * result + packedFixed32.hashCode()
-        result = 31 * result + packedFixed64.hashCode()
-        result = 31 * result + packedSfixed32.hashCode()
-        result = 31 * result + packedSfixed64.hashCode()
-        result = 31 * result + packedFloat.hashCode()
-        result = 31 * result + packedDouble.hashCode()
-        result = 31 * result + packedBool.hashCode()
-        result = 31 * result + packedNestedEnum.hashCode()
-        result = 31 * result + unpackedInt32.hashCode()
-        result = 31 * result + unpackedInt64.hashCode()
-        result = 31 * result + unpackedUint32.hashCode()
-        result = 31 * result + unpackedUint64.hashCode()
-        result = 31 * result + unpackedSint32.hashCode()
-        result = 31 * result + unpackedSint64.hashCode()
-        result = 31 * result + unpackedFixed32.hashCode()
-        result = 31 * result + unpackedFixed64.hashCode()
-        result = 31 * result + unpackedSfixed32.hashCode()
-        result = 31 * result + unpackedSfixed64.hashCode()
-        result = 31 * result + unpackedFloat.hashCode()
-        result = 31 * result + unpackedDouble.hashCode()
-        result = 31 * result + unpackedBool.hashCode()
-        result = 31 * result + unpackedNestedEnum.hashCode()
-        result = 31 * result + mapInt32Int32.hashCode()
-        result = 31 * result + mapInt64Int64.hashCode()
-        result = 31 * result + mapUint32Uint32.hashCode()
-        result = 31 * result + mapUint64Uint64.hashCode()
-        result = 31 * result + mapSint32Sint32.hashCode()
-        result = 31 * result + mapSint64Sint64.hashCode()
-        result = 31 * result + mapFixed32Fixed32.hashCode()
-        result = 31 * result + mapFixed64Fixed64.hashCode()
-        result = 31 * result + mapSfixed32Sfixed32.hashCode()
-        result = 31 * result + mapSfixed64Sfixed64.hashCode()
-        result = 31 * result + mapInt32Bool.hashCode()
-        result = 31 * result + mapInt32Float.hashCode()
-        result = 31 * result + mapInt32Double.hashCode()
-        result = 31 * result + mapInt32NestedMessage.hashCode()
-        result = 31 * result + mapBoolBool.hashCode()
-        result = 31 * result + mapStringString.hashCode()
-        result = 31 * result + mapStringBytes.hashCode()
-        result = 31 * result + mapStringNestedMessage.hashCode()
-        result = 31 * result + mapStringForeignMessage.hashCode()
-        result = 31 * result + mapStringNestedEnum.hashCode()
-        result = 31 * result + mapStringForeignEnum.hashCode()
-        result = 31 * result + if (presenceMask[22]) data.hashCode() else 0
-        result = 31 * result + if (presenceMask[23]) multiwordgroupfield.hashCode() else 0
-        result = 31 * result + if (presenceMask[24]) defaultInt32.hashCode() else 0
-        result = 31 * result + if (presenceMask[25]) defaultInt64.hashCode() else 0
-        result = 31 * result + if (presenceMask[26]) defaultUint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[27]) defaultUint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[28]) defaultSint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[29]) defaultSint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[30]) defaultFixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[31]) defaultFixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[32]) defaultSfixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[33]) defaultSfixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[34]) defaultFloat.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[35]) defaultDouble.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[36]) defaultBool.hashCode() else 0
-        result = 31 * result + if (presenceMask[37]) defaultString.hashCode() else 0
-        result = 31 * result + if (presenceMask[38]) defaultBytes.hashCode() else 0
-        result = 31 * result + if (presenceMask[39]) (fieldname1?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[40]) (fieldName2?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[41]) (FieldName3?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[42]) (field_Name4_?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[43]) (field0name5?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[44]) (field_0Name6?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[45]) (fieldName7?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[46]) (FieldName8?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[47]) (field_Name9?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[48]) (Field_Name10?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[49]) (FIELD_NAME11?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[50]) (FIELDName12?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[51]) (_FieldName13?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[52]) (__FieldName14?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[53]) (field_Name15?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[54]) (field__Name16?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[55]) (fieldName17__?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[56]) (FieldName18__?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[57]) messageSetCorrect.hashCode() else 0
-        result = 31 * result + (oneofField?.oneOfHashCode() ?: 0)
+        var result = if (presenceMask[0]) (this.optionalInt32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.optionalInt64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[2]) (this.optionalUint32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[3]) (this.optionalUint64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[4]) (this.optionalSint32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[5]) (this.optionalSint64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[6]) (this.optionalFixed32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[7]) (this.optionalFixed64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[8]) (this.optionalSfixed32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[9]) (this.optionalSfixed64?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[10]) (this.optionalFloat?.toBits()?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[11]) (this.optionalDouble?.toBits()?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[12]) (this.optionalBool?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[13]) (this.optionalString?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[14]) (this.optionalBytes?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[15]) this.optionalNestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[16]) this.optionalForeignMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[17]) (this.optionalNestedEnum?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[18]) (this.optionalForeignEnum?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[19]) (this.optionalStringPiece?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[20]) (this.optionalCord?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[21]) this.recursiveMessage.hashCode() else 0
+        result = 31 * result + this.repeatedInt32.hashCode()
+        result = 31 * result + this.repeatedInt64.hashCode()
+        result = 31 * result + this.repeatedUint32.hashCode()
+        result = 31 * result + this.repeatedUint64.hashCode()
+        result = 31 * result + this.repeatedSint32.hashCode()
+        result = 31 * result + this.repeatedSint64.hashCode()
+        result = 31 * result + this.repeatedFixed32.hashCode()
+        result = 31 * result + this.repeatedFixed64.hashCode()
+        result = 31 * result + this.repeatedSfixed32.hashCode()
+        result = 31 * result + this.repeatedSfixed64.hashCode()
+        result = 31 * result + this.repeatedFloat.hashCode()
+        result = 31 * result + this.repeatedDouble.hashCode()
+        result = 31 * result + this.repeatedBool.hashCode()
+        result = 31 * result + this.repeatedString.hashCode()
+        result = 31 * result + this.repeatedBytes.hashCode()
+        result = 31 * result + this.repeatedNestedMessage.hashCode()
+        result = 31 * result + this.repeatedForeignMessage.hashCode()
+        result = 31 * result + this.repeatedNestedEnum.hashCode()
+        result = 31 * result + this.repeatedForeignEnum.hashCode()
+        result = 31 * result + this.repeatedStringPiece.hashCode()
+        result = 31 * result + this.repeatedCord.hashCode()
+        result = 31 * result + this.packedInt32.hashCode()
+        result = 31 * result + this.packedInt64.hashCode()
+        result = 31 * result + this.packedUint32.hashCode()
+        result = 31 * result + this.packedUint64.hashCode()
+        result = 31 * result + this.packedSint32.hashCode()
+        result = 31 * result + this.packedSint64.hashCode()
+        result = 31 * result + this.packedFixed32.hashCode()
+        result = 31 * result + this.packedFixed64.hashCode()
+        result = 31 * result + this.packedSfixed32.hashCode()
+        result = 31 * result + this.packedSfixed64.hashCode()
+        result = 31 * result + this.packedFloat.hashCode()
+        result = 31 * result + this.packedDouble.hashCode()
+        result = 31 * result + this.packedBool.hashCode()
+        result = 31 * result + this.packedNestedEnum.hashCode()
+        result = 31 * result + this.unpackedInt32.hashCode()
+        result = 31 * result + this.unpackedInt64.hashCode()
+        result = 31 * result + this.unpackedUint32.hashCode()
+        result = 31 * result + this.unpackedUint64.hashCode()
+        result = 31 * result + this.unpackedSint32.hashCode()
+        result = 31 * result + this.unpackedSint64.hashCode()
+        result = 31 * result + this.unpackedFixed32.hashCode()
+        result = 31 * result + this.unpackedFixed64.hashCode()
+        result = 31 * result + this.unpackedSfixed32.hashCode()
+        result = 31 * result + this.unpackedSfixed64.hashCode()
+        result = 31 * result + this.unpackedFloat.hashCode()
+        result = 31 * result + this.unpackedDouble.hashCode()
+        result = 31 * result + this.unpackedBool.hashCode()
+        result = 31 * result + this.unpackedNestedEnum.hashCode()
+        result = 31 * result + this.mapInt32Int32.hashCode()
+        result = 31 * result + this.mapInt64Int64.hashCode()
+        result = 31 * result + this.mapUint32Uint32.hashCode()
+        result = 31 * result + this.mapUint64Uint64.hashCode()
+        result = 31 * result + this.mapSint32Sint32.hashCode()
+        result = 31 * result + this.mapSint64Sint64.hashCode()
+        result = 31 * result + this.mapFixed32Fixed32.hashCode()
+        result = 31 * result + this.mapFixed64Fixed64.hashCode()
+        result = 31 * result + this.mapSfixed32Sfixed32.hashCode()
+        result = 31 * result + this.mapSfixed64Sfixed64.hashCode()
+        result = 31 * result + this.mapInt32Bool.hashCode()
+        result = 31 * result + this.mapInt32Float.hashCode()
+        result = 31 * result + this.mapInt32Double.hashCode()
+        result = 31 * result + this.mapInt32NestedMessage.hashCode()
+        result = 31 * result + this.mapBoolBool.hashCode()
+        result = 31 * result + this.mapStringString.hashCode()
+        result = 31 * result + this.mapStringBytes.hashCode()
+        result = 31 * result + this.mapStringNestedMessage.hashCode()
+        result = 31 * result + this.mapStringForeignMessage.hashCode()
+        result = 31 * result + this.mapStringNestedEnum.hashCode()
+        result = 31 * result + this.mapStringForeignEnum.hashCode()
+        result = 31 * result + if (presenceMask[22]) this.data.hashCode() else 0
+        result = 31 * result + if (presenceMask[23]) this.multiwordgroupfield.hashCode() else 0
+        result = 31 * result + if (presenceMask[24]) this.defaultInt32.hashCode() else 0
+        result = 31 * result + if (presenceMask[25]) this.defaultInt64.hashCode() else 0
+        result = 31 * result + if (presenceMask[26]) this.defaultUint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[27]) this.defaultUint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[28]) this.defaultSint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[29]) this.defaultSint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[30]) this.defaultFixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[31]) this.defaultFixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[32]) this.defaultSfixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[33]) this.defaultSfixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[34]) this.defaultFloat.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[35]) this.defaultDouble.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[36]) this.defaultBool.hashCode() else 0
+        result = 31 * result + if (presenceMask[37]) this.defaultString.hashCode() else 0
+        result = 31 * result + if (presenceMask[38]) this.defaultBytes.hashCode() else 0
+        result = 31 * result + if (presenceMask[39]) (this.fieldname1?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[40]) (this.fieldName2?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[41]) (this.FieldName3?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[42]) (this.field_Name4_?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[43]) (this.field0name5?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[44]) (this.field_0Name6?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[45]) (this.fieldName7?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[46]) (this.FieldName8?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[47]) (this.field_Name9?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[48]) (this.Field_Name10?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[49]) (this.FIELD_NAME11?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[50]) (this.FIELDName12?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[51]) (this._FieldName13?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[52]) (this.__FieldName14?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[53]) (this.field_Name15?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[54]) (this.field__Name16?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[55]) (this.fieldName17__?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[56]) (this.FieldName18__?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[57]) this.messageSetCorrect.hashCode() else 0
+        result = 31 * result + (this.oneofField?.oneOfHashCode() ?: 0)
         result = 31 * result + extensionsHashCode()
         return result
     }
@@ -1636,8 +1636,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (a?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) corecursive.hashCode() else 0
+            var result = if (presenceMask[0]) (this.a?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) this.corecursive.hashCode() else 0
             return result
         }
 
@@ -1758,8 +1758,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1831,8 +1831,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1904,8 +1904,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -1977,8 +1977,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2050,8 +2050,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2123,8 +2123,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2196,8 +2196,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2269,8 +2269,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2342,8 +2342,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2415,8 +2415,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2488,8 +2488,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2561,8 +2561,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.toBits().hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.toBits().hashCode() else 0
             return result
         }
 
@@ -2634,8 +2634,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.toBits().hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.toBits().hashCode() else 0
             return result
         }
 
@@ -2707,8 +2707,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2780,8 +2780,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2853,8 +2853,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2926,8 +2926,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -2999,8 +2999,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3072,8 +3072,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3145,8 +3145,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3218,8 +3218,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) key.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) value.hashCode() else 0
+            var result = if (presenceMask[0]) this.key.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.value.hashCode() else 0
             return result
         }
 
@@ -3302,8 +3302,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (groupInt32?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) (groupUint32?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.groupInt32?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) (this.groupUint32?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3435,8 +3435,8 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (groupInt32?.hashCode() ?: 0) else 0
-            result = 31 * result + if (presenceMask[1]) (groupUint32?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.groupInt32?.hashCode() ?: 0) else 0
+            result = 31 * result + if (presenceMask[1]) (this.groupUint32?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3662,7 +3662,7 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (str?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.str?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3778,7 +3778,7 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (i?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.i?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -3880,7 +3880,7 @@ class TestAllTypesProto2Internal: TestAllTypesProto2.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = (oneofField?.oneOfHashCode() ?: 0)
+            var result = (this.oneofField?.oneOfHashCode() ?: 0)
             return result
         }
 
@@ -4038,7 +4038,7 @@ class ForeignMessageProto2Internal: ForeignMessageProto2.Builder, InternalMessag
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (c?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.c?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -4159,8 +4159,8 @@ class GroupFieldInternal: GroupField.Builder, InternalMessage(fieldsWithPresence
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (groupInt32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (groupUint32?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.groupInt32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.groupUint32?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -4309,12 +4309,12 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (optionalInt32?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (optionalString?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[2]) nestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[3]) optionalgroup.hashCode() else 0
-        result = 31 * result + if (presenceMask[4]) (optionalBool?.hashCode() ?: 0) else 0
-        result = 31 * result + repeatedInt32.hashCode()
+        var result = if (presenceMask[0]) (this.optionalInt32?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.optionalString?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[2]) this.nestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[3]) this.optionalgroup.hashCode() else 0
+        result = 31 * result + if (presenceMask[4]) (this.optionalBool?.hashCode() ?: 0) else 0
+        result = 31 * result + this.repeatedInt32.hashCode()
         return result
     }
 
@@ -4440,7 +4440,7 @@ class UnknownToTestAllTypesInternal: UnknownToTestAllTypes.Builder, InternalMess
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) (a?.hashCode() ?: 0) else 0
+            var result = if (presenceMask[0]) (this.a?.hashCode() ?: 0) else 0
             return result
         }
 
@@ -4769,7 +4769,7 @@ class OneStringProto2Internal: OneStringProto2.Builder, InternalMessage(fieldsWi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (data?.hashCode() ?: 0) else 0
+        var result = if (presenceMask[0]) (this.data?.hashCode() ?: 0) else 0
         return result
     }
 
@@ -4892,9 +4892,9 @@ class ProtoWithKeywordsInternal: ProtoWithKeywords.Builder, InternalMessage(fiel
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) (inline?.hashCode() ?: 0) else 0
-        result = 31 * result + if (presenceMask[1]) (concept?.hashCode() ?: 0) else 0
-        result = 31 * result + requires.hashCode()
+        var result = if (presenceMask[0]) (this.inline?.hashCode() ?: 0) else 0
+        result = 31 * result + if (presenceMask[1]) (this.concept?.hashCode() ?: 0) else 0
+        result = 31 * result + this.requires.hashCode()
         return result
     }
 
@@ -5218,45 +5218,45 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = if (presenceMask[0]) requiredInt32.hashCode() else 0
-        result = 31 * result + if (presenceMask[1]) requiredInt64.hashCode() else 0
-        result = 31 * result + if (presenceMask[2]) requiredUint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[3]) requiredUint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[4]) requiredSint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[5]) requiredSint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[6]) requiredFixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[7]) requiredFixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[8]) requiredSfixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[9]) requiredSfixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[10]) requiredFloat.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[11]) requiredDouble.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[12]) requiredBool.hashCode() else 0
-        result = 31 * result + if (presenceMask[13]) requiredString.hashCode() else 0
-        result = 31 * result + if (presenceMask[14]) requiredBytes.hashCode() else 0
-        result = 31 * result + if (presenceMask[15]) requiredNestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[16]) requiredForeignMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[17]) requiredNestedEnum.hashCode() else 0
-        result = 31 * result + if (presenceMask[18]) requiredForeignEnum.hashCode() else 0
-        result = 31 * result + if (presenceMask[19]) requiredStringPiece.hashCode() else 0
-        result = 31 * result + if (presenceMask[20]) requiredCord.hashCode() else 0
-        result = 31 * result + if (presenceMask[21]) recursiveMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[22]) optionalRecursiveMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[23]) data.hashCode() else 0
-        result = 31 * result + if (presenceMask[24]) defaultInt32.hashCode() else 0
-        result = 31 * result + if (presenceMask[25]) defaultInt64.hashCode() else 0
-        result = 31 * result + if (presenceMask[26]) defaultUint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[27]) defaultUint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[28]) defaultSint32.hashCode() else 0
-        result = 31 * result + if (presenceMask[29]) defaultSint64.hashCode() else 0
-        result = 31 * result + if (presenceMask[30]) defaultFixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[31]) defaultFixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[32]) defaultSfixed32.hashCode() else 0
-        result = 31 * result + if (presenceMask[33]) defaultSfixed64.hashCode() else 0
-        result = 31 * result + if (presenceMask[34]) defaultFloat.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[35]) defaultDouble.toBits().hashCode() else 0
-        result = 31 * result + if (presenceMask[36]) defaultBool.hashCode() else 0
-        result = 31 * result + if (presenceMask[37]) defaultString.hashCode() else 0
-        result = 31 * result + if (presenceMask[38]) defaultBytes.hashCode() else 0
+        var result = if (presenceMask[0]) this.requiredInt32.hashCode() else 0
+        result = 31 * result + if (presenceMask[1]) this.requiredInt64.hashCode() else 0
+        result = 31 * result + if (presenceMask[2]) this.requiredUint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[3]) this.requiredUint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[4]) this.requiredSint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[5]) this.requiredSint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[6]) this.requiredFixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[7]) this.requiredFixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[8]) this.requiredSfixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[9]) this.requiredSfixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[10]) this.requiredFloat.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[11]) this.requiredDouble.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[12]) this.requiredBool.hashCode() else 0
+        result = 31 * result + if (presenceMask[13]) this.requiredString.hashCode() else 0
+        result = 31 * result + if (presenceMask[14]) this.requiredBytes.hashCode() else 0
+        result = 31 * result + if (presenceMask[15]) this.requiredNestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[16]) this.requiredForeignMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[17]) this.requiredNestedEnum.hashCode() else 0
+        result = 31 * result + if (presenceMask[18]) this.requiredForeignEnum.hashCode() else 0
+        result = 31 * result + if (presenceMask[19]) this.requiredStringPiece.hashCode() else 0
+        result = 31 * result + if (presenceMask[20]) this.requiredCord.hashCode() else 0
+        result = 31 * result + if (presenceMask[21]) this.recursiveMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[22]) this.optionalRecursiveMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[23]) this.data.hashCode() else 0
+        result = 31 * result + if (presenceMask[24]) this.defaultInt32.hashCode() else 0
+        result = 31 * result + if (presenceMask[25]) this.defaultInt64.hashCode() else 0
+        result = 31 * result + if (presenceMask[26]) this.defaultUint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[27]) this.defaultUint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[28]) this.defaultSint32.hashCode() else 0
+        result = 31 * result + if (presenceMask[29]) this.defaultSint64.hashCode() else 0
+        result = 31 * result + if (presenceMask[30]) this.defaultFixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[31]) this.defaultFixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[32]) this.defaultSfixed32.hashCode() else 0
+        result = 31 * result + if (presenceMask[33]) this.defaultSfixed64.hashCode() else 0
+        result = 31 * result + if (presenceMask[34]) this.defaultFloat.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[35]) this.defaultDouble.toBits().hashCode() else 0
+        result = 31 * result + if (presenceMask[36]) this.defaultBool.hashCode() else 0
+        result = 31 * result + if (presenceMask[37]) this.defaultString.hashCode() else 0
+        result = 31 * result + if (presenceMask[38]) this.defaultBytes.hashCode() else 0
         result = 31 * result + extensionsHashCode()
         return result
     }
@@ -5767,9 +5767,9 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) a.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) corecursive.hashCode() else 0
-            result = 31 * result + if (presenceMask[2]) optionalCorecursive.hashCode() else 0
+            var result = if (presenceMask[0]) this.a.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.corecursive.hashCode() else 0
+            result = 31 * result + if (presenceMask[2]) this.optionalCorecursive.hashCode() else 0
             return result
         }
 
@@ -5912,8 +5912,8 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) groupInt32.hashCode() else 0
-            result = 31 * result + if (presenceMask[1]) groupUint32.hashCode() else 0
+            var result = if (presenceMask[0]) this.groupInt32.hashCode() else 0
+            result = 31 * result + if (presenceMask[1]) this.groupUint32.hashCode() else 0
             return result
         }
 
@@ -6139,7 +6139,7 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) str.hashCode() else 0
+            var result = if (presenceMask[0]) this.str.hashCode() else 0
             return result
         }
 
@@ -6255,7 +6255,7 @@ class TestAllRequiredTypesProto2Internal: TestAllRequiredTypesProto2.Builder, In
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = if (presenceMask[0]) i.hashCode() else 0
+            var result = if (presenceMask[0]) this.i.hashCode() else 0
             return result
         }
 
@@ -6394,7 +6394,7 @@ class TestLargeOneofInternal: TestLargeOneof.Builder, InternalMessage(fieldsWith
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = (largeOneof?.oneOfHashCode() ?: 0)
+        var result = (this.largeOneof?.oneOfHashCode() ?: 0)
         return result
     }
 
@@ -8895,7 +8895,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Int32.isNotEmpty()) {
-        __result += mapInt32Int32.entries.sumOf { kEntry ->
+        __result += this.mapInt32Int32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32Int32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8905,7 +8905,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt64Int64.isNotEmpty()) {
-        __result += mapInt64Int64.entries.sumOf { kEntry ->
+        __result += this.mapInt64Int64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt64Int64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8915,7 +8915,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapUint32Uint32.isNotEmpty()) {
-        __result += mapUint32Uint32.entries.sumOf { kEntry ->
+        __result += this.mapUint32Uint32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapUint32Uint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8925,7 +8925,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapUint64Uint64.isNotEmpty()) {
-        __result += mapUint64Uint64.entries.sumOf { kEntry ->
+        __result += this.mapUint64Uint64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapUint64Uint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8935,7 +8935,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSint32Sint32.isNotEmpty()) {
-        __result += mapSint32Sint32.entries.sumOf { kEntry ->
+        __result += this.mapSint32Sint32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSint32Sint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8945,7 +8945,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSint64Sint64.isNotEmpty()) {
-        __result += mapSint64Sint64.entries.sumOf { kEntry ->
+        __result += this.mapSint64Sint64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSint64Sint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8955,7 +8955,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapFixed32Fixed32.isNotEmpty()) {
-        __result += mapFixed32Fixed32.entries.sumOf { kEntry ->
+        __result += this.mapFixed32Fixed32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapFixed32Fixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8965,7 +8965,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapFixed64Fixed64.isNotEmpty()) {
-        __result += mapFixed64Fixed64.entries.sumOf { kEntry ->
+        __result += this.mapFixed64Fixed64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapFixed64Fixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8975,7 +8975,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed32Sfixed32.isNotEmpty()) {
-        __result += mapSfixed32Sfixed32.entries.sumOf { kEntry ->
+        __result += this.mapSfixed32Sfixed32.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSfixed32Sfixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8985,7 +8985,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed64Sfixed64.isNotEmpty()) {
-        __result += mapSfixed64Sfixed64.entries.sumOf { kEntry ->
+        __result += this.mapSfixed64Sfixed64.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapSfixed64Sfixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -8995,7 +8995,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Bool.isNotEmpty()) {
-        __result += mapInt32Bool.entries.sumOf { kEntry ->
+        __result += this.mapInt32Bool.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32BoolEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9005,7 +9005,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Float.isNotEmpty()) {
-        __result += mapInt32Float.entries.sumOf { kEntry ->
+        __result += this.mapInt32Float.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32FloatEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9015,7 +9015,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Double.isNotEmpty()) {
-        __result += mapInt32Double.entries.sumOf { kEntry ->
+        __result += this.mapInt32Double.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32DoubleEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9025,7 +9025,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapInt32NestedMessage.isNotEmpty()) {
-        __result += mapInt32NestedMessage.entries.sumOf { kEntry ->
+        __result += this.mapInt32NestedMessage.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapInt32NestedMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9035,7 +9035,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapBoolBool.isNotEmpty()) {
-        __result += mapBoolBool.entries.sumOf { kEntry ->
+        __result += this.mapBoolBool.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapBoolBoolEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9045,7 +9045,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringString.isNotEmpty()) {
-        __result += mapStringString.entries.sumOf { kEntry ->
+        __result += this.mapStringString.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringStringEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9055,7 +9055,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringBytes.isNotEmpty()) {
-        __result += mapStringBytes.entries.sumOf { kEntry ->
+        __result += this.mapStringBytes.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringBytesEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9065,7 +9065,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedMessage.isNotEmpty()) {
-        __result += mapStringNestedMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedMessage.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringNestedMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9075,7 +9075,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignMessage.isNotEmpty()) {
-        __result += mapStringForeignMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignMessage.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringForeignMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9085,7 +9085,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedEnum.isNotEmpty()) {
-        __result += mapStringNestedEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedEnum.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringNestedEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -9095,7 +9095,7 @@ private fun TestAllTypesProto2Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignEnum.isNotEmpty()) {
-        __result += mapStringForeignEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignEnum.entries.sumOf { kEntry ->
             TestAllTypesProto2Internal.MapStringForeignEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value

--- a/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto3/_rpc_internal/TestMessagesProto3.kt
+++ b/tests/protobuf-conformance/src/main/generated-code/kotlin-multiplatform/com/google/protobuf_test_messages/proto3/_rpc_internal/TestMessagesProto3.kt
@@ -462,150 +462,150 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = optionalInt32.hashCode()
-        result = 31 * result + optionalInt64.hashCode()
-        result = 31 * result + optionalUint32.hashCode()
-        result = 31 * result + optionalUint64.hashCode()
-        result = 31 * result + optionalSint32.hashCode()
-        result = 31 * result + optionalSint64.hashCode()
-        result = 31 * result + optionalFixed32.hashCode()
-        result = 31 * result + optionalFixed64.hashCode()
-        result = 31 * result + optionalSfixed32.hashCode()
-        result = 31 * result + optionalSfixed64.hashCode()
-        result = 31 * result + optionalFloat.toBits().hashCode()
-        result = 31 * result + optionalDouble.toBits().hashCode()
-        result = 31 * result + optionalBool.hashCode()
-        result = 31 * result + optionalString.hashCode()
-        result = 31 * result + optionalBytes.hashCode()
-        result = 31 * result + if (presenceMask[0]) optionalNestedMessage.hashCode() else 0
-        result = 31 * result + if (presenceMask[1]) optionalForeignMessage.hashCode() else 0
-        result = 31 * result + optionalNestedEnum.hashCode()
-        result = 31 * result + optionalForeignEnum.hashCode()
-        result = 31 * result + optionalAliasedEnum.hashCode()
-        result = 31 * result + optionalStringPiece.hashCode()
-        result = 31 * result + optionalCord.hashCode()
-        result = 31 * result + if (presenceMask[2]) recursiveMessage.hashCode() else 0
-        result = 31 * result + repeatedInt32.hashCode()
-        result = 31 * result + repeatedInt64.hashCode()
-        result = 31 * result + repeatedUint32.hashCode()
-        result = 31 * result + repeatedUint64.hashCode()
-        result = 31 * result + repeatedSint32.hashCode()
-        result = 31 * result + repeatedSint64.hashCode()
-        result = 31 * result + repeatedFixed32.hashCode()
-        result = 31 * result + repeatedFixed64.hashCode()
-        result = 31 * result + repeatedSfixed32.hashCode()
-        result = 31 * result + repeatedSfixed64.hashCode()
-        result = 31 * result + repeatedFloat.hashCode()
-        result = 31 * result + repeatedDouble.hashCode()
-        result = 31 * result + repeatedBool.hashCode()
-        result = 31 * result + repeatedString.hashCode()
-        result = 31 * result + repeatedBytes.hashCode()
-        result = 31 * result + repeatedNestedMessage.hashCode()
-        result = 31 * result + repeatedForeignMessage.hashCode()
-        result = 31 * result + repeatedNestedEnum.hashCode()
-        result = 31 * result + repeatedForeignEnum.hashCode()
-        result = 31 * result + repeatedStringPiece.hashCode()
-        result = 31 * result + repeatedCord.hashCode()
-        result = 31 * result + packedInt32.hashCode()
-        result = 31 * result + packedInt64.hashCode()
-        result = 31 * result + packedUint32.hashCode()
-        result = 31 * result + packedUint64.hashCode()
-        result = 31 * result + packedSint32.hashCode()
-        result = 31 * result + packedSint64.hashCode()
-        result = 31 * result + packedFixed32.hashCode()
-        result = 31 * result + packedFixed64.hashCode()
-        result = 31 * result + packedSfixed32.hashCode()
-        result = 31 * result + packedSfixed64.hashCode()
-        result = 31 * result + packedFloat.hashCode()
-        result = 31 * result + packedDouble.hashCode()
-        result = 31 * result + packedBool.hashCode()
-        result = 31 * result + packedNestedEnum.hashCode()
-        result = 31 * result + unpackedInt32.hashCode()
-        result = 31 * result + unpackedInt64.hashCode()
-        result = 31 * result + unpackedUint32.hashCode()
-        result = 31 * result + unpackedUint64.hashCode()
-        result = 31 * result + unpackedSint32.hashCode()
-        result = 31 * result + unpackedSint64.hashCode()
-        result = 31 * result + unpackedFixed32.hashCode()
-        result = 31 * result + unpackedFixed64.hashCode()
-        result = 31 * result + unpackedSfixed32.hashCode()
-        result = 31 * result + unpackedSfixed64.hashCode()
-        result = 31 * result + unpackedFloat.hashCode()
-        result = 31 * result + unpackedDouble.hashCode()
-        result = 31 * result + unpackedBool.hashCode()
-        result = 31 * result + unpackedNestedEnum.hashCode()
-        result = 31 * result + mapInt32Int32.hashCode()
-        result = 31 * result + mapInt64Int64.hashCode()
-        result = 31 * result + mapUint32Uint32.hashCode()
-        result = 31 * result + mapUint64Uint64.hashCode()
-        result = 31 * result + mapSint32Sint32.hashCode()
-        result = 31 * result + mapSint64Sint64.hashCode()
-        result = 31 * result + mapFixed32Fixed32.hashCode()
-        result = 31 * result + mapFixed64Fixed64.hashCode()
-        result = 31 * result + mapSfixed32Sfixed32.hashCode()
-        result = 31 * result + mapSfixed64Sfixed64.hashCode()
-        result = 31 * result + mapInt32Float.hashCode()
-        result = 31 * result + mapInt32Double.hashCode()
-        result = 31 * result + mapBoolBool.hashCode()
-        result = 31 * result + mapStringString.hashCode()
-        result = 31 * result + mapStringBytes.hashCode()
-        result = 31 * result + mapStringNestedMessage.hashCode()
-        result = 31 * result + mapStringForeignMessage.hashCode()
-        result = 31 * result + mapStringNestedEnum.hashCode()
-        result = 31 * result + mapStringForeignEnum.hashCode()
-        result = 31 * result + if (presenceMask[3]) optionalBoolWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[4]) optionalInt32Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[5]) optionalInt64Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[6]) optionalUint32Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[7]) optionalUint64Wrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[8]) optionalFloatWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[9]) optionalDoubleWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[10]) optionalStringWrapper.hashCode() else 0
-        result = 31 * result + if (presenceMask[11]) optionalBytesWrapper.hashCode() else 0
-        result = 31 * result + repeatedBoolWrapper.hashCode()
-        result = 31 * result + repeatedInt32Wrapper.hashCode()
-        result = 31 * result + repeatedInt64Wrapper.hashCode()
-        result = 31 * result + repeatedUint32Wrapper.hashCode()
-        result = 31 * result + repeatedUint64Wrapper.hashCode()
-        result = 31 * result + repeatedFloatWrapper.hashCode()
-        result = 31 * result + repeatedDoubleWrapper.hashCode()
-        result = 31 * result + repeatedStringWrapper.hashCode()
-        result = 31 * result + repeatedBytesWrapper.hashCode()
-        result = 31 * result + if (presenceMask[12]) optionalDuration.hashCode() else 0
-        result = 31 * result + if (presenceMask[13]) optionalTimestamp.hashCode() else 0
-        result = 31 * result + if (presenceMask[14]) optionalFieldMask.hashCode() else 0
-        result = 31 * result + if (presenceMask[15]) optionalStruct.hashCode() else 0
-        result = 31 * result + if (presenceMask[16]) optionalAny.hashCode() else 0
-        result = 31 * result + if (presenceMask[17]) optionalValue.hashCode() else 0
-        result = 31 * result + optionalNullValue.hashCode()
-        result = 31 * result + if (presenceMask[18]) optionalEmpty.hashCode() else 0
-        result = 31 * result + repeatedDuration.hashCode()
-        result = 31 * result + repeatedTimestamp.hashCode()
-        result = 31 * result + repeatedFieldmask.hashCode()
-        result = 31 * result + repeatedStruct.hashCode()
-        result = 31 * result + repeatedAny.hashCode()
-        result = 31 * result + repeatedValue.hashCode()
-        result = 31 * result + repeatedListValue.hashCode()
-        result = 31 * result + repeatedEmpty.hashCode()
-        result = 31 * result + fieldname1.hashCode()
-        result = 31 * result + fieldName2.hashCode()
-        result = 31 * result + FieldName3.hashCode()
-        result = 31 * result + field_Name4_.hashCode()
-        result = 31 * result + field0name5.hashCode()
-        result = 31 * result + field_0Name6.hashCode()
-        result = 31 * result + fieldName7.hashCode()
-        result = 31 * result + FieldName8.hashCode()
-        result = 31 * result + field_Name9.hashCode()
-        result = 31 * result + Field_Name10.hashCode()
-        result = 31 * result + FIELD_NAME11.hashCode()
-        result = 31 * result + FIELDName12.hashCode()
-        result = 31 * result + _FieldName13.hashCode()
-        result = 31 * result + __FieldName14.hashCode()
-        result = 31 * result + field_Name15.hashCode()
-        result = 31 * result + field__Name16.hashCode()
-        result = 31 * result + fieldName17__.hashCode()
-        result = 31 * result + FieldName18__.hashCode()
-        result = 31 * result + (oneofField?.oneOfHashCode() ?: 0)
+        var result = this.optionalInt32.hashCode()
+        result = 31 * result + this.optionalInt64.hashCode()
+        result = 31 * result + this.optionalUint32.hashCode()
+        result = 31 * result + this.optionalUint64.hashCode()
+        result = 31 * result + this.optionalSint32.hashCode()
+        result = 31 * result + this.optionalSint64.hashCode()
+        result = 31 * result + this.optionalFixed32.hashCode()
+        result = 31 * result + this.optionalFixed64.hashCode()
+        result = 31 * result + this.optionalSfixed32.hashCode()
+        result = 31 * result + this.optionalSfixed64.hashCode()
+        result = 31 * result + this.optionalFloat.toBits().hashCode()
+        result = 31 * result + this.optionalDouble.toBits().hashCode()
+        result = 31 * result + this.optionalBool.hashCode()
+        result = 31 * result + this.optionalString.hashCode()
+        result = 31 * result + this.optionalBytes.hashCode()
+        result = 31 * result + if (presenceMask[0]) this.optionalNestedMessage.hashCode() else 0
+        result = 31 * result + if (presenceMask[1]) this.optionalForeignMessage.hashCode() else 0
+        result = 31 * result + this.optionalNestedEnum.hashCode()
+        result = 31 * result + this.optionalForeignEnum.hashCode()
+        result = 31 * result + this.optionalAliasedEnum.hashCode()
+        result = 31 * result + this.optionalStringPiece.hashCode()
+        result = 31 * result + this.optionalCord.hashCode()
+        result = 31 * result + if (presenceMask[2]) this.recursiveMessage.hashCode() else 0
+        result = 31 * result + this.repeatedInt32.hashCode()
+        result = 31 * result + this.repeatedInt64.hashCode()
+        result = 31 * result + this.repeatedUint32.hashCode()
+        result = 31 * result + this.repeatedUint64.hashCode()
+        result = 31 * result + this.repeatedSint32.hashCode()
+        result = 31 * result + this.repeatedSint64.hashCode()
+        result = 31 * result + this.repeatedFixed32.hashCode()
+        result = 31 * result + this.repeatedFixed64.hashCode()
+        result = 31 * result + this.repeatedSfixed32.hashCode()
+        result = 31 * result + this.repeatedSfixed64.hashCode()
+        result = 31 * result + this.repeatedFloat.hashCode()
+        result = 31 * result + this.repeatedDouble.hashCode()
+        result = 31 * result + this.repeatedBool.hashCode()
+        result = 31 * result + this.repeatedString.hashCode()
+        result = 31 * result + this.repeatedBytes.hashCode()
+        result = 31 * result + this.repeatedNestedMessage.hashCode()
+        result = 31 * result + this.repeatedForeignMessage.hashCode()
+        result = 31 * result + this.repeatedNestedEnum.hashCode()
+        result = 31 * result + this.repeatedForeignEnum.hashCode()
+        result = 31 * result + this.repeatedStringPiece.hashCode()
+        result = 31 * result + this.repeatedCord.hashCode()
+        result = 31 * result + this.packedInt32.hashCode()
+        result = 31 * result + this.packedInt64.hashCode()
+        result = 31 * result + this.packedUint32.hashCode()
+        result = 31 * result + this.packedUint64.hashCode()
+        result = 31 * result + this.packedSint32.hashCode()
+        result = 31 * result + this.packedSint64.hashCode()
+        result = 31 * result + this.packedFixed32.hashCode()
+        result = 31 * result + this.packedFixed64.hashCode()
+        result = 31 * result + this.packedSfixed32.hashCode()
+        result = 31 * result + this.packedSfixed64.hashCode()
+        result = 31 * result + this.packedFloat.hashCode()
+        result = 31 * result + this.packedDouble.hashCode()
+        result = 31 * result + this.packedBool.hashCode()
+        result = 31 * result + this.packedNestedEnum.hashCode()
+        result = 31 * result + this.unpackedInt32.hashCode()
+        result = 31 * result + this.unpackedInt64.hashCode()
+        result = 31 * result + this.unpackedUint32.hashCode()
+        result = 31 * result + this.unpackedUint64.hashCode()
+        result = 31 * result + this.unpackedSint32.hashCode()
+        result = 31 * result + this.unpackedSint64.hashCode()
+        result = 31 * result + this.unpackedFixed32.hashCode()
+        result = 31 * result + this.unpackedFixed64.hashCode()
+        result = 31 * result + this.unpackedSfixed32.hashCode()
+        result = 31 * result + this.unpackedSfixed64.hashCode()
+        result = 31 * result + this.unpackedFloat.hashCode()
+        result = 31 * result + this.unpackedDouble.hashCode()
+        result = 31 * result + this.unpackedBool.hashCode()
+        result = 31 * result + this.unpackedNestedEnum.hashCode()
+        result = 31 * result + this.mapInt32Int32.hashCode()
+        result = 31 * result + this.mapInt64Int64.hashCode()
+        result = 31 * result + this.mapUint32Uint32.hashCode()
+        result = 31 * result + this.mapUint64Uint64.hashCode()
+        result = 31 * result + this.mapSint32Sint32.hashCode()
+        result = 31 * result + this.mapSint64Sint64.hashCode()
+        result = 31 * result + this.mapFixed32Fixed32.hashCode()
+        result = 31 * result + this.mapFixed64Fixed64.hashCode()
+        result = 31 * result + this.mapSfixed32Sfixed32.hashCode()
+        result = 31 * result + this.mapSfixed64Sfixed64.hashCode()
+        result = 31 * result + this.mapInt32Float.hashCode()
+        result = 31 * result + this.mapInt32Double.hashCode()
+        result = 31 * result + this.mapBoolBool.hashCode()
+        result = 31 * result + this.mapStringString.hashCode()
+        result = 31 * result + this.mapStringBytes.hashCode()
+        result = 31 * result + this.mapStringNestedMessage.hashCode()
+        result = 31 * result + this.mapStringForeignMessage.hashCode()
+        result = 31 * result + this.mapStringNestedEnum.hashCode()
+        result = 31 * result + this.mapStringForeignEnum.hashCode()
+        result = 31 * result + if (presenceMask[3]) this.optionalBoolWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[4]) this.optionalInt32Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[5]) this.optionalInt64Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[6]) this.optionalUint32Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[7]) this.optionalUint64Wrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[8]) this.optionalFloatWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[9]) this.optionalDoubleWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[10]) this.optionalStringWrapper.hashCode() else 0
+        result = 31 * result + if (presenceMask[11]) this.optionalBytesWrapper.hashCode() else 0
+        result = 31 * result + this.repeatedBoolWrapper.hashCode()
+        result = 31 * result + this.repeatedInt32Wrapper.hashCode()
+        result = 31 * result + this.repeatedInt64Wrapper.hashCode()
+        result = 31 * result + this.repeatedUint32Wrapper.hashCode()
+        result = 31 * result + this.repeatedUint64Wrapper.hashCode()
+        result = 31 * result + this.repeatedFloatWrapper.hashCode()
+        result = 31 * result + this.repeatedDoubleWrapper.hashCode()
+        result = 31 * result + this.repeatedStringWrapper.hashCode()
+        result = 31 * result + this.repeatedBytesWrapper.hashCode()
+        result = 31 * result + if (presenceMask[12]) this.optionalDuration.hashCode() else 0
+        result = 31 * result + if (presenceMask[13]) this.optionalTimestamp.hashCode() else 0
+        result = 31 * result + if (presenceMask[14]) this.optionalFieldMask.hashCode() else 0
+        result = 31 * result + if (presenceMask[15]) this.optionalStruct.hashCode() else 0
+        result = 31 * result + if (presenceMask[16]) this.optionalAny.hashCode() else 0
+        result = 31 * result + if (presenceMask[17]) this.optionalValue.hashCode() else 0
+        result = 31 * result + this.optionalNullValue.hashCode()
+        result = 31 * result + if (presenceMask[18]) this.optionalEmpty.hashCode() else 0
+        result = 31 * result + this.repeatedDuration.hashCode()
+        result = 31 * result + this.repeatedTimestamp.hashCode()
+        result = 31 * result + this.repeatedFieldmask.hashCode()
+        result = 31 * result + this.repeatedStruct.hashCode()
+        result = 31 * result + this.repeatedAny.hashCode()
+        result = 31 * result + this.repeatedValue.hashCode()
+        result = 31 * result + this.repeatedListValue.hashCode()
+        result = 31 * result + this.repeatedEmpty.hashCode()
+        result = 31 * result + this.fieldname1.hashCode()
+        result = 31 * result + this.fieldName2.hashCode()
+        result = 31 * result + this.FieldName3.hashCode()
+        result = 31 * result + this.field_Name4_.hashCode()
+        result = 31 * result + this.field0name5.hashCode()
+        result = 31 * result + this.field_0Name6.hashCode()
+        result = 31 * result + this.fieldName7.hashCode()
+        result = 31 * result + this.FieldName8.hashCode()
+        result = 31 * result + this.field_Name9.hashCode()
+        result = 31 * result + this.Field_Name10.hashCode()
+        result = 31 * result + this.FIELD_NAME11.hashCode()
+        result = 31 * result + this.FIELDName12.hashCode()
+        result = 31 * result + this._FieldName13.hashCode()
+        result = 31 * result + this.__FieldName14.hashCode()
+        result = 31 * result + this.field_Name15.hashCode()
+        result = 31 * result + this.field__Name16.hashCode()
+        result = 31 * result + this.fieldName17__.hashCode()
+        result = 31 * result + this.FieldName18__.hashCode()
+        result = 31 * result + (this.oneofField?.oneOfHashCode() ?: 0)
         return result
     }
 
@@ -1328,8 +1328,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = a.hashCode()
-            result = 31 * result + if (presenceMask[0]) corecursive.hashCode() else 0
+            var result = this.a.hashCode()
+            result = 31 * result + if (presenceMask[0]) this.corecursive.hashCode() else 0
             return result
         }
 
@@ -1437,8 +1437,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1494,8 +1494,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1551,8 +1551,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1608,8 +1608,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1665,8 +1665,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1722,8 +1722,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1779,8 +1779,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1836,8 +1836,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1893,8 +1893,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -1950,8 +1950,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2007,8 +2007,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.toBits().hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.toBits().hashCode()
             return result
         }
 
@@ -2064,8 +2064,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.toBits().hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.toBits().hashCode()
             return result
         }
 
@@ -2121,8 +2121,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2178,8 +2178,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2235,8 +2235,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2296,8 +2296,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + if (presenceMask[0]) value.hashCode() else 0
+            var result = this.key.hashCode()
+            result = 31 * result + if (presenceMask[0]) this.value.hashCode() else 0
             return result
         }
 
@@ -2363,8 +2363,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + if (presenceMask[0]) value.hashCode() else 0
+            var result = this.key.hashCode()
+            result = 31 * result + if (presenceMask[0]) this.value.hashCode() else 0
             return result
         }
 
@@ -2426,8 +2426,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2483,8 +2483,8 @@ class TestAllTypesProto3Internal: TestAllTypesProto3.Builder, InternalMessage(fi
 
         override fun hashCode(): Int {
             checkRequiredFields()
-            var result = key.hashCode()
-            result = 31 * result + value.hashCode()
+            var result = this.key.hashCode()
+            result = 31 * result + this.value.hashCode()
             return result
         }
 
@@ -2575,7 +2575,7 @@ class ForeignMessageInternal: ForeignMessage.Builder, InternalMessage(fieldsWith
 
     override fun hashCode(): Int {
         checkRequiredFields()
-        var result = c.hashCode()
+        var result = this.c.hashCode()
         return result
     }
 
@@ -5045,7 +5045,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Int32.isNotEmpty()) {
-        __result += mapInt32Int32.entries.sumOf { kEntry ->
+        __result += this.mapInt32Int32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt32Int32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5055,7 +5055,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt64Int64.isNotEmpty()) {
-        __result += mapInt64Int64.entries.sumOf { kEntry ->
+        __result += this.mapInt64Int64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt64Int64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5065,7 +5065,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapUint32Uint32.isNotEmpty()) {
-        __result += mapUint32Uint32.entries.sumOf { kEntry ->
+        __result += this.mapUint32Uint32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapUint32Uint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5075,7 +5075,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapUint64Uint64.isNotEmpty()) {
-        __result += mapUint64Uint64.entries.sumOf { kEntry ->
+        __result += this.mapUint64Uint64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapUint64Uint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5085,7 +5085,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSint32Sint32.isNotEmpty()) {
-        __result += mapSint32Sint32.entries.sumOf { kEntry ->
+        __result += this.mapSint32Sint32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSint32Sint32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5095,7 +5095,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSint64Sint64.isNotEmpty()) {
-        __result += mapSint64Sint64.entries.sumOf { kEntry ->
+        __result += this.mapSint64Sint64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSint64Sint64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5105,7 +5105,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapFixed32Fixed32.isNotEmpty()) {
-        __result += mapFixed32Fixed32.entries.sumOf { kEntry ->
+        __result += this.mapFixed32Fixed32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapFixed32Fixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5115,7 +5115,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapFixed64Fixed64.isNotEmpty()) {
-        __result += mapFixed64Fixed64.entries.sumOf { kEntry ->
+        __result += this.mapFixed64Fixed64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapFixed64Fixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5125,7 +5125,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed32Sfixed32.isNotEmpty()) {
-        __result += mapSfixed32Sfixed32.entries.sumOf { kEntry ->
+        __result += this.mapSfixed32Sfixed32.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSfixed32Sfixed32EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5135,7 +5135,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapSfixed64Sfixed64.isNotEmpty()) {
-        __result += mapSfixed64Sfixed64.entries.sumOf { kEntry ->
+        __result += this.mapSfixed64Sfixed64.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapSfixed64Sfixed64EntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5145,7 +5145,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Float.isNotEmpty()) {
-        __result += mapInt32Float.entries.sumOf { kEntry ->
+        __result += this.mapInt32Float.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt32FloatEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5155,7 +5155,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapInt32Double.isNotEmpty()) {
-        __result += mapInt32Double.entries.sumOf { kEntry ->
+        __result += this.mapInt32Double.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapInt32DoubleEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5165,7 +5165,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapBoolBool.isNotEmpty()) {
-        __result += mapBoolBool.entries.sumOf { kEntry ->
+        __result += this.mapBoolBool.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapBoolBoolEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5175,7 +5175,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringString.isNotEmpty()) {
-        __result += mapStringString.entries.sumOf { kEntry ->
+        __result += this.mapStringString.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringStringEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5185,7 +5185,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringBytes.isNotEmpty()) {
-        __result += mapStringBytes.entries.sumOf { kEntry ->
+        __result += this.mapStringBytes.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringBytesEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5195,7 +5195,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedMessage.isNotEmpty()) {
-        __result += mapStringNestedMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedMessage.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringNestedMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5205,7 +5205,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignMessage.isNotEmpty()) {
-        __result += mapStringForeignMessage.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignMessage.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringForeignMessageEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5215,7 +5215,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringNestedEnum.isNotEmpty()) {
-        __result += mapStringNestedEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringNestedEnum.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringNestedEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value
@@ -5225,7 +5225,7 @@ private fun TestAllTypesProto3Internal.computeSize(): Int {
     }
 
     if (this.mapStringForeignEnum.isNotEmpty()) {
-        __result += mapStringForeignEnum.entries.sumOf { kEntry ->
+        __result += this.mapStringForeignEnum.entries.sumOf { kEntry ->
             TestAllTypesProto3Internal.MapStringForeignEnumEntryInternal().apply {
                 key = kEntry.key
                 value = kEntry.value

--- a/tests/protobuf-unittest/src/main/proto/protobuf/kotlin/generator/evil_names_proto3.proto
+++ b/tests/protobuf-unittest/src/main/proto/protobuf/kotlin/generator/evil_names_proto3.proto
@@ -67,6 +67,9 @@ message EvilNamesProto3 {
   optional string a_b_notification = 37;
   optional string __DEPRECATED_Bar = 38;
   optional string not_DEPRECATED_foo = 39;
+  oneof result {
+    string result_field = 40;
+  };
 }
 
 message HardKeywordsAllTypesProto3 {

--- a/tests/protobuf-unittest/src/test/kotlin/protobuf/kotlin/generator/EvilNamesProto3Test.kt
+++ b/tests/protobuf-unittest/src/test/kotlin/protobuf/kotlin/generator/EvilNamesProto3Test.kt
@@ -104,6 +104,7 @@ class EvilNamesProto3Test {
             key = mapOf("k" to 1)
             map = mapOf(1 to "one")
             pairs = mapOf("p" to 2)
+            result = EvilNamesProto3.Result.ResultField("result")
         }
         assertEquals("val", msg.value)
         assertEquals(42L, msg.index)
@@ -115,6 +116,7 @@ class EvilNamesProto3Test {
         assertEquals(mapOf("k" to 1), msg.key)
         assertEquals(mapOf(1 to "one"), msg.map)
         assertEquals(mapOf("p" to 2), msg.pairs)
+        assertEquals(EvilNamesProto3.Result.ResultField("result"), msg.result)
     }
 
     // https://github.com/protocolbuffers/protobuf/blob/main/java/kotlin/src/test/kotlin/com/google/protobuf/Proto3Test.kt#testEvilNames


### PR DESCRIPTION
**Subsystem**
protoc-gen/Protobuf

**Problem Description**
Proto fields called `result` are shadowed by local `result` variable in the generated `hashOf` method. This is causes a wrong `hashOf` implementation and a compilation error in case of `oneof` fields.

**Solution**
Explicitly use the `this` receiver for field references in the generated `hashOf` method.

Closes #633 
