### PR TITLE
Add CI polling scripts for fix-issue skill

### DIFF
--- a/.claude/skills/fix-issue/references/ci-polling.md
+++ b/.claude/skills/fix-issue/references/ci-polling.md
@@ -4,62 +4,48 @@ Concrete patterns for the two background subagents that monitor CI during Phase 
 
 ## GitHub Actions polling subagent
 
-The subagent should run a poll loop using `gh`:
+Run the polling script from the worktree root:
 
 ```bash
-# Wait for all GH Actions check runs to complete (poll every 90s, up to 30min)
-PR_NUMBER=<pr-number>
-for i in $(seq 1 20); do
-  STATUS=$(GH_TOKEN=$GH_TOKEN gh pr checks "$PR_NUMBER" \
-    --repo Kotlin/kotlinx-rpc --json name,state,conclusion \
-    --jq '[.[] | select(.state != "COMPLETED")] | length')
-  if [ "$STATUS" = "0" ]; then
-    echo "All GH Actions complete."
-    GH_TOKEN=$GH_TOKEN gh pr checks "$PR_NUMBER" --repo Kotlin/kotlinx-rpc
-    break
-  fi
-  echo "Iteration $i: $STATUS check(s) still running..."
-  sleep 90
-done
+GH_TOKEN=$GH_TOKEN .claude/skills/fix-issue/scripts/poll-gh-actions.sh <pr-number>
 ```
 
-Report: the full `gh pr checks` table on completion, highlighting any failures.
+The script polls every 90s for up to 30 minutes. Exit codes:
+- `0` — all checks passed
+- `1` — at least one check failed
+- `2` — timeout (some checks still running after 30min)
+
+Report: relay the script's structured report (check table + RESULT line).
+On failure, highlight which checks failed so the main agent can investigate.
 
 ## TeamCity polling subagent
 
-The subagent should trigger the required builds, collect their IDs, then poll:
+Trigger builds and poll from the worktree root:
 
 ```bash
-# 1. Trigger builds and capture IDs
-BUILD_ID=$(TEAMCITY_TOKEN=$TEAMCITY_AGENT_TOKEN teamcity run start <build-config> \
-  --branch <branch-name> --json | jq -r '.id')
-
-# 2. Poll each build (every 90s, up to 30min)
-for i in $(seq 1 20); do
-  STATUS=$(TEAMCITY_TOKEN=$TEAMCITY_AGENT_TOKEN teamcity run view "$BUILD_ID" \
-    --json=state,status | jq -r '.state')
-  if [ "$STATUS" = "finished" ]; then
-    echo "TC build $BUILD_ID finished."
-    TEAMCITY_TOKEN=$TEAMCITY_AGENT_TOKEN teamcity run view "$BUILD_ID"
-    break
-  fi
-  echo "Iteration $i: build $BUILD_ID state=$STATUS..."
-  sleep 90
-done
+TEAMCITY_AGENT_TOKEN=$TEAMCITY_AGENT_TOKEN \
+  .claude/skills/fix-issue/scripts/poll-tc-builds.sh <branch-name> <build-config-id> [<build-config-id> ...]
 ```
 
-For multiple TC builds, poll all IDs in the same loop — check each, exit when
-all are `finished`. On any failure, immediately run
-`TEAMCITY_TOKEN=$TEAMCITY_AGENT_TOKEN teamcity run log <build-id> --failed`
-and include the failure summary in the report.
+The script triggers all specified build configs, collects their IDs, then polls
+every 90s for up to 30 minutes. Exit codes:
+- `0` — all builds succeeded
+- `1` — at least one build failed (failure details included in output)
+- `2` — timeout (some builds still running after 30min)
+
+Report: relay the script's structured report (per-build status + RESULT line).
+On failure, the script automatically fetches `teamcity run log <id> --failed`
+output for each failed build — include this in the report.
 
 ## Polling guidelines
 
-- **Interval**: 90 seconds. CI builds typically take 5–20 minutes; polling faster
-  wastes API calls, polling slower delays feedback unnecessarily.
-- **Timeout**: 30 minutes (20 iterations × 90s). If a build hasn't completed by
-  then, report the current state and let the main agent decide whether to wait
-  longer or investigate.
-- **Report format**: Each subagent should return a structured summary —
-  build name/ID, final status (success/failure/timeout), duration, and for
-  failures the first few lines of the error.
+- **Interval**: 90 seconds (hardcoded in scripts). CI builds typically take
+  5–20 minutes; polling faster wastes API calls, polling slower delays feedback.
+- **Timeout**: 30 minutes (20 iterations x 90s). If a build hasn't completed by
+  then, the script reports the current state and exits with code 2. The main
+  agent decides whether to wait longer or investigate.
+- **Report format**: Each script outputs a structured summary — build name/ID,
+  final status (SUCCESS/FAILURE/TIMEOUT), and for failures the first lines of
+  the error. Subagents should relay this output verbatim.
+- **Token refresh**: If the GH Actions script gets a 401, regenerate `GH_TOKEN`
+  via `scripts/gh-app-token.sh` and re-run.

