### PR TITLE
Cancel pending RPC calls when connection closes before kRPC handshake

### DIFF
--- a/krpc/krpc-client/src/commonMain/kotlin/kotlinx/rpc/krpc/client/KrpcClient.kt
+++ b/krpc/krpc-client/src/commonMain/kotlin/kotlinx/rpc/krpc/client/KrpcClient.kt
@@ -167,6 +167,15 @@ public abstract class KrpcClient : RpcClient, KrpcEndpoint {
                 }
 
                 requestChannels.clear()
+
+                // The connection may close before the handshake completes (e.g. the server fails
+                // during route setup). In that case nothing else will ever complete this deferred,
+                // so any call awaiting the handshake would dangle forever. Fail it explicitly.
+                if (!serverSupportedPlugins.isCompleted) {
+                    serverSupportedPlugins.completeExceptionally(
+                        CancellationException("Connection closed before the kRPC handshake completed")
+                    )
+                }
             }
         }
 

--- a/krpc/krpc-ktor/krpc-ktor-core/src/jvmTest/kotlin/kotlinx/rpc/krpc/ktor/KtorTransportTest.kt
+++ b/krpc/krpc-ktor/krpc-ktor-core/src/jvmTest/kotlin/kotlinx/rpc/krpc/ktor/KtorTransportTest.kt
@@ -37,6 +37,7 @@ import java.net.ServerSocket
 import java.util.concurrent.Executors
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
 
@@ -354,6 +355,46 @@ class KtorTransportTest {
         serverJob.join()
 
         newPool.close()
+    }
+
+    @Test
+    fun testClientCallFailsWhenServerThrowsDuringRouteSetup() = testApplication {
+        install(Krpc)
+        routing {
+            rpc("/rpc") {
+                rpcConfig {
+                    serialization {
+                        json()
+                    }
+                }
+
+                // Throw during route/service setup, before the kRPC handshake is processed. Ktor closes
+                // the WebSocket without any protocol message reaching the client (see issue #506).
+                error("Simulated server-side failure during route setup")
+            }
+        }
+
+        val client = createClient {
+            installKrpc {
+                serialization {
+                    json()
+                }
+            }
+        }
+
+        // The service is never registered on the server, but the call must not dangle: it must fail
+        // once the server closes the connection without ever completing the handshake.
+        val service = client.rpc("/rpc").withService<SlowService>()
+
+        assertFailsWith<CancellationException> {
+            service.verySlow()
+        }
+
+        // The failure must come from the dangling handshake being cancelled, not from the caller's
+        // own scope being torn down.
+        currentCoroutineContext().ensureActive()
+
+        client.cancel()
     }
 
     private fun findFreePort(): Int {


### PR DESCRIPTION
## What

When a kRPC client opens a connection but the server closes it **before completing the kRPC handshake** (e.g. the server throws during route/service setup), the client's suspend call hangs forever instead of failing.

`KrpcClient` awaits `serverSupportedPlugins` (the handshake result) before dispatching any call. If the transport closes before a `Handshake`/`Failure` protocol message arrives, that deferred is never completed, so every call awaiting it dangles.

This completes `serverSupportedPlugins` exceptionally with a `CancellationException` when the client's coroutine scope finishes (the transport job completes), unblocking awaiting calls with the cancellation the caller expects.

## Why

Fixes #506 — an exception on the server side leaves a dangling suspend function on the client.

## How to verify

New test `KtorTransportTest.testClientCallFailsWhenServerThrowsDuringRouteSetup`, using Ktor's in-memory `testApplication`:
- A `rpc { }` route throws during setup (before the handshake is processed), so the WebSocket is closed without any protocol message reaching the client.
- Asserts the client call fails with `CancellationException` instead of hanging, and that the caller's own scope is still active afterwards.

Reproduction confirmed: with the fix reverted, the test hangs to the test timeout (`UncompletedCoroutinesError: After waiting for 1m`); with the fix it passes in ~0.02s. The full `KtorTransportTest` class passes (4 tests, including the existing client/server WS-teardown tests), and `checkLegacyAbi` is unaffected.

## Risk

Low. The added code runs only during scope teardown and is a no-op in the normal flow, where `serverSupportedPlugins` is already completed before teardown.
