### PR TITLE
Remove 2.1 Kotlin support and add 2.4 to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Kotlin Experimental](https://kotl.in/badges/experimental.svg)](https://kotlinlang.org/docs/components-stability.html)
 [![Official JetBrains project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
-[![Kotlin](https://img.shields.io/badge/kotlin-2.2.0--2.3.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.2.0--2.4.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 
 [//]: # ([![TeamCity build]&#40;https://img.shields.io/teamcity/build/s/Build_kRPC_All.svg?server=http%3A%2F%2Fkrpc.teamcity.com&#41;]&#40;https://teamcity.jetbrains.com/viewType.html?buildTypeId=Build_kRPC_All&guest=1&#41;)
@@ -107,7 +107,8 @@ To ensure that all IDE features of our compiler plugin work properly on IntelliJ
 ## Kotlin compatibility
 We support all stable Kotlin versions starting from 2.2.0:
 - 2.2.0, 2.2.10, 2.2.20, 2.2.21
-- 2.3.0
+- 2.3.0, 2.3.10, 2.3.20, 2.3.21
+- 2.4.0
 
 For a full compatibility checklist,
 see [Versions](https://kotlin.github.io/kotlinx-rpc/versions.html).
@@ -139,8 +140,8 @@ that will set up code generation in a project.
 Example of a setup in a project's `build.gradle.kts`:
 ```kotlin
 plugins {
-    kotlin("multiplatform") version "2.3.0"
-    kotlin("plugin.serialization") version "2.3.0"
+    kotlin("multiplatform") version "2.4.0"
+    kotlin("plugin.serialization") version "2.4.0"
     id("org.jetbrains.kotlinx.rpc.plugin") version "0.10.2"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Kotlin Experimental](https://kotl.in/badges/experimental.svg)](https://kotlinlang.org/docs/components-stability.html)
 [![Official JetBrains project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
-[![Kotlin](https://img.shields.io/badge/kotlin-2.1.0--2.3.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.2.0--2.3.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![GitHub License](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0)
 
 [//]: # ([![TeamCity build]&#40;https://img.shields.io/teamcity/build/s/Build_kRPC_All.svg?server=http%3A%2F%2Fkrpc.teamcity.com&#41;]&#40;https://teamcity.jetbrains.com/viewType.html?buildTypeId=Build_kRPC_All&guest=1&#41;)
@@ -105,8 +105,7 @@ To ensure that all IDE features of our compiler plugin work properly on IntelliJ
 [Kotlin External FIR Support](https://plugins.jetbrains.com/plugin/26480-kotlin-external-fir-support?noRedirect=true) plugin.
 
 ## Kotlin compatibility
-We support all stable Kotlin versions starting from 2.1.0:
-- 2.1.0, 2.1.10, 2.1.20, 2.1.21
+We support all stable Kotlin versions starting from 2.2.0:
 - 2.2.0, 2.2.10, 2.2.20, 2.2.21
 - 2.3.0
 

--- a/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/RpcIrProtoProcessorDelegate.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/RpcIrProtoProcessorDelegate.kt
@@ -8,28 +8,8 @@ import kotlinx.rpc.codegen.extension.RpcIrContext
 import kotlinx.rpc.codegen.extension.RpcIrProtoProcessor
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrClass
-//##csm RpcIrProtoProcessorDelegate.kt-import
-//##csm specific=[2.1.0...2.1.21]
-import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
-//##csm /specific
-//##csm default
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
-//##csm /default
-//##csm /RpcIrProtoProcessorDelegate.kt-import
 
-//##csm RpcIrProtoProcessorDelegate
-//##csm specific=[2.1.0...2.1.21]
-internal class RpcIrProtoProcessorDelegate(
-    val processor: RpcIrProtoProcessor,
-) : IrElementTransformer<RpcIrContext> {
-    override fun visitClass(declaration: IrClass, data: RpcIrContext): IrStatement {
-        processor.visitClass(declaration, data)
-
-        return super.visitClass(declaration, data)
-    }
-}
-//##csm /specific
-//##csm default
 internal class RpcIrProtoProcessorDelegate(
     val processor: RpcIrProtoProcessor,
 ) : IrTransformer<RpcIrContext>() {
@@ -39,5 +19,3 @@ internal class RpcIrProtoProcessorDelegate(
         return super.visitClass(declaration, data)
     }
 }
-//##csm /default
-//##csm /RpcIrProtoProcessorDelegate

--- a/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/RpcIrServiceProcessorDelegate.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/RpcIrServiceProcessorDelegate.kt
@@ -8,28 +8,8 @@ import kotlinx.rpc.codegen.extension.RpcIrContext
 import kotlinx.rpc.codegen.extension.RpcIrServiceProcessor
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrClass
-//##csm RpcIrServiceProcessorDelegate.kt-import
-//##csm specific=[2.1.0...2.1.21]
-import org.jetbrains.kotlin.ir.visitors.IrElementTransformer
-//##csm /specific
-//##csm default
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
-//##csm /default
-//##csm /RpcIrServiceProcessorDelegate.kt-import
 
-//##csm RpcIrServiceProcessorDelegate
-//##csm specific=[2.1.0...2.1.21]
-internal class RpcIrServiceProcessorDelegate(
-    val processor: RpcIrServiceProcessor,
-) : IrElementTransformer<RpcIrContext> {
-    override fun visitClass(declaration: IrClass, data: RpcIrContext): IrStatement {
-        processor.visitClass(declaration, data)
-
-        return super.visitClass(declaration, data)
-    }
-}
-//##csm /specific
-//##csm default
 internal class RpcIrServiceProcessorDelegate(
     val processor: RpcIrServiceProcessor,
 ) : IrTransformer<RpcIrContext>() {
@@ -39,5 +19,3 @@ internal class RpcIrServiceProcessorDelegate(
         return super.visitClass(declaration, data)
     }
 }
-//##csm /default
-//##csm /RpcIrServiceProcessorDelegate

--- a/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
@@ -5,74 +5,7 @@
 package kotlinx.rpc.codegen
 
 //##csm VersionSpecificApiImpl.kt-import
-//##csm specific=[2.1.0...2.1.10, 2.1.20-ij243-*]
-import kotlinx.rpc.codegen.extension.IrMemberAccessExpressionData
-import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfigurationKey
-import org.jetbrains.kotlin.descriptors.SourceElement
-import org.jetbrains.kotlin.ir.backend.js.utils.valueArguments
-import org.jetbrains.kotlin.ir.builders.declarations.IrFieldBuilder
-import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrCall
-import org.jetbrains.kotlin.ir.expressions.IrConst
-import org.jetbrains.kotlin.ir.expressions.IrConstKind
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
-import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
-import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
-import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
-import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
-import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
-import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.isNullable
-import org.jetbrains.kotlin.ir.util.copyTo
-import org.jetbrains.kotlin.name.CallableId
-import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.platform.isJs
-import org.jetbrains.kotlin.platform.isWasm
-import kotlin.reflect.KClass
-import kotlin.reflect.safeCast
-//##csm /specific
-//##csm specific=[2.1.11...2.1.21]
-import kotlinx.rpc.codegen.extension.IrMemberAccessExpressionData
-import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
-import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfigurationKey
-import org.jetbrains.kotlin.descriptors.SourceElement
-import org.jetbrains.kotlin.ir.builders.declarations.IrFieldBuilder
-import org.jetbrains.kotlin.ir.declarations.*
-import org.jetbrains.kotlin.ir.expressions.IrCall
-import org.jetbrains.kotlin.ir.expressions.IrConst
-import org.jetbrains.kotlin.ir.expressions.IrConstKind
-import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
-import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
-import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
-import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
-import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
-import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
-import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
-import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.util.copyTo
-import org.jetbrains.kotlin.ir.util.isNullable
-import org.jetbrains.kotlin.name.CallableId
-import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.platform.isJs
-import org.jetbrains.kotlin.platform.isWasm
-import kotlin.reflect.KClass
-import kotlin.reflect.safeCast
-//##csm /specific
-//##csm specific=[2.1.22...2.3.*]
+//##csm specific=[2.2.0...2.3.*]
 import kotlinx.rpc.codegen.extension.IrMemberAccessExpressionData
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -155,34 +88,11 @@ object VersionSpecificApiImpl : VersionSpecificApi {
             origin = value
         }
 
-    //##csm IrConstructor.parametersVS
-    //##csm specific=[2.1.0...2.1.10, 2.1.20-ij243-*]
-    override val IrConstructor.parametersVS: List<IrValueParameter>
-        get() = valueParameters
-
-    //##csm /specific
-    //##csm default
     override val IrConstructor.parametersVS: List<IrValueParameter>
         get() = parameters
-    //##csm /default
-    //##csm /IrConstructor.parametersVS
 
-    //##csm IrConstructorCall.argumentsVS
-    //##csm specific=[2.1.0...2.1.10, 2.1.20-ij243-*]
-    override val IrConstructorCall.argumentsVS: List<IrExpression?>
-        get() = valueArguments
-
-    //##csm /specific
-    //##csm specific=[2.1.11...2.1.21]
-    override val IrConstructorCall.argumentsVS: List<IrExpression?>
-        get() = arguments
-
-    //##csm /specific
-    //##csm default
     override val IrConstructorCall.argumentsVS: List<IrExpression?>
         get() = arguments.toList()
-    //##csm /default
-    //##csm /IrConstructorCall.argumentsVS
 
     override fun IrType.isNullableVS(): Boolean {
         return isNullable()
@@ -194,7 +104,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         name: String
     ): IrClassSymbol? {
         //##csm referenceBuiltInClass
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return context.referenceClass(
         //##csm /specific
         //##csm default
@@ -216,7 +126,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         from: IrFile,
     ): IrClassSymbol? {
         //##csm referenceClass
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return context.referenceClass(
         //##csm /specific
         //##csm default
@@ -237,7 +147,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         name: String,
     ): Collection<IrSimpleFunctionSymbol> {
         //##csm referenceBuiltinFunctions
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return context.referenceFunctions(
         //##csm /specific
         //##csm default
@@ -258,7 +168,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         from: IrFile,
     ): Collection<IrSimpleFunctionSymbol> {
         //##csm referenceFunctions
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return context.referenceFunctions(
         //##csm /specific
         //##csm default
@@ -280,7 +190,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
     //##csm default
     @OptIn(org.jetbrains.kotlin.config.MessageCollectorAccess::class)
     //##csm /default
-    //##csm specific=[2.1.0...2.4.19]
+    //##csm specific=[2.2.0...2.4.19]
     //##csm /specific
     //##csm /MessageCollectorAccess
     override val messageCollectorKeyVS: CompilerConfigurationKey<MessageCollector>
@@ -330,54 +240,19 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         )
     }
 
-    //##csm IrFunction.valueParametersVS
-    //##csm specific=[2.1.0...2.1.21]
-    override fun IrFunction.valueParametersVS(): List<IrValueParameter> {
-        return valueParameters
-    }
-
-    //##csm /specific
-    //##csm default
     override fun IrFunction.valueParametersVS(): List<IrValueParameter> {
         return parameters.filter { it.kind == IrParameterKind.Regular }
     }
-    //##csm /default
-    //##csm /IrFunction.valueParametersVS
 
     override var IrFunction.dispatchReceiverParameterVS: IrValueParameter?
         get() = dispatchReceiverParameter
         set(value) {
-            //##csm IrFunction.extensionReceiverParameterVS
-            //##csm specific=[2.1.0...2.1.21]
-            dispatchReceiverParameter = value
-            //##csm /specific
-            //##csm default
             if (value != null) {
                 parameters += value
             }
-            //##csm /default
-            //##csm /IrFunction.extensionReceiverParameterVS
         }
 
     override fun IrMemberAccessExpressionData.buildForVS(access: IrMemberAccessExpression<*>) {
-        //##csm IrMemberAccessExpressionData.buildFor
-        //##csm specific=[2.1.0...2.1.21]
-        if (dispatchReceiver != null) {
-            access.dispatchReceiver = dispatchReceiver
-        }
-
-        if (extensionReceiver != null) {
-            access.extensionReceiver = extensionReceiver
-        }
-        valueArguments.forEachIndexed { index, irExpression ->
-            access.putValueArgument(index, irExpression)
-        }
-
-        typeArguments.forEachIndexed { index, irType ->
-            access.putTypeArgument(index, irType)
-        }
-        //##csm /specific
-        //##csm default
         var offset = if (dispatchReceiver != null) {
             access.arguments[0] = dispatchReceiver
             1
@@ -399,8 +274,6 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         typeArguments.forEachIndexed { index, irType ->
             access.typeArguments[index] = irType
         }
-        //##csm /default
-        //##csm /IrMemberAccessExpressionData.buildFor
     }
 
     override fun IrAnnotationVS(
@@ -413,7 +286,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         constructorTypeArgumentsCount: Int,
     ): IrMemberAccessExpression<*> {
         //##csm IrAnnotationVS
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return IrConstructorCallImplVS(
             startOffset = startOffset,
             endOffset = endOffset,
@@ -437,7 +310,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
 
     override fun IrMutableAnnotationContainer.addAnnotationVS(annotation: IrMemberAccessExpression<*>) {
         //##csm addAnnotationVS
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         annotations += annotation as IrConstructorCallImpl
         //##csm /specific
         //##csm default
@@ -452,7 +325,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         annotation: IrMemberAccessExpression<*>,
     ) {
         //##csm addMetadataVisibleAnnotationVS
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         context.metadataDeclarationRegistrar.addMetadataVisibleAnnotationsToElement(
             declaration,
             listOf(annotation as IrConstructorCall),
@@ -468,14 +341,7 @@ object VersionSpecificApiImpl : VersionSpecificApi {
     }
 
     override fun IrConstructorCall.valueArgumentAtVS(index: Int): IrExpression? {
-        //##csm IrConstructorCall.valueArgumentAt
-        //##csm specific=[2.1.0...2.1.10]
-        return getValueArgument(index)
-        //##csm /specific
-        //##csm default
         return arguments.getOrNull(index)
-        //##csm /default
-        //##csm /IrConstructorCall.valueArgumentAt
     }
 
     override fun <T : Any> IrExpression.asConstValueVS(clazz: KClass<T>): T? {

--- a/compiler-plugin/compiler-plugin-cli/src/main/templates/kotlinx/rpc/codegen/CompilerPluginRegistrar.kt
+++ b/compiler-plugin/compiler-plugin-cli/src/main/templates/kotlinx/rpc/codegen/CompilerPluginRegistrar.kt
@@ -13,7 +13,7 @@ class RpcCompilerPlugin : CompilerPluginRegistrar() {
     override val supportsK2: Boolean = true
 
 //##csm RpcCompilerPlugin.pluginId
-//##csm specific=[2.1.0...2.2.99]
+//##csm specific=[2.2.0...2.2.99]
 //##csm /specific
 //##csm default
     override val pluginId: String = PLUGIN_ID

--- a/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/FirVersionSpecificApiImpl.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/FirVersionSpecificApiImpl.kt
@@ -5,37 +5,7 @@
 package kotlinx.rpc.codegen
 
 //##csm FirVersionSpecificApiImpl.kt-import
-//##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-import org.jetbrains.kotlin.KtFakeSourceElementKind
-import org.jetbrains.kotlin.KtSourceElement
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfigurationKey
-import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.analysis.checkers.toRegularClassSymbol
-import org.jetbrains.kotlin.fir.declarations.FirRegularClass
-import org.jetbrains.kotlin.fir.declarations.getBooleanArgument
-import org.jetbrains.kotlin.fir.declarations.getStringArgument
-import org.jetbrains.kotlin.fir.declarations.getKClassArgument
-import org.jetbrains.kotlin.fir.expressions.FirAnnotation
-import org.jetbrains.kotlin.fir.resolve.toClassSymbol
-import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
-import org.jetbrains.kotlin.fir.symbols.FirBasedSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
-import org.jetbrains.kotlin.fir.plugin.DeclarationBuildingContext
-import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
-import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirCallableSymbol
-import org.jetbrains.kotlin.fir.scopes.impl.declaredMemberScope
-import org.jetbrains.kotlin.fir.scopes.processAllCallables
-import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.ConeKotlinType
-import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
-import org.jetbrains.kotlin.fir.types.FirTypeRef
-import org.jetbrains.kotlin.name.ClassId
-import org.jetbrains.kotlin.name.Name
-//##csm /specific
-//##csm specific=[2.1.22...2.2.10]
+//##csm specific=[2.2.0...2.2.10]
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -132,8 +102,6 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
         return toClassSymbol(session)
     }
 
-    //##csm FirRegularClass.declarationsVS
-    //##csm default
     override fun FirRegularClassSymbol.declarationsVS(session: FirSession): List<FirBasedSymbol<*>> {
         val declarations = mutableListOf<FirBasedSymbol<*>>()
         processAllDeclarations(session) { symbol ->
@@ -141,15 +109,6 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
         }
         return declarations
     }
-
-    //##csm /default
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    @org.jetbrains.kotlin.fir.symbols.SymbolInternals
-    override fun FirRegularClassSymbol.declarationsVS(session: FirSession): List<FirBasedSymbol<*>> {
-        return fir.declarations.map { it.symbol }
-    }
-    //##csm /specific
-    //##csm /FirRegularClass.declarationsVS
 
     override val FirResolvedTypeRef.coneTypeVS: ConeKotlinType get() = coneType
 
@@ -165,7 +124,7 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
     //##csm default
     @OptIn(org.jetbrains.kotlin.config.MessageCollectorAccess::class)
     //##csm /default
-    //##csm specific=[2.1.0...2.4.19]
+    //##csm specific=[2.2.0...2.4.19]
     //##csm /specific
     //##csm /MessageCollectorAccess
     override val messageCollectorKey: CompilerConfigurationKey<MessageCollector>
@@ -179,15 +138,7 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
     }
 
     override fun FirSession.getRegularClassSymbolByClassIdVS(classId: ClassId): FirRegularClassSymbol? {
-        //##csm ConeKotlinType.toClassSymbolVS
-        //##csm default
         return getRegularClassSymbolByClassId(classId)
-        //##csm /default
-        //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-        // this is the same implementation as getRegularClassSymbolByClassId() in 2.1.22+
-        return symbolProvider.getClassLikeSymbolByClassId(classId) as? FirRegularClassSymbol
-        //##csm /specific
-        //##csm /ConeKotlinType.toClassSymbolVS
     }
 
     override fun FirAnnotation.getKClassArgumentVS(name: Name, session: FirSession): ConeKotlinType? {
@@ -195,7 +146,7 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
         //##csm default
         return getKClassArgument(name)
         //##csm /default
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return getKClassArgument(name, session)
         //##csm /specific
         //##csm /FirAnnotation.getKClassArgumentVS
@@ -206,7 +157,7 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
         //##csm default
         return getBooleanArgument(name)
         //##csm /default
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return getBooleanArgument(name, session)
         //##csm /specific
         //##csm /FirAnnotation.getBooleanArgumentVS
@@ -217,38 +168,21 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
         //##csm default
         return getStringArgument(name)
         //##csm /default
-        //##csm specific=[2.1.0...2.3.99]
+        //##csm specific=[2.2.0...2.3.99]
         return getStringArgument(name, session)
         //##csm /specific
         //##csm /FirAnnotation.getStringArgumentVS
     }
 
     override fun FirClassSymbol<*>.forAllCallablesVS(session: FirSession, body: (FirCallableSymbol<*>) -> Unit) {
-        //##csm FirClassSymbol.forAllCallables
-        //##csm default
         processAllDeclaredCallables(session) {
             body(it)
         }
-        //##csm /default
-        //##csm specific=[2.1.0...2.1.99, 2.2.0-ij251-*]
-        declaredMemberScope(session, null).processAllCallables {
-            body(it)
-        }
-        //##csm /specific
-        //##csm /FirClassSymbol.forAllCallables
     }
 
     override var DeclarationBuildingContext<*>.sourceVS: KtSourceElement?
-        //##csm ClassBuildingContext.sourceVS
-        //##csm default
         get() = source
         set(value) { source = value }
-        //##csm /default
-        //##csm specific=[2.1.0...2.1.99]
-        get() = null
-        set(_) {}
-        //##csm /specific
-        //##csm /ClassBuildingContext.sourceVS
 
 
     override fun pluginGeneratedElementKindVS(marker: Any?): KtFakeSourceElementKind {
@@ -259,7 +193,7 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
             else -> KtFakeSourceElementKind.PluginGenerated.Custom(marker)
         }
         //##csm /default
-        //##csm specific=[2.1.0...2.4.19]
+        //##csm specific=[2.2.0...2.4.19]
         return KtFakeSourceElementKind.PluginGenerated
         //##csm /specific
         //##csm /ClassBuildingContext.sourceVS

--- a/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/FirRpcCheckersVS.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/FirRpcCheckersVS.kt
@@ -22,170 +22,79 @@ import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
 class FirCheckedAnnotationFunctionCallCheckerVS(
     private val ctx: FirCheckersContext,
 ) : FirFunctionCallChecker(MppCheckerKind.Common) {
-    //##csm FirCheckedAnnotationFunctionCallCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(expression: FirFunctionCall, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirCheckedAnnotationFunctionCallChecker.check(ctx, expression, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(expression: FirFunctionCall) {
         FirCheckedAnnotationFunctionCallChecker.check(ctx, expression, context, reporter)
     }
-    //##csm /default
-    //##csm /FirCheckedAnnotationFunctionCallCheckerVS_context
 }
 
 class FirCheckedAnnotationTypeParameterCheckerVS(
     private val ctx: FirCheckersContext,
 ) : FirTypeParameterChecker(MppCheckerKind.Common) {
-    //##csm FirCheckedAnnotationTypeParameterCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirTypeParameter, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirCheckedAnnotationTypeParameterChecker.check(ctx, declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirTypeParameter) {
         FirCheckedAnnotationTypeParameterChecker.check(ctx, declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirCheckedAnnotationTypeParameterCheckerVS_context
 }
 
 class FirCheckedAnnotationFirClassCheckerVS(
     private val ctx: FirCheckersContext,
 ) : FirClassChecker(MppCheckerKind.Common) {
-    //##csm FirCheckedAnnotationFirClassCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirCheckedAnnotationFirClassChecker.check(ctx, declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirClass) {
         FirCheckedAnnotationFirClassChecker.check(ctx, declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirCheckedAnnotationFirClassCheckerVS_context
 }
 
 class FirCheckedAnnotationFirFunctionCheckerVS(
     private val ctx: FirCheckersContext,
 ) : FirFunctionChecker(MppCheckerKind.Common) {
-    //##csm FirCheckedAnnotationFirFunctionCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirFunction, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirCheckedAnnotationFirFunctionChecker.check(ctx, declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirFunction) {
         FirCheckedAnnotationFirFunctionChecker.check(ctx, declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirCheckedAnnotationFirFunctionCheckerVS_context
 }
 
 class FirRpcAnnotationCheckerVS : FirRegularClassChecker(MppCheckerKind.Common) {
-    //##csm FirRpcAnnotationCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirRpcAnnotationChecker.check(declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirRegularClass) {
         FirRpcAnnotationChecker.check(declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirRpcAnnotationCheckerVS_context
 }
 
 class FirRpcServiceDeclarationCheckerVS(
     private val ctx: FirCheckersContext,
 ) : FirRegularClassChecker(MppCheckerKind.Common) {
-    //##csm FirRpcServiceDeclarationCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirRpcServiceDeclarationChecker.check(ctx, declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirRegularClass) {
         FirRpcServiceDeclarationChecker.check(ctx, declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirRpcServiceDeclarationCheckerVS_context
 }
 
 class FirRpcStrictModeClassCheckerVS : FirRegularClassChecker(MppCheckerKind.Common) {
-    //##csm FirRpcStrictModeClassCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirRpcStrictModeClassChecker.check(declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirRegularClass) {
         FirRpcStrictModeClassChecker.check(declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirRpcStrictModeClassCheckerVS_context
 }
 
 class FirGrpcServiceDeclarationCheckerVS : FirRegularClassChecker(MppCheckerKind.Common) {
-    //##csm FirGrpcServiceDeclarationCheckerVS_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirGrpcServiceDeclarationChecker.check(declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirRegularClass) {
         FirGrpcServiceDeclarationChecker.check(declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirGrpcServiceDeclarationCheckerVS_context
 }
 
 class FirWithGrpcMarshallerDeclarationCheckerVS : FirRegularClassChecker(MppCheckerKind.Common) {
-    //##csm FirWithGrpcMarshallerDeclarationChecker_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirWithGrpcMarshallerDeclarationChecker.check(declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirRegularClass) {
         FirWithGrpcMarshallerDeclarationChecker.check(declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirWithGrpcMarshallerDeclarationChecker_context
 }
 
 class FirProtoMessageAnnotationCheckerVS : FirRegularClassChecker(MppCheckerKind.Common) {
-    //##csm FirWithGrpcMarshallerDeclarationChecker_context
-    //##csm specific=[2.1.0...2.1.21, 2.2.0-ij251-*]
-    override fun check(declaration: FirRegularClass, context: CheckerContext, reporter: DiagnosticReporter) {
-        FirProtoMessageAnnotationChecker.check(declaration, context, reporter)
-    }
-    //##csm /specific
-    //##csm default
     context(context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirRegularClass) {
         FirProtoMessageAnnotationChecker.check(declaration, context, reporter)
     }
-    //##csm /default
-    //##csm /FirWithGrpcMarshallerDeclarationChecker_context
 }
-

--- a/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/diagnostics/RpcKtDiagnosticFactoryToRendererMap.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/diagnostics/RpcKtDiagnosticFactoryToRendererMap.kt
@@ -11,7 +11,7 @@ fun RpcKtDiagnosticFactoryToRendererMap(
     init: (KtDiagnosticFactoryToRendererMap) -> Unit,
 ): Lazy<KtDiagnosticFactoryToRendererMap> {
     //##csm RpcKtDiagnosticFactoryToRendererMap
-    //##csm specific=[2.1.0...2.2.10]
+    //##csm specific=[2.2.0...2.2.10]
     return lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
         KtDiagnosticFactoryToRendererMap(name).also(init)
     }

--- a/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/diagnostics/RpcKtDiagnosticsContainer.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/checkers/diagnostics/RpcKtDiagnosticsContainer.kt
@@ -5,13 +5,13 @@
 package kotlinx.rpc.codegen.checkers.diagnostics
 
 //##csm RpcKtDiagnosticsContainer.kt-imports
-//##csm specific=[2.1.0...2.2.10]
+//##csm specific=[2.2.0...2.2.10]
 import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 //##csm /specific
 //##csm /RpcKtDiagnosticsContainer.kt-imports
 
 //##csm RpcKtDiagnosticsContainer
-//##csm specific=[2.1.0...2.2.10]
+//##csm specific=[2.2.0...2.2.10]
 abstract class RpcKtDiagnosticsContainer : RpcKtDiagnosticsContainerCore
 //##csm /specific
 //##csm default
@@ -29,7 +29,7 @@ abstract class RpcKtDiagnosticsContainer : KtDiagnosticsContainer(), RpcKtDiagno
 // Automatically done for later versions
 fun registerDiagnosticRendererFactories() {
 //##csm registerDiagnosticRendererFactories
-//##csm specific=[2.1.0...2.2.10]
+//##csm specific=[2.2.0...2.2.10]
     RootDiagnosticRendererFactory.registerFactory(FirRpcDiagnostics.getRendererFactoryVs())
     RootDiagnosticRendererFactory.registerFactory(FirRpcStrictModeDiagnostics.getRendererFactoryVs())
     RootDiagnosticRendererFactory.registerFactory(FirGrpcDiagnostics.getRendererFactoryVs())

--- a/docs/pages/kotlinx-rpc/topics/versions.topic
+++ b/docs/pages/kotlinx-rpc/topics/versions.topic
@@ -22,7 +22,6 @@
         the following versions of Kotlin are supported:
     </p>
     <list>
-        <li>2.1.0, 2.1.10, 2.1.20, 2.1.21</li>
         <li>2.2.0, 2.2.10, 2.2.20, 2.2.21</li>
         <li>2.3.0</li>
     </list>

--- a/docs/pages/kotlinx-rpc/topics/versions.topic
+++ b/docs/pages/kotlinx-rpc/topics/versions.topic
@@ -23,7 +23,8 @@
     </p>
     <list>
         <li>2.2.0, 2.2.10, 2.2.20, 2.2.21</li>
-        <li>2.3.0</li>
+        <li>2.3.0, 2.3.10, 2.3.20, 2.3.21</li>
+        <li>2.4.0</li>
     </list>
     <p>
         Our code generation will support these versions (See more on <a anchor="code-generation-artifacts">code

--- a/docs/pages/kotlinx-rpc/v.list
+++ b/docs/pages/kotlinx-rpc/v.list
@@ -15,5 +15,5 @@
 
     <!--  Library versions  -->
     <var name="kotlinx-rpc-version" value="0.10.2"/>
-    <var name="kotlin-version" value="2.3.20"/>
+    <var name="kotlin-version" value="2.4.0"/>
 </vars>

--- a/gradle-conventions/src/main/kotlin/conventions-jvm.gradle.kts
+++ b/gradle-conventions/src/main/kotlin/conventions-jvm.gradle.kts
@@ -24,7 +24,7 @@ if (project.name != "gradle-plugin") {
     configureJavaCompatibility(8)
 }
 
-configureKotlinCompatibility("2.1.0")
+configureKotlinCompatibility("2.2.0")
 
 kotlin {
     explicitApi()

--- a/gradle-plugin/src/test/kotlin/kotlinx/rpc/base/BaseTest.kt
+++ b/gradle-plugin/src/test/kotlin/kotlinx/rpc/base/BaseTest.kt
@@ -62,10 +62,11 @@ internal val VersionsEnv.isAgp9: Boolean
 private val DEFAULT_TEST_TIMEOUT: Duration = Duration.ofMinutes(5)
 
 private val GradleVersions = listOf(
-    VersionsEnv("9.3.1", "2.2.21", "9.1.0"),
+    VersionsEnv("9.5.1", "2.4.0", "9.1.1"),
+    VersionsEnv("9.3.1", "2.2.21", "9.1.1"),
     VersionsEnv("9.2.1", "2.2.21", "8.13.1"),
     VersionsEnv("8.14.1", "2.2.0", "8.10.0"),
-    VersionsEnv("8.8", "2.1.0", "8.4.0"),
+    VersionsEnv("8.8", "2.2.0", "8.4.0"),
 )
 
 internal fun BaseTest.runWithGradleVersions(

--- a/native-deps/bazel-support/toolchain/konan_llvm_bundles.json
+++ b/native-deps/bazel-support/toolchain/konan_llvm_bundles.json
@@ -1,16 +1,4 @@
 {
-  "2.1.0": {
-    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-63"
-  },
-  "2.1.10": {
-    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-63"
-  },
-  "2.1.20": {
-    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-63"
-  },
-  "2.1.21": {
-    "macos-aarch64": "llvm-16.0.0-aarch64-macos-essentials-65"
-  },
   "2.2.0": {
     "linux-x86_64": "llvm-19-x86_64-linux-essentials-100",
     "macos-aarch64": "llvm-19-aarch64-macos-essentials-74",
@@ -36,13 +24,28 @@
     "macos-aarch64": "llvm-19-aarch64-macos-essentials-79",
     "macos-x86_64": "llvm-19-x86_64-macos-essentials-75"
   },
-  "2.4.0-Beta1": {
-    "linux-x86_64": "llvm-21-x86_64-linux-essentials-114",
-    "macos-aarch64": "llvm-21-aarch64-macos-essentials-93",
-    "macos-x86_64": "llvm-21-x86_64-macos-essentials-81"
+  "2.3.10": {
+    "linux-x86_64": "llvm-19-x86_64-linux-essentials-103",
+    "macos-aarch64": "llvm-19-aarch64-macos-essentials-79",
+    "macos-x86_64": "llvm-19-x86_64-macos-essentials-75"
+  },
+  "2.3.20": {
+    "linux-x86_64": "llvm-19-x86_64-linux-essentials-109",
+    "macos-aarch64": "llvm-19-aarch64-macos-essentials-81",
+    "macos-x86_64": "llvm-19-x86_64-macos-essentials-77"
+  },
+  "2.3.21": {
+    "linux-x86_64": "llvm-19-x86_64-linux-essentials-109",
+    "macos-aarch64": "llvm-19-aarch64-macos-essentials-81",
+    "macos-x86_64": "llvm-19-x86_64-macos-essentials-77"
+  },
+  "2.4.0": {
+    "linux-x86_64": "llvm-21-x86_64-linux-essentials-116",
+    "macos-aarch64": "llvm-21-aarch64-macos-essentials-97",
+    "macos-x86_64": "llvm-21-x86_64-macos-essentials-83"
   },
   "_metadata": {
-    "generated_at": "2026-03-31T13:54:48Z",
+    "generated_at": "2026-06-10T12:39:47Z",
     "source": "https://raw.githubusercontent.com/JetBrains/kotlin/v<kotlin-version>/kotlin-native/gradle.properties",
     "supported_hosts": [
       "linux-x86_64",


### PR DESCRIPTION
**Subsystem**
Docs, Compiler Plugin

**Problem Description**
2.1 reached EOL for support when 2.4 came out, so we are dropping additional support for it in the compiler.
Meanwhile, we have already published 2.4 artifacts, but didn't update the doc, so we are doing that too.

**Solution**
Updating docs, cleanup

Fixes: KRPC-613
Fixes: KRPC-612