### PR TITLE
Fix compiler plugin compatibility with Kotlin 2.4.20

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/VersionSpecificApi.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/VersionSpecificApi.kt
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.name.Name
 import kotlin.reflect.KClass
 
 interface VersionSpecificApi {
@@ -121,6 +122,8 @@ interface VersionSpecificApi {
     fun IrMemberAccessExpressionData.buildForVS(access: IrMemberAccessExpression<*>)
 
     fun IrConstructorCall.valueArgumentAtVS(index: Int): IrExpression?
+
+    fun IrMemberAccessExpression<*>.getValueArgumentVS(name: Name): IrExpression?
 
     fun <T : Any> IrExpression.asConstValueVS(clazz: KClass<T>): T?
 }

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -83,7 +83,6 @@ import org.jetbrains.kotlin.ir.util.dumpKotlinLike
 import org.jetbrains.kotlin.ir.util.file
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.getAnnotation
-import org.jetbrains.kotlin.ir.util.getValueArgument
 import org.jetbrains.kotlin.ir.util.isObject
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.primaryConstructor
@@ -1236,23 +1235,23 @@ internal class RpcStubGenerator(
                     // schemaDescriptor
                     +nullConst(ctx.anyNullable)
 
-                    val idempotentArgument = grpcMethodAnnotation
-                        ?.getValueArgument(Name.identifier("idempotent"))
-                    val idempotent = idempotentArgument?.asConstValueVS(Boolean::class) ?: false
+                    val idempotent = vsApi {
+                        grpcMethodAnnotation?.getValueArgumentVS(Name.identifier("idempotent"))
+                    }?.asConstValueVS(Boolean::class) ?: false
 
                     // idempotent
                     +booleanConst(idempotent)
 
-                    val safeArgument = grpcMethodAnnotation
-                        ?.getValueArgument(Name.identifier("safe"))
-                    val safe = safeArgument?.asConstValueVS(Boolean::class) ?: false
+                    val safe = vsApi {
+                        grpcMethodAnnotation?.getValueArgumentVS(Name.identifier("safe"))
+                    }?.asConstValueVS(Boolean::class) ?: false
 
                     // safe
                     +booleanConst(safe)
 
-                    val sampledToLocalTracingArgument = grpcMethodAnnotation
-                        ?.getValueArgument(Name.identifier("sampledToLocalTracing"))
-                    val sampledToLocalTracing = sampledToLocalTracingArgument?.asConstValueVS(Boolean::class) ?: true
+                    val sampledToLocalTracing = vsApi {
+                        grpcMethodAnnotation?.getValueArgumentVS(Name.identifier("sampledToLocalTracing"))
+                    }?.asConstValueVS(Boolean::class) ?: true
 
                     // sampledToLocalTracing
                     +booleanConst(sampledToLocalTracing)

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/ServiceDeclaration.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/ServiceDeclaration.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.getAnnotation
-import org.jetbrains.kotlin.ir.util.getValueArgument
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.name.Name
@@ -46,10 +45,9 @@ internal class ServiceDeclaration(
                 RpcClassId.grpcMethodAnnotation.asSingleFqName(),
             )
 
-            val nameArgument = grpcMethodAnnotation?.getValueArgument(Name.identifier("name"))
-
             ctx.vsApi {
-                nameArgument?.asConstValueVS(String::class)
+                grpcMethodAnnotation?.getValueArgumentVS(Name.identifier("name"))
+                    ?.asConstValueVS(String::class)
                     ?.takeIf { it.isNotBlank() }
                     ?: name
             }

--- a/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.copyTo
+import org.jetbrains.kotlin.ir.util.getValueArgument
 import org.jetbrains.kotlin.ir.util.isNullable
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -37,7 +38,44 @@ import org.jetbrains.kotlin.platform.isWasm
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
 //##csm /specific
-//##csm specific=[2.4.0...2.*]
+//##csm specific=[2.4.0...2.4.19]
+import kotlinx.rpc.codegen.extension.IrMemberAccessExpressionData
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+import org.jetbrains.kotlin.descriptors.SourceElement
+import org.jetbrains.kotlin.ir.builders.declarations.IrFieldBuilder
+import org.jetbrains.kotlin.ir.declarations.*
+import org.jetbrains.kotlin.ir.expressions.IrAnnotation
+import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrConst
+import org.jetbrains.kotlin.ir.expressions.IrConstKind
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrExpression
+import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
+import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
+import org.jetbrains.kotlin.ir.expressions.impl.IrAnnotationImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.IrConstructorCallImpl
+import org.jetbrains.kotlin.ir.expressions.impl.fromSymbolOwner
+import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
+import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
+import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.copyTo
+import org.jetbrains.kotlin.ir.util.getValueArgument
+import org.jetbrains.kotlin.ir.util.isNullable
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.platform.isJs
+import org.jetbrains.kotlin.platform.isWasm
+import kotlin.reflect.KClass
+import kotlin.reflect.safeCast
+//##csm /specific
+//##csm default
 import kotlinx.rpc.codegen.extension.IrMemberAccessExpressionData
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
@@ -72,7 +110,7 @@ import org.jetbrains.kotlin.platform.isJs
 import org.jetbrains.kotlin.platform.isWasm
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
-//##csm /specific
+//##csm /default
 //##csm /VersionSpecificApiImpl.kt-import
 
 object VersionSpecificApiImpl : VersionSpecificApi {
@@ -342,6 +380,17 @@ object VersionSpecificApiImpl : VersionSpecificApi {
 
     override fun IrConstructorCall.valueArgumentAtVS(index: Int): IrExpression? {
         return arguments.getOrNull(index)
+    }
+
+    override fun IrMemberAccessExpression<*>.getValueArgumentVS(name: Name): IrExpression? {
+        //##csm getValueArgumentVS
+        //##csm specific=[2.2.0...2.4.19]
+        return (this as IrConstructorCall).getValueArgument(name)
+        //##csm /specific
+        //##csm default
+        return (this as IrAnnotation).argumentMapping[name]
+        //##csm /default
+        //##csm /getValueArgumentVS
     }
 
     override fun <T : Any> IrExpression.asConstValueVS(clazz: KClass<T>): T? {


### PR DESCRIPTION
**Subsystem**
Compiler Plugin

**Problem Description**
`IrAnnotation` was separated from `IrConstructorCall` and the extension method `IrConstructorCall.getValueArgument` was replaces by a direct call to `argumentMapping`.

**Solution**
From 2.4.20 onwards `argumentMapping` is called directly instead of using the extension method.