### PR TITLE
Use providers.gradleProperty for Gradle plugin property lookups

### DIFF
--- a/gradle-plugin/src/main/kotlin/kotlinx/rpc/RpcPluginConst.kt
+++ b/gradle-plugin/src/main/kotlin/kotlinx/rpc/RpcPluginConst.kt
@@ -35,12 +35,14 @@ internal object RpcPluginConst {
 
 internal val Project.isInternalDevelopment: Boolean
     get() {
-        return (properties.getOrDefault(INTERNAL_DEVELOPMENT_PROPERTY, null) as String?)
-            ?.toBoolean() ?: false
+        return providers.gradleProperty(INTERNAL_DEVELOPMENT_PROPERTY)
+            .map(String::toBoolean)
+            .getOrElse(false)
     }
 
 internal val Project.isProtocEnabled: Boolean
     get() {
-        return (properties.getOrDefault(PROTOC_ENABLED_PROPERTY, null) as String?)
-            ?.toBoolean() ?: false
+        return providers.gradleProperty(PROTOC_ENABLED_PROPERTY)
+            .map(String::toBoolean)
+            .getOrElse(false)
     }


### PR DESCRIPTION
## Problem

The Gradle plugin reads `kotlinx.rpc.plugin.internalDevelopment` and `kotlinx.rpc.protoc` through `Project.getProperties()`:

```kotlin
internal val Project.isInternalDevelopment: Boolean
    get() {
        return (properties.getOrDefault(INTERNAL_DEVELOPMENT_PROPERTY, null) as String?)
            ?.toBoolean() ?: false
    }
```

`Project.getProperties()` performs a dynamic lookup that falls through to parent projects. This has two consequences on recent Gradle:

- Gradle 9.6 deprecates implicit parent-project property lookup (scheduled for removal in Gradle 10, see gradle/gradle#37830).
- Under Isolated Projects, the access is reported as a configuration cache problem in **every subproject** that applies the plugin, once per plugin class. In our build, four affected subprojects produce 16 problems — currently the only violations standing between us and a clean Isolated Projects adoption:

```
- Plugin class 'kotlinx.rpc.CompilerPluginBackend': Project ':core:rpc' cannot dynamically look up a property in the parent project ':core'
- Plugin class 'kotlinx.rpc.CompilerPluginCli': Project ':core:rpc' cannot dynamically look up a property in the parent project ':core'
...
```

## Fix

Read both properties through `providers.gradleProperty`, which is configuration-cache- and Isolated-Projects-safe.

Both properties are only ever supplied via `gradle.properties` files (in this repository and in consumer builds), which `providers.gradleProperty` covers, so behavior is unchanged.