### PR TITLE
KRPC-560: Fix Native segfault in callables property itable dispatch (…

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -724,7 +724,10 @@ internal class RpcStubGenerator(
 
         callables = addProperty {
             name = Name.identifier(Descriptor.CALLABLES)
-            visibility = DescriptorVisibilities.PRIVATE
+            // The property must be PUBLIC to match the interface declaration.
+            // On Kotlin/Native, a PRIVATE property with a PUBLIC getter does not get
+            // a proper itable entry, causing a segfault on interface dispatch (KRPC-560).
+            visibility = DescriptorVisibilities.PUBLIC
             modality = Modality.FINAL
         }.apply {
             overriddenSymbols = listOf(interfaceProperty)
@@ -752,9 +755,12 @@ internal class RpcStubGenerator(
             }
 
             addDefaultGetter(this@generateCallablesProperty, ctx.irBuiltIns) {
-                visibility =
-                    DescriptorVisibilities.PUBLIC
-                overriddenSymbols = listOf(ctx.rpcServiceDescriptor.getPropertyGetter(Descriptor.CALLABLES)!!)
+                visibility = DescriptorVisibilities.PUBLIC
+
+                val propertyGetter = ctx.rpcServiceDescriptor.getPropertyGetter(Descriptor.CALLABLES)
+                    ?: error("Expected RpcServiceDescriptor.callables property getter to exist")
+
+                overriddenSymbols = listOf(propertyGetter)
             }
         }
     }

--- a/tests/compiler-plugin-tests/src/testData/box/customParameterTypes.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/customParameterTypes.fir.ir.txt
@@ -179,7 +179,7 @@ FILE fqName:<root> fileName:/customParameterTypes.kt
               RETURN type=kotlin.Nothing from='private final fun <get-test2Invokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:test2Invokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-test2Invokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        PROPERTY name:callables visibility:private modality:FINAL [val]
+        PROPERTY name:callables visibility:public modality:FINAL [val]
           overridden:
             public abstract callables: kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:callables type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
@@ -246,7 +246,7 @@ FILE fqName:<root> fileName:/customParameterTypes.kt
                       ARG isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
           FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
             VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
-            correspondingProperty: PROPERTY name:callables visibility:private modality:FINAL [val]
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
             BLOCK_BODY

--- a/tests/compiler-plugin-tests/src/testData/box/flowParameter.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/flowParameter.fir.ir.txt
@@ -67,7 +67,7 @@ FILE fqName:<root> fileName:/flowParameter.kt
               RETURN type=kotlin.Nothing from='private final fun <get-streamInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:streamInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-streamInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        PROPERTY name:callables visibility:private modality:FINAL [val]
+        PROPERTY name:callables visibility:public modality:FINAL [val]
           overridden:
             public abstract callables: kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:callables type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
@@ -106,7 +106,7 @@ FILE fqName:<root> fileName:/flowParameter.kt
                       ARG isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
           FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
             VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
-            correspondingProperty: PROPERTY name:callables visibility:private modality:FINAL [val]
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
             BLOCK_BODY

--- a/tests/compiler-plugin-tests/src/testData/box/multiModule.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/multiModule.fir.ir.txt
@@ -64,7 +64,7 @@ FILE fqName:<root> fileName:/module_lib_multiModule.kt
               RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        PROPERTY name:callables visibility:private modality:FINAL [val]
+        PROPERTY name:callables visibility:public modality:FINAL [val]
           overridden:
             public abstract callables: kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:callables type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
@@ -92,7 +92,7 @@ FILE fqName:<root> fileName:/module_lib_multiModule.kt
                       ARG isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
           FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
             VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
-            correspondingProperty: PROPERTY name:callables visibility:private modality:FINAL [val]
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
             BLOCK_BODY

--- a/tests/compiler-plugin-tests/src/testData/box/serviceDescriptor.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/serviceDescriptor.fir.ir.txt
@@ -63,7 +63,7 @@ FILE fqName:<root> fileName:/serviceDescriptor.kt
               RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        PROPERTY name:callables visibility:private modality:FINAL [val]
+        PROPERTY name:callables visibility:public modality:FINAL [val]
           overridden:
             public abstract callables: kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:callables type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
@@ -91,7 +91,7 @@ FILE fqName:<root> fileName:/serviceDescriptor.kt
                       ARG isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
           FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
             VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
-            correspondingProperty: PROPERTY name:callables visibility:private modality:FINAL [val]
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
             BLOCK_BODY

--- a/tests/compiler-plugin-tests/src/testData/box/simple.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/simple.fir.ir.txt
@@ -63,7 +63,7 @@ FILE fqName:<root> fileName:/simple.kt
               RETURN type=kotlin.Nothing from='private final fun <get-simpleInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
                 GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleInvokator type:kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.Method<<root>.BoxService> origin=null
                   receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
-        PROPERTY name:callables visibility:private modality:FINAL [val]
+        PROPERTY name:callables visibility:public modality:FINAL [val]
           overridden:
             public abstract callables: kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
           FIELD PROPERTY_BACKING_FIELD name:callables type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
@@ -91,7 +91,7 @@ FILE fqName:<root> fileName:/simple.kt
                       ARG isNonSuspendFunction: CONST Boolean type=kotlin.Boolean value=false
           FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
             VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
-            correspondingProperty: PROPERTY name:callables visibility:private modality:FINAL [val]
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
             overridden:
               public abstract fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<T of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
             BLOCK_BODY


### PR DESCRIPTION
**Subsystem**
Compiler Plugin

**Problem Description**
Native build fails due to public getter on private property.

**Solution**
Cherry picking solution from main branch (KRPC-560).
