### PR TITLE
gRPC: Add channel-level userAgent configuration to client

### DIFF
--- a/grpc/grpc-client/api/grpc-client.api
+++ b/grpc/grpc-client/api/grpc-client.api
@@ -69,6 +69,7 @@ public final class kotlinx/rpc/grpc/client/GrpcClientConfiguration {
 	public final fun getMarshallerConfig ()Lkotlinx/rpc/grpc/marshaller/GrpcMarshallerConfig;
 	public final fun getMessageMarshallerResolver ()Lkotlinx/rpc/grpc/marshaller/GrpcMarshallerResolver;
 	public final fun getOverrideAuthority ()Ljava/lang/String;
+	public final fun getUserAgent ()Ljava/lang/String;
 	public final fun intercept ([Lkotlinx/rpc/grpc/client/GrpcClientInterceptor;)V
 	public final fun keepAlive (Lkotlin/jvm/functions/Function1;)V
 	public final fun plaintext ()Lkotlinx/rpc/grpc/client/GrpcClientCredentials;
@@ -76,6 +77,7 @@ public final class kotlinx/rpc/grpc/client/GrpcClientConfiguration {
 	public final fun setMarshallerConfig (Lkotlinx/rpc/grpc/marshaller/GrpcMarshallerConfig;)V
 	public final fun setMessageMarshallerResolver (Lkotlinx/rpc/grpc/marshaller/GrpcMarshallerResolver;)V
 	public final fun setOverrideAuthority (Ljava/lang/String;)V
+	public final fun setUserAgent (Ljava/lang/String;)V
 	public final fun tls (Lkotlin/jvm/functions/Function1;)Lkotlinx/rpc/grpc/client/GrpcClientCredentials;
 }
 

--- a/grpc/grpc-client/api/grpc-client.klib.api
+++ b/grpc/grpc-client/api/grpc-client.klib.api
@@ -89,6 +89,9 @@ final class kotlinx.rpc.grpc.client/GrpcClientConfiguration { // kotlinx.rpc.grp
     final var overrideAuthority // kotlinx.rpc.grpc.client/GrpcClientConfiguration.overrideAuthority|{}overrideAuthority[0]
         final fun <get-overrideAuthority>(): kotlin/String? // kotlinx.rpc.grpc.client/GrpcClientConfiguration.overrideAuthority.<get-overrideAuthority>|<get-overrideAuthority>(){}[0]
         final fun <set-overrideAuthority>(kotlin/String?) // kotlinx.rpc.grpc.client/GrpcClientConfiguration.overrideAuthority.<set-overrideAuthority>|<set-overrideAuthority>(kotlin.String?){}[0]
+    final var userAgent // kotlinx.rpc.grpc.client/GrpcClientConfiguration.userAgent|{}userAgent[0]
+        final fun <get-userAgent>(): kotlin/String? // kotlinx.rpc.grpc.client/GrpcClientConfiguration.userAgent.<get-userAgent>|<get-userAgent>(){}[0]
+        final fun <set-userAgent>(kotlin/String?) // kotlinx.rpc.grpc.client/GrpcClientConfiguration.userAgent.<set-userAgent>|<set-userAgent>(kotlin.String?){}[0]
 
     final fun intercept(kotlin/Array<out kotlinx.rpc.grpc.client/GrpcClientInterceptor>...) // kotlinx.rpc.grpc.client/GrpcClientConfiguration.intercept|intercept(kotlin.Array<out|kotlinx.rpc.grpc.client.GrpcClientInterceptor>...){}[0]
     final fun keepAlive(kotlin/Function1<kotlinx.rpc.grpc.client/GrpcClientConfiguration.KeepAlive, kotlin/Unit>) // kotlinx.rpc.grpc.client/GrpcClientConfiguration.keepAlive|keepAlive(kotlin.Function1<kotlinx.rpc.grpc.client.GrpcClientConfiguration.KeepAlive,kotlin.Unit>){}[0]

--- a/grpc/grpc-client/src/commonMain/kotlin/kotlinx/rpc/grpc/client/GrpcClient.kt
+++ b/grpc/grpc-client/src/commonMain/kotlin/kotlinx/rpc/grpc/client/GrpcClient.kt
@@ -261,8 +261,7 @@ public class GrpcClientConfiguration internal constructor() {
      * Set this here rather than via request [kotlinx.rpc.grpc.GrpcMetadata]: `user-agent` is a reserved
      * header and any value added to the metadata is overwritten by the gRPC runtime.
      *
-     * Maps to `ManagedChannelBuilder.userAgent(...)` on JVM and the `GRPC_ARG_PRIMARY_USER_AGENT_STRING`
-     * channel argument on native. If `null` (the default), only the runtime's own token is sent.
+     * If `null` (the default), only the runtime's own token is sent.
      *
      * ```
      * GrpcClient("example.com", 443) {

--- a/grpc/grpc-client/src/commonMain/kotlin/kotlinx/rpc/grpc/client/GrpcClient.kt
+++ b/grpc/grpc-client/src/commonMain/kotlin/kotlinx/rpc/grpc/client/GrpcClient.kt
@@ -250,6 +250,27 @@ public class GrpcClientConfiguration internal constructor() {
      */
     public var overrideAuthority: String? = null
 
+    /**
+     * A custom application `User-Agent` for this channel.
+     *
+     * The value is used as a **prefix**: the runtime appends its own token after a single space, so the
+     * `User-Agent` on the wire is `"<userAgent> <runtime-token>"` (e.g. `grpc-java-okhttp/<version>` on
+     * JVM, or the `grpc-c/<version>` C-core token on native). A full override is not supported by the
+     * underlying gRPC implementations.
+     *
+     * Set this here rather than via request [kotlinx.rpc.grpc.GrpcMetadata]: `user-agent` is a reserved
+     * header and any value added to the metadata is overwritten by the gRPC runtime.
+     *
+     * Maps to `ManagedChannelBuilder.userAgent(...)` on JVM and the `GRPC_ARG_PRIMARY_USER_AGENT_STRING`
+     * channel argument on native. If `null` (the default), only the runtime's own token is sent.
+     *
+     * ```
+     * GrpcClient("example.com", 443) {
+     *     userAgent = "MyApp/1.2.3"
+     * }
+     * ```
+     */
+    public var userAgent: String? = null
 
     /**
      * Adds one or more client-side interceptors to the current gRPC client configuration.

--- a/grpc/grpc-client/src/jvmMain/kotlin/kotlinx/rpc/grpc/client/internal/ManagedChannel.jvm.kt
+++ b/grpc/grpc-client/src/jvmMain/kotlin/kotlinx/rpc/grpc/client/internal/ManagedChannel.jvm.kt
@@ -91,5 +91,6 @@ internal actual fun ManagedChannelBuilder<*>.applyConfig(config: GrpcClientConfi
     }
 
     config.overrideAuthority?.let { overrideAuthority(it) }
+    config.userAgent?.let { userAgent(it) }
     return this
 }

--- a/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/ManagedChannel.native.kt
+++ b/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/ManagedChannel.native.kt
@@ -43,6 +43,7 @@ internal class NativeManagedChannelBuilder(
             target,
             overrideAuthority = config?.overrideAuthority,
             keepAlive = config?.keepAlive,
+            userAgent = config?.userAgent,
             clientCredentials = credentials.value,
         )
     }

--- a/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/NativeManagedChannel.kt
+++ b/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/NativeManagedChannel.kt
@@ -65,6 +65,7 @@ internal class NativeManagedChannel(
     target: String,
     val overrideAuthority: String?,
     val keepAlive: GrpcClientConfiguration.KeepAlive?,
+    val userAgent: String?,
     // this is not a composite channel credentials
     clientCredentials: GrpcClientCredentials,
 ) : ManagedChannel, ManagedChannelPlatform() {
@@ -91,6 +92,14 @@ internal class NativeManagedChannel(
             // instead, it can be done by setting the "grpc.ssl_target_name_override" argument.
             args.add(GrpcArg.Str(
                     key = "grpc.ssl_target_name_override",
+                    value = it
+            ))
+        }
+
+        userAgent?.let {
+            // GRPC_ARG_PRIMARY_USER_AGENT_STRING — prepended to the C-core's own User-Agent token.
+            args.add(GrpcArg.Str(
+                    key = "grpc.primary_user_agent",
                     value = it
             ))
         }

--- a/grpc/grpc-core/src/desktopNativeTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcUserAgentTest.desktopNative.kt
+++ b/grpc/grpc-core/src/desktopNativeTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcUserAgentTest.desktopNative.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.test.integration
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.rpc.grpc.test.EchoRequest
+import kotlinx.rpc.grpc.test.EchoService
+import kotlinx.rpc.grpc.test.captureGrpcLogs
+import kotlinx.rpc.grpc.test.invoke
+import kotlinx.rpc.withService
+import kotlin.test.assertEquals
+
+actual fun GrpcTestBase.testUserAgent(
+    userAgent: String,
+) = runTest {
+    val logs = captureGrpcLogs(
+        nativeTracers = listOf("pick_first")
+    ) {
+        runGrpcTest(
+            clientConfiguration = {
+                this.userAgent = userAgent
+            }
+        ) {
+            it.withService<EchoService>().UnaryEcho(EchoRequest { message = "Hello" })
+        }
+    }
+
+    assertEquals(userAgent, extractPrimaryUserAgent(logs))
+}
+
+private fun extractPrimaryUserAgent(logs: String): String {
+    val channelArgsPattern = Regex("""channel args: \{([^}]+)\}""")
+    val channelArgsMatch = channelArgsPattern.find(logs)
+        ?: error("Could not find channel args in logs")
+
+    val argsText = channelArgsMatch.groupValues[1]
+
+    return Regex("""grpc\.primary_user_agent=([^,}]+)""")
+        .find(argsText)?.groupValues?.get(1)?.trim()
+        ?: error("Could not find grpc.primary_user_agent in logs")
+}

--- a/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcUserAgentTest.kt
+++ b/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcUserAgentTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.test.integration
+
+import kotlinx.rpc.RpcServer
+import kotlinx.rpc.grpc.test.EchoService
+import kotlinx.rpc.grpc.test.EchoServiceImpl
+import kotlinx.rpc.registerService
+import kotlin.test.Test
+
+/**
+ * Tests that the client-configured [userAgent] is applied at the channel level and used as a prefix
+ * of the `User-Agent` actually sent on the wire.
+ *
+ * Like [GrpcKeepAliveTest], this is verified platform-specifically: on JVM by reflecting the composed
+ * user-agent stored on the channel, on native by capturing the gRPC trace output and reading the
+ * `grpc.primary_user_agent` channel argument.
+ */
+class GrpcUserAgentTest : GrpcTestBase() {
+    override fun RpcServer.registerServices() {
+        return registerService<EchoService> { EchoServiceImpl() }
+    }
+
+    @Test
+    fun `test userAgent set - should propagate as prefix to core libraries`() = testUserAgent(
+        userAgent = "MyApp/1.2.3",
+    )
+}
+
+expect fun GrpcTestBase.testUserAgent(
+    userAgent: String,
+)

--- a/grpc/grpc-core/src/jvmTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcUserAgentTest.jvm.kt
+++ b/grpc/grpc-core/src/jvmTest/kotlin/kotlinx/rpc/grpc/test/integration/GrpcUserAgentTest.jvm.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-2026 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.test.integration
+
+import kotlinx.rpc.grpc.client.internal.ManagedChannel
+import kotlinx.rpc.grpc.test.EchoRequest
+import kotlinx.rpc.grpc.test.EchoService
+import kotlinx.rpc.grpc.test.invoke
+import kotlinx.rpc.withService
+import java.lang.reflect.Field
+import kotlin.test.assertTrue
+
+actual fun GrpcTestBase.testUserAgent(
+    userAgent: String,
+) {
+    runGrpcTest(
+        clientConfiguration = {
+            this.userAgent = userAgent
+        }
+    ) {
+        it.withService<EchoService>().UnaryEcho(EchoRequest { message = "Hello" })
+
+        // grpc-java stores the composed user-agent ("<prefix> grpc-java-<transport>/<version>")
+        // on ManagedChannelImpl, reachable through the forwarding wrapper's `delegate`.
+        val composedUserAgent = it.getField<ManagedChannel>("channel")
+            .platformApi
+            .getField<String>("delegate", "userAgent")
+
+        assertTrue(
+            composedUserAgent.startsWith(userAgent),
+            "Expected composed user-agent to start with '$userAgent', but was '$composedUserAgent'",
+        )
+    }
+}
+
+private inline fun <reified R> Any.getField(vararg names: String): R {
+    var curr: Any = this
+    for (name in names) {
+        val field = findFieldInHierarchy(curr::class.java, name)
+            ?: throw NoSuchFieldException("Field '$name' not found in ${curr::class.java}")
+        field.isAccessible = true
+        curr = field.get(curr) as Any
+    }
+    return curr as R
+}
+
+private fun findFieldInHierarchy(clazz: Class<*>, name: String): Field? {
+    var c: Class<*>? = clazz
+    while (c != null) {
+        try {
+            return c.getDeclaredField(name)
+        } catch (_: NoSuchFieldException) {
+            c = c.superclass
+        }
+    }
+    return null
+}


### PR DESCRIPTION
# PR 2 — channel-level userAgent

- **Title:** Add channel-level userAgent configuration to gRPC client
- **Base:** `Kotlin/kotlinx-rpc:main`  ←  **Head:** `mlilienberg:feat/grpc-client-user-agent-pr`
- **Open with:** `gh pr create -R Kotlin/kotlinx-rpc --base main --head mlilienberg:feat/grpc-client-user-agent-pr --title "Add channel-level userAgent configuration to gRPC client" --body-file PR_DRAFT_grpc-client-user-agent.md`

---

## Summary

Adds a `userAgent` option to `GrpcClientConfiguration`, applied at the channel/transport
level so it is actually sent on the wire. A `user-agent` entry added to request
`GrpcMetadata` is a reserved header and is dropped/overwritten by the gRPC runtime, so this
is the correct way to influence the `User-Agent`.

The value is **prepended**, not set: the runtime always appends its own token after a space,
so the wire value is `"<userAgent> <runtime-token>"`. This matches the behavior of the other
gRPC client implementations (grpc-go's `WithUserAgent`, grpc-java's `ManagedChannelBuilder.userAgent`,
grpc-swift's `userAgentSuffix`/prefix handling), which all treat the application user-agent as a
prefix to the runtime's own token rather than a full replacement. Suppressing the appended token
(a full override) is not supported by the underlying gRPC implementations.

For example, with:

```kotlin
GrpcClient("example.com", 443) {
    userAgent = "MyApp/1.2.3"
}
```

the `User-Agent` actually sent on the wire is:

- JVM: `MyApp/1.2.3 grpc-java-okhttp/<version>` (or `grpc-java-netty/<version>`)
- Native: `MyApp/1.2.3 grpc-c/<version> (<platform>; <engine>)`

## Motivation

`GrpcClientConfiguration` already mirrors common channel-level knobs from the other gRPC
implementations (keep-alive, override-authority, interceptors), but there was no way to set the
application `User-Agent`. This aligns `kotlinx.rpc`'s gRPC client with grpc-go, grpc-java,
grpc-kotlin, and grpc-swift, all of which expose a channel-level user-agent prefix — letting
servers and proxies identify the calling application (version, platform) in logs and routing.

## Changes

- `GrpcClientConfiguration.userAgent: String?` (default `null`), fully documented.
- JVM: maps to `ManagedChannelBuilder.userAgent(...)`.
- Native: maps to the `grpc.primary_user_agent` (`GRPC_ARG_PRIMARY_USER_AGENT_STRING`) channel arg.
- Regenerated ABI dumps (`grpc-client.api` / `grpc-client.klib.api`).
- Tests (`GrpcUserAgentTest`) mirroring the existing `GrpcKeepAliveTest` pattern.

## Verification

- `./gradlew :grpc:grpc-core:jvmTest --tests "*GrpcUserAgentTest*"` — passes (asserts the composed
  channel user-agent starts with the configured prefix).
- `./gradlew :grpc:grpc-core:macosArm64Test --tests "*GrpcUserAgentTest*"` — passes (asserts the
  `grpc.primary_user_agent` channel arg from trace logs equals the configured value).
- `./gradlew :grpc:grpc-client:detekt :grpc:grpc-core:detekt` — passes.

## AI use disclosure

Co-authored with Claude (implementation review, tests, ABI regeneration, verification).
