### PR TITLE
gRPC: Race condition in requests; Request flow subscription fix

### DIFF
--- a/grpc/grpc-client/build.gradle.kts
+++ b/grpc/grpc-client/build.gradle.kts
@@ -23,6 +23,13 @@ kotlin {
             }
         }
 
+        commonTest {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.coroutines.test)
+            }
+        }
+
         nativeMain {
             dependencies {
                 implementation(libs.atomicfu)

--- a/grpc/grpc-client/src/commonMain/kotlin/kotlinx/rpc/grpc/client/internal/suspendClientCalls.kt
+++ b/grpc/grpc-client/src/commonMain/kotlin/kotlinx/rpc/grpc/client/internal/suspendClientCalls.kt
@@ -6,12 +6,18 @@ package kotlinx.rpc.grpc.client.internal
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.onFailure
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -119,32 +125,33 @@ public fun <Request, Response> GrpcClient.bidirectionalStreamingRpc(
     )
 }
 
-private sealed interface ClientRequest<Request> {
-    suspend fun sendTo(
-        clientCall: ClientCall<Request, *>,
-        ready: Ready,
-    )
-
-    class Unary<Request>(private val request: Request) : ClientRequest<Request> {
-        override suspend fun sendTo(
-            clientCall: ClientCall<Request, *>,
-            ready: Ready,
-        ) {
-            clientCall.sendMessage(request)
+/**
+ * Pumps responses from the [responses] channel into this [FlowCollector], requesting the next
+ * message through [requestNext] after every emit and running [onError] cleanup (under
+ * [NonCancellable]) if the collection fails.
+ *
+ * If the surrounding coroutine has been cancelled, this completes with that cancellation instead of
+ * rethrowing the channel's close-cause. The for-loop reads an already-closed channel through a
+ * non-suspending fast path that does not observe coroutine cancellation, so without this guard a
+ * server status sitting in the closed [responses] channel would leak past cancellation to operators
+ * such as `retry()`/`catch()` instead of the expected [CancellationException]
+ * (KRPC-461, grpc-kotlin #318).
+ */
+internal suspend fun <Response> FlowCollector<Response>.emitResponses(
+    responses: ReceiveChannel<Response>,
+    requestNext: () -> Unit,
+    onError: suspend (Throwable) -> Unit,
+) {
+    try {
+        requestNext()
+        for (response in responses) {
+            emit(response)
+            requestNext()
         }
-    }
-
-    class Flowing<Request>(private val requestFlow: Flow<Request>) : ClientRequest<Request> {
-        override suspend fun sendTo(
-            clientCall: ClientCall<Request, *>,
-            ready: Ready,
-        ) {
-            ready.suspendUntilReady()
-            requestFlow.collect { request ->
-                clientCall.sendMessage(request)
-                ready.suspendUntilReady()
-            }
-        }
+    } catch (e: Exception) {
+        withContext(NonCancellable) { onError(e) }
+        currentCoroutineContext().ensureActive()
+        throw e
     }
 }
 
@@ -219,25 +226,49 @@ private class ClientCallScopeImpl<Request, Response>(
              */
             val responses = Channel<Response>(1)
             val ready = Ready { call.isReady() }
+            val fullMethodName = method.getFullMethodName()
+
+            // (KRPC-461 / grpc-kotlin #378) For client/bidi streaming, subscribe to the request flow
+            // eagerly — before the RPC is started and independently of readiness — so that the flow's
+            // initialization runs deterministically and cannot be skipped or interrupted by an early
+            // RPC failure. The collected messages are handed to the sender through a rendezvous
+            // channel, which keeps the original backpressure (the flow is pulled only as fast as
+            // messages are actually sent). Unary and server-streaming send a single, already
+            // materialized request, so there is nothing to subscribe eagerly.
+            val requestChannel: Channel<Request>? = when (method.methodType) {
+                GrpcMethodType.CLIENT_STREAMING, GrpcMethodType.BIDI_STREAMING -> Channel(Channel.RENDEZVOUS)
+                else -> null
+            }
+
+            val requestCollector: Job? = if (requestChannel != null) {
+                launch(
+                    context = CoroutineName("grpc-collect-requests-$fullMethodName"),
+                    start = CoroutineStart.UNDISPATCHED,
+                ) {
+                    try {
+                        request.collect { requestChannel.send(it) }
+                        requestChannel.close()
+                    } catch (e: Throwable) {
+                        requestChannel.close(e)
+                        throw e
+                    }
+                }
+            } else {
+                null
+            }
 
             call.start(channelResponseListener(call, responses, ready), requestHeaders)
 
-            suspend fun Flow<Request>.send() {
-                if (method.methodType == GrpcMethodType.UNARY || method.methodType == GrpcMethodType.SERVER_STREAMING) {
-                    call.sendMessage(single())
-                } else {
-                    ready.suspendUntilReady()
-                    this.collect { request ->
-                        call.sendMessage(request)
-                        ready.suspendUntilReady()
-                    }
-                }
-            }
-
-            val fullMethodName = method.getFullMethodName()
             val sender = launch(CoroutineName("grpc-send-message-$fullMethodName")) {
                 try {
-                    request.send()
+                    if (requestChannel != null) {
+                        for (message in requestChannel) {
+                            ready.suspendUntilReady()
+                            call.sendMessage(message)
+                        }
+                    } else {
+                        call.sendMessage(request.single())
+                    }
                     call.halfClose()
                 } catch (ex: Exception) {
                     call.cancel("Collection of requests completed exceptionally", ex)
@@ -245,25 +276,25 @@ private class ClientCallScopeImpl<Request, Response>(
                 }
             }
 
-            try {
-                call.request(1)
-                for (response in responses) {
-                    emit(response)
-                    call.request(1)
-                }
-            } catch (e: Exception) {
-                withContext(NonCancellable) {
+            emitResponses(
+                responses = responses,
+                requestNext = { call.request(1) },
+                onError = { e ->
                     sender.cancel("Collection of responses completed exceptionally", e)
                     sender.join()
+                    requestCollector?.cancel("Collection of responses completed exceptionally", e)
+                    requestCollector?.join()
                     // we want the sender to be done cancelling before we cancel the handler, or it might try
                     // sending to a dead call, which results in ugly exception messages
                     call.cancel("Collection of responses completed exceptionally", e)
-                }
-                throw e
-            }
+                },
+            )
 
             if (!sender.isCompleted) {
                 sender.cancel("Collection of responses completed before collection of requests")
+            }
+            if (requestCollector?.isCompleted == false) {
+                requestCollector.cancel("Collection of responses completed before collection of requests")
             }
         }
     }

--- a/grpc/grpc-client/src/commonTest/kotlin/kotlinx/rpc/grpc/client/internal/EmitResponsesCancellationTest.kt
+++ b/grpc/grpc-client/src/commonTest/kotlin/kotlinx/rpc/grpc/client/internal/EmitResponsesCancellationTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.client.internal
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.rpc.grpc.GrpcStatus
+import kotlinx.rpc.grpc.GrpcStatusCode
+import kotlinx.rpc.grpc.GrpcStatusException
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for KRPC-461 / grpc-kotlin #318.
+ *
+ * Deterministically reproduces the cancellation race in [emitResponses]: a server-originated status
+ * sits in the already-closed response channel while the surrounding coroutine is cancelled. The
+ * for-loop reads the closed channel through a non-suspending fast path that does not observe
+ * cancellation, so without the cancellation guard the server status would be rethrown instead of a
+ * [CancellationException], leaking it to operators like `retry()`/`catch()`.
+ */
+class EmitResponsesCancellationTest {
+
+    @Test
+    fun emitResponses_honors_cancellation_over_a_closed_channel_server_status() = runTest {
+        val responses = Channel<Int>(1)
+        // A server-originated status delivered through onClose (cause == null on the wire) and stored
+        // as the channel's close-cause: exactly what the cancelled for-loop must not leak.
+        responses.close(GrpcStatusException(GrpcStatus(GrpcStatusCode.INTERNAL, "server boom")))
+
+        var observed: Throwable? = null
+
+        val scopeJob = Job(coroutineContext[Job])
+        val scope = CoroutineScope(coroutineContext + scopeJob)
+        // Cancel the collector before it reads the (already closed) channel.
+        scopeJob.cancel()
+
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            val sink = FlowCollector<Int> { /* values are dropped; the channel is empty */ }
+            try {
+                sink.emitResponses(responses, requestNext = {}, onError = {})
+            } catch (e: Throwable) {
+                observed = e
+            }
+        }.join()
+
+        assertTrue(
+            observed is CancellationException,
+            "A cancelled collection must fail with CancellationException, not a leaked server " +
+                "status (KRPC-461 / grpc-kotlin #318). Observed: $observed",
+        )
+    }
+}

--- a/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcRequestFlowSubscriptionTest.kt
+++ b/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcRequestFlowSubscriptionTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.test.integration
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.rpc.RpcServer
+import kotlinx.rpc.grpc.test.EchoService
+import kotlinx.rpc.grpc.test.EchoServiceImpl
+import kotlinx.rpc.grpc.test.invoke
+import kotlinx.rpc.registerService
+import kotlinx.rpc.withService
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for KRPC-461 / grpc-kotlin #378.
+ *
+ * The request flow of a client/bidi streaming call must be subscribed eagerly — its initialization
+ * must run as soon as collection starts, decoupled from RPC readiness — so an early failure or
+ * cancellation cannot prevent or interrupt it. Previously the request flow was collected by a
+ * dispatched coroutine that first waited for readiness, so cancelling before the call became ready
+ * could skip subscription entirely.
+ */
+class GrpcRequestFlowSubscriptionTest : GrpcTestBase() {
+    override fun RpcServer.registerServices() {
+        registerService<EchoService> { EchoServiceImpl() }
+    }
+
+    @Test
+    fun `request flow is subscribed eagerly even if the call is cancelled before readiness`() = runGrpcTest { client ->
+        val service = client.withService<EchoService>()
+        var requestFlowSubscribed = false
+
+        coroutineScope {
+            // UNDISPATCHED so the whole call setup runs synchronously up to the first suspension
+            // point before we cancel: an eagerly-subscribed request flow has already run its
+            // initialization, a lazily/dispatched one has not.
+            val job = launch(start = CoroutineStart.UNDISPATCHED) {
+                service.BidirectionalStreamingEcho(
+                    flow {
+                        requestFlowSubscribed = true
+                        awaitCancellation()
+                    },
+                ).collect { }
+            }
+            job.cancel()
+            job.join()
+        }
+
+        assertTrue(
+            requestFlowSubscribed,
+            "The request flow must be subscribed (its initialization must run) eagerly, even " +
+                "when the call is cancelled before it becomes ready (KRPC-461 / grpc-kotlin #378).",
+        )
+    }
+}


### PR DESCRIPTION
**Subsystem**
gRPC Core

**Problem Description**
#611 

**Solution**
Fix both problems:
- Provide a deterministic order of collection for request flows
- Ensure no unwanted exception leaks into the client scope

Fixes: KRPC-461
Fixes: #611
