### PR TITLE
Fix getValueArgumentVS

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
@@ -388,7 +388,13 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         return (this as IrConstructorCall).getValueArgument(name)
         //##csm /specific
         //##csm default
-        return (this as IrAnnotation).argumentMapping.orEmpty()[name]
+        val constructorCall = this as IrConstructorCall
+        val parameterIndex = constructorCall.symbol.owner.parameters
+            .firstOrNull { it.name == name }
+            ?.indexInParameters
+            ?: return null
+
+        return constructorCall.argumentsVS.getOrNull(parameterIndex)
         //##csm /default
         //##csm /getValueArgumentVS
     }


### PR DESCRIPTION
**Subsystem**
Compiler Plugin

**Problem Description**
New way of getting annotation arguments in 2.4.20-Beta1

**Solution**
Fix it, Claude!

