### PR TITLE
Work around native segfault in callables property dispatch

### DIFF
--- a/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/descriptor/GrpcServiceDescriptor.kt
+++ b/grpc/grpc-core/src/commonMain/kotlin/kotlinx/rpc/grpc/descriptor/GrpcServiceDescriptor.kt
@@ -21,5 +21,6 @@ public class GrpcServiceDelegate(
     private val methodDescriptorMap: Map<String, GrpcMethodDescriptor<*, *>>,
     public val serviceDescriptor: ServiceDescriptor,
 ) {
+    public val methodNames: Set<String> get() = methodDescriptorMap.keys
     public fun getMethodDescriptor(methodName: String): GrpcMethodDescriptor<*, *>? = methodDescriptorMap[methodName]
 }

--- a/grpc/grpc-server/src/commonMain/kotlin/kotlinx/rpc/grpc/server/internal/GrpcServerImpl.kt
+++ b/grpc/grpc-server/src/commonMain/kotlin/kotlinx/rpc/grpc/server/internal/GrpcServerImpl.kt
@@ -107,14 +107,17 @@ public class GrpcServerImpl internal constructor(
 
         val delegate = descriptor.delegate(messageMarshallerResolver, marshallerConfig)
 
-        val methods = descriptor.callables.values.map {
+        val methods = delegate.methodNames.map { methodName ->
+            val callable = descriptor.getCallable(methodName)
+                ?: error("No callable found for method $methodName")
+
             @Suppress("UNCHECKED_CAST")
-            val methodDescriptor = delegate.getMethodDescriptor(it.name)
+            val methodDescriptor = delegate.getMethodDescriptor(methodName)
                 as? GrpcMethodDescriptor<RequestType, ResponseType>
                 ?: error("Expected a gRPC method descriptor")
 
             // TODO: support per service and per method interceptors (KRPC-222)
-            it.toDefinitionOn(methodDescriptor, service, interceptors)
+            callable.toDefinitionOn(methodDescriptor, service, interceptors)
         }
 
         return serverServiceDefinition(delegate.serviceDescriptor, methods)


### PR DESCRIPTION
**Subsystem**
gRPC server, gRPC core

**Problem Description**
`descriptor.callables` segfaults on Kotlin/Native when consuming published kotlinx-rpc artifacts, making `GrpcServerImpl.registerService()` crash for any `@Grpc` service. See https://github.com/Kotlin/kotlinx-rpc/issues/663.

`descriptor.getCallable(name)`, which reads from the same backing field, works fine.

**Solution**
Avoid `descriptor.callables` in `GrpcServerImpl.getDefinition()` by iterating `delegate.methodNames` and using `descriptor.getCallable()` instead.

Adds `GrpcServiceDelegate.methodNames` to expose the method name set (the underlying `methodDescriptorMap` is private).
