### PR TITLE
KRPC-584: Skip testClientCancellationCancelsStream on wasmWasi (flaky)

### DIFF
--- a/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/cancellation/CancellationTest.kt
+++ b/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/cancellation/CancellationTest.kt
@@ -414,6 +414,11 @@ class CancellationTest {
 
     @Test
     fun testClientCancellationCancelsStream() = runCancellationTest {
+        // KRPC-584: flaky on wasmWasi/node due to WASI non-blocking I/O during concurrent close + flow teardown
+        if (platform == Platform.WASI) {
+            return@runCancellationTest
+        }
+
         val fence = CompletableDeferred<Unit>()
         launch {
             service.outgoingStream(resumableFlow(fence))


### PR DESCRIPTION
### Subsystem

krpc-test

### Problem

YouTrack: [KRPC-584](https://youtrack.jetbrains.com/issue/KRPC-584)

### Solution

Skip `CancellationTest.testClientCancellationCancelsStream` on the WASI platform using the same `if (platform == Platform.WASI) return@runCancellationTest` pattern already used by four other tests in `CancellationTest.kt` (most directly mirroring the KRPC-568 fix for `testCancelServer`, which addresses the same class of WASI runtime flakiness).

The narrower `Platform.WASI`-only guard (rather than `isJs() || Platform.WASI` used by three other tests) is intentional and matches the test's structural similarity to `testCancelServer` — the failure is WASI-specific and has not been observed on wasmJs. An inline comment was added to record this rationale.

---

> [!NOTE]
> Fully autonomous AI-generated PR — no human reviewed the code before submission.
> Problem analysis and root cause details: [KRPC-584](https://youtrack.jetbrains.com/issue/KRPC-584)