--- a/.claude/skills/fix-issue/references/ship-workflow.md
+++ b/.claude/skills/fix-issue/references/ship-workflow.md
@@ -58,9 +58,9 @@ if the change is trivial and local verifications covered it.
 **GH Actions**: Are run automatically.
 
 **Monitor both via subagents**: Spawn two background subagents — one for GitHub
-Actions, one for TeamCity. Each polls its CI system and reports back with
-pass/fail results. See `references/ci-polling.md` for concrete poll loops,
-auth token usage, interval/timeout guidelines, and expected report format.
+Actions, one for TeamCity. Each runs the corresponding polling script and reports
+back with pass/fail results. See `references/ci-polling.md` for script usage,
+auth token requirements, and expected report format.
 
 See Error Recovery in SKILL.md for handling canceled or failed builds.
 

--- a/.claude/skills/fix-issue/scripts/poll-gh-actions.sh
+++ b/.claude/skills/fix-issue/scripts/poll-gh-actions.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Polls GitHub Actions check runs for a PR until all complete or timeout.
+#
+# Usage: poll-gh-actions.sh <pr-number>
+#
+# Required env vars:
+#   GH_TOKEN  — GitHub App installation token (from gh-app-token.sh)
+#
+# Exits 0 if all checks pass, 1 if any fail, 2 on timeout.
+# Outputs a structured report to stdout.
+
+set -euo pipefail
+
+REPO="Kotlin/kotlinx-rpc"
+INTERVAL=90      # seconds between polls
+MAX_ITERATIONS=20 # 20 × 90s = 30min
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <pr-number>" >&2
+  exit 1
+fi
+
+PR_NUMBER="$1"
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is not set" >&2
+  exit 1
+fi
+
+echo "Polling GH Actions for PR #$PR_NUMBER (every ${INTERVAL}s, max ${MAX_ITERATIONS} iterations)..."
+
+for i in $(seq 1 "$MAX_ITERATIONS"); do
+  CHECKS_JSON=$(GH_TOKEN="$GH_TOKEN" gh pr checks "$PR_NUMBER" \
+    --repo "$REPO" --json name,state,bucket 2>&1) || {
+    echo "ERROR: gh pr checks failed: $CHECKS_JSON" >&2
+    exit 1
+  }
+
+  # PENDING = still running; everything else (SUCCESS, FAILURE, SKIPPED, etc.) = done
+  PENDING=$(echo "$CHECKS_JSON" | python3 -c "
+import sys, json
+checks = json.load(sys.stdin)
+print(len([c for c in checks if c.get('state') == 'PENDING']))
+" 2>/dev/null)
+
+  if [ "$PENDING" = "0" ]; then
+    echo ""
+    echo "== GH Actions Report (PR #$PR_NUMBER) =="
+    echo ""
+
+    # Full table for readability
+    GH_TOKEN="$GH_TOKEN" gh pr checks "$PR_NUMBER" --repo "$REPO"
+    echo ""
+
+    # Check for failures via the bucket field (fail/pass/skipping/pending)
+    FAILURES=$(echo "$CHECKS_JSON" | python3 -c "
+import sys, json
+checks = json.load(sys.stdin)
+failed = [c['name'] for c in checks if c.get('bucket') == 'fail']
+for f in failed:
+    print(f'  - {f}')
+" 2>/dev/null)
+
+    if [ -n "$FAILURES" ]; then
+      echo "RESULT: FAILURE"
+      echo "Failed checks:"
+      echo "$FAILURES"
+      exit 1
+    else
+      echo "RESULT: SUCCESS"
+      echo "All checks passed."
+      exit 0
+    fi
+  fi
+
+  echo "[$i/$MAX_ITERATIONS] $PENDING check(s) still running..."
+  sleep "$INTERVAL"
+done
+
+echo ""
+echo "== GH Actions Report (PR #$PR_NUMBER) =="
+echo "RESULT: TIMEOUT (${MAX_ITERATIONS} iterations, $((MAX_ITERATIONS * INTERVAL))s elapsed)"
+echo ""
+echo "Current state:"
+GH_TOKEN="$GH_TOKEN" gh pr checks "$PR_NUMBER" --repo "$REPO"
+exit 2

--- a/.claude/skills/fix-issue/scripts/poll-tc-builds.sh
+++ b/.claude/skills/fix-issue/scripts/poll-tc-builds.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Triggers TeamCity builds and polls until all complete or timeout.
+#
+# Usage: poll-tc-builds.sh <branch-name> <build-config-id> [<build-config-id> ...]
+#
+# Required env vars:
+#   TEAMCITY_AGENT_TOKEN  — TeamCity token for the AI Agent
+#
+# Exits 0 if all builds succeed, 1 if any fail, 2 on timeout.
+# Outputs a structured report to stdout.
+
+set -euo pipefail
+
+INTERVAL=90      # seconds between polls
+MAX_ITERATIONS=20 # 20 × 90s = 30min
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <branch-name> <build-config-id> [<build-config-id> ...]" >&2
+  exit 1
+fi
+
+if [ -z "${TEAMCITY_AGENT_TOKEN:-}" ]; then
+  echo "ERROR: TEAMCITY_AGENT_TOKEN is not set" >&2
+  exit 1
+fi
+
+export TEAMCITY_TOKEN="$TEAMCITY_AGENT_TOKEN"
+
+BRANCH="$1"
+shift
+
+# Parallel arrays: BUILD_CONFIGS[i] <-> BUILD_IDS[i]
+BUILD_CONFIGS=()
+BUILD_IDS=()
+
+# ── Trigger all builds ─────────────────────────────────────────────
+echo "Triggering $# build(s) on branch '$BRANCH'..."
+
+for CONFIG in "$@"; do
+  BUILD_CONFIGS+=("$CONFIG")
+
+  OUTPUT=$(teamcity run start "$CONFIG" --branch "$BRANCH" --json 2>&1) || {
+    echo "ERROR: Failed to trigger $CONFIG: $OUTPUT" >&2
+    exit 1
+  }
+
+  # Extract build ID from JSON output
+  BUILD_ID=$(echo "$OUTPUT" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('id', ''))
+" 2>/dev/null)
+
+  if [ -z "$BUILD_ID" ]; then
+    echo "ERROR: Could not extract build ID for $CONFIG from output" >&2
+    echo "$OUTPUT" >&2
+    exit 1
+  fi
+
+  BUILD_IDS+=("$BUILD_ID")
+  echo "  Triggered $CONFIG -> build #$BUILD_ID"
+done
+
+NUM_BUILDS=${#BUILD_IDS[@]}
+echo ""
+echo "Polling $NUM_BUILDS build(s) (every ${INTERVAL}s, max ${MAX_ITERATIONS} iterations)..."
+
+# ── Helper: get a JSON field from a build ──────────────────────────
+get_field() {
+  local bid="$1"
+  local field="$2"
+  teamcity run view "$bid" --json 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('$field','unknown'))" 2>/dev/null \
+    || echo "unknown"
+}
+
+# ── Poll loop ──────────────────────────────────────────────────────
+for i in $(seq 1 "$MAX_ITERATIONS"); do
+  STILL_RUNNING=0
+
+  for idx in $(seq 0 $((NUM_BUILDS - 1))); do
+    STATE=$(get_field "${BUILD_IDS[$idx]}" "state")
+    if [ "$STATE" != "finished" ]; then
+      STILL_RUNNING=$((STILL_RUNNING + 1))
+    fi
+  done
+
+  if [ "$STILL_RUNNING" -eq 0 ]; then
+    break
+  fi
+
+  echo "[$i/$MAX_ITERATIONS] $STILL_RUNNING build(s) still running..."
+  sleep "$INTERVAL"
+done
+
+# ── Report ─────────────────────────────────────────────────────────
+echo ""
+echo "== TeamCity Report (branch: $BRANCH) =="
+echo ""
+
+HAS_FAILURE=false
+HAS_TIMEOUT=false
+
+for idx in $(seq 0 $((NUM_BUILDS - 1))); do
+  CONFIG="${BUILD_CONFIGS[$idx]}"
+  BUILD_ID="${BUILD_IDS[$idx]}"
+  STATE=$(get_field "$BUILD_ID" "state")
+  STATUS=$(get_field "$BUILD_ID" "status")
+
+  if [ "$STATE" != "finished" ]; then
+    echo "  $CONFIG (#$BUILD_ID): TIMEOUT (state=$STATE)"
+    HAS_TIMEOUT=true
+  elif echo "$STATUS" | grep -qi "failure"; then
+    echo "  $CONFIG (#$BUILD_ID): FAILURE"
+    HAS_FAILURE=true
+
+    # Fetch failure details
+    echo "  Failure details:"
+    teamcity run log "$BUILD_ID" --failed 2>&1 | head -30 | sed 's/^/    /'
+    echo ""
+  else
+    echo "  $CONFIG (#$BUILD_ID): SUCCESS"
+  fi
+done
+
+echo ""
+
+if [ "$HAS_FAILURE" = true ]; then
+  echo "RESULT: FAILURE"
+  exit 1
+elif [ "$HAS_TIMEOUT" = true ]; then
+  echo "RESULT: TIMEOUT"
+  exit 2
+else
+  echo "RESULT: SUCCESS"
+  echo "All builds passed."
+  exit 0
+fi


### PR DESCRIPTION
Replace inline bash snippets in ci-polling.md with actual shell scripts that subagents execute directly. Both scripts handle triggering, polling, structured reporting, and proper exit codes.
