### PR TITLE
Apply default values for absent optional parameters in invokators

### DIFF
--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/IrMemberAccessExpressionBuilder.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/IrMemberAccessExpressionBuilder.kt
@@ -13,14 +13,15 @@ class IrMemberAccessExpressionData(
     val dispatchReceiver: IrExpression?,
     val extensionReceiver: IrExpression?,
     val typeArguments: List<IrType>,
-    val valueArguments: List<IrExpression>,
+    // null entries are skipped, leaving the argument unset (the callee's default value applies)
+    val valueArguments: List<IrExpression?>,
 )
 
 class IrMemberAccessExpressionBuilder {
     var dispatchReceiver: IrExpression? = null
     var extensionReceiver: IrExpression? = null
 
-    private var valueArguments: List<IrExpression> = emptyList()
+    private var valueArguments: List<IrExpression?> = emptyList()
     private var typeArguments: List<IrType> = emptyList()
 
     val typeBuilder = TypeBuilder()
@@ -44,6 +45,14 @@ class IrMemberAccessExpressionBuilder {
     inner class ValueBuilder {
         operator fun IrExpression.unaryPlus() {
             valueArguments += this
+        }
+
+        /**
+         * Leaves the argument at the current position unset.
+         * Only valid for parameters with a default value.
+         */
+        fun skip() {
+            valueArguments += null
         }
     }
 

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcIrContext.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcIrContext.kt
@@ -179,6 +179,10 @@ internal class RpcIrContext(
         rpcInvokator.subClass("FlowResponse")
     }
 
+    val rpcInvokatorAbsent by lazy {
+        rpcInvokator.subClass("Absent")
+    }
+
     val rpcParameter by lazy {
         referenceRpcIrClassSymbol("RpcParameter", "descriptor")
     }

--- a/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/kotlin/kotlinx/rpc/codegen/extension/RpcStubGenerator.kt
@@ -26,9 +26,11 @@ import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irBranch
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irEqeqeq
 import org.jetbrains.kotlin.ir.builders.irEqualsNull
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irIfNull
+import org.jetbrains.kotlin.ir.builders.irIfThenElse
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.builders.irTemporary
 import org.jetbrains.kotlin.ir.builders.irTrue
@@ -608,6 +610,22 @@ internal class RpcStubGenerator(
      * Where:
      *  - `<method-name>` - the name of the method
      *  - <argument-type-k> - type of the kth argument
+     *
+     * Arguments of optional parameters (declared with a default value) are checked for absence,
+     * so that the default value is applied (GitHub issue #543):
+     * ```kotlin
+     * private val <method-name>Invokator = RpcInvokator.UnaryResponse<MyService> {
+     *     service: MyService, arguments: Array<Any?> ->
+     *
+     *     val optionalArg1 = arguments[1]
+     *     if (optionalArg1 === RpcInvokator.Absent || optionalArg1 == null /* non-nullable types only */) {
+     *         service.<method-name>(arguments[0] as <argument-type-1>)
+     *     } else {
+     *         service.<method-name>(arguments[0] as <argument-type-1>, optionalArg1 as <argument-type-2>)
+     *     }
+     * }
+     * ```
+     * With one `if` per optional parameter, nested (2^n branches for n optional parameters).
      */
     private fun IrClass.generateInvokator(callable: ServiceDeclaration.Callable) {
         check(callable is ServiceDeclaration.Method) {
@@ -658,38 +676,7 @@ internal class RpcStubGenerator(
                     }
 
                     body = irBuilder(ctx.pluginContext, symbol).irBlockBody {
-                        val call = irCall(callable.function).apply {
-                            arguments {
-                                dispatchReceiver = irGet(serviceParameter)
-
-                                values {
-                                    callable.arguments.forEachIndexed { argIndex, arg ->
-                                        val argument = irCall(
-                                            callee = ctx.functions.arrayGet.symbol,
-                                            type = ctx.anyNullable,
-                                        ).apply {
-                                            vsApi { originVS = IrStatementOrigin.GET_ARRAY_ELEMENT }
-
-                                            arguments {
-                                                dispatchReceiver = irGet(argumentsParameter)
-
-                                                values {
-                                                    +intConst(argIndex)
-                                                }
-                                            }
-                                        }
-
-                                        if (vsApi { arg.type.isNullableVS() }) {
-                                            +irSafeAs(argument, arg.type)
-                                        } else {
-                                            +irAs(argument, arg.type)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        +irReturn(call)
+                        invokatorLambdaBody(callable, serviceParameter, argumentsParameter)
                     }
                 }
 
@@ -731,6 +718,104 @@ internal class RpcStubGenerator(
                 visibility = DescriptorVisibilities.PRIVATE
             }
         }
+    }
+
+    /**
+     * Body of the invokator lambda, see [generateInvokator] for the shape of the generated code.
+     */
+    private fun IrBlockBodyBuilder.invokatorLambdaBody(
+        callable: ServiceDeclaration.Method,
+        serviceParameter: IrValueParameter,
+        argumentsParameter: IrValueParameter,
+    ) {
+        fun irGetArrayElement(argIndex: Int): IrExpression {
+            return irCall(
+                callee = ctx.functions.arrayGet.symbol,
+                type = ctx.anyNullable,
+            ).apply {
+                vsApi { originVS = IrStatementOrigin.GET_ARRAY_ELEMENT }
+
+                arguments {
+                    dispatchReceiver = irGet(argumentsParameter)
+
+                    values {
+                        +intConst(argIndex)
+                    }
+                }
+            }
+        }
+
+        // arguments of optional parameters are hoisted into locals to check them for absence
+        val optionalArguments = callable.arguments
+            .withIndex()
+            .filter { (_, arg) -> arg.isOptional }
+            .associate { (argIndex, _) ->
+                argIndex to irTemporary(
+                    value = irGetArrayElement(argIndex),
+                    nameHint = "optionalArg$argIndex",
+                )
+            }
+
+        fun irCastedArgument(argIndex: Int, arg: ServiceDeclaration.Method.Argument): IrExpression {
+            val argument = optionalArguments[argIndex]?.let { irGet(it) }
+                ?: irGetArrayElement(argIndex)
+
+            return if (vsApi { arg.type.isNullableVS() }) {
+                irSafeAs(argument, arg.type)
+            } else {
+                irAs(argument, arg.type)
+            }
+        }
+
+        fun irCallWithAbsent(absentArgs: Set<Int>): IrExpression {
+            return irCall(callable.function).apply {
+                arguments {
+                    dispatchReceiver = irGet(serviceParameter)
+
+                    values {
+                        callable.arguments.forEachIndexed { argIndex, arg ->
+                            if (argIndex in absentArgs) {
+                                skip() // unset, the default value is applied
+                            } else {
+                                +irCastedArgument(argIndex, arg)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        fun irCallBranchingOnAbsence(optionalIndexes: List<Int>, absentArgs: Set<Int>): IrExpression {
+            val argIndex = optionalIndexes.firstOrNull()
+                ?: return irCallWithAbsent(absentArgs)
+
+            val rest = optionalIndexes.subList(1, optionalIndexes.size)
+            val temporary = optionalArguments.getValue(argIndex)
+
+            val isAbsentMarker = irEqeqeq(irGet(temporary), irGetObjectValue(ctx.rpcInvokatorAbsent))
+
+            val isAbsent = if (vsApi { callable.arguments[argIndex].type.isNullableVS() }) {
+                isAbsentMarker
+            } else {
+                // null cannot be a valid argument for a non-nullable type, treat it as absent too
+                irIfThenElse(
+                    type = ctx.irBuiltIns.booleanType,
+                    condition = irEqualsNull(irGet(temporary)),
+                    thenPart = irTrue(),
+                    elsePart = isAbsentMarker,
+                    origin = IrStatementOrigin.OROR,
+                )
+            }
+
+            return irIfThenElse(
+                type = callable.function.returnType,
+                condition = isAbsent,
+                thenPart = irCallBranchingOnAbsence(rest, absentArgs + argIndex),
+                elsePart = irCallBranchingOnAbsence(rest, absentArgs),
+            )
+        }
+
+        +irReturn(irCallBranchingOnAbsence(optionalArguments.keys.sorted(), emptySet()))
     }
 
     private var callables: IrProperty by Delegates.notNull()
@@ -1853,6 +1938,13 @@ internal class RpcStubGenerator(
         endOffset = UNDEFINED_OFFSET,
         type = ctx.irBuiltIns.booleanType,
         value = value,
+    )
+
+    private fun irGetObjectValue(symbol: IrClassSymbol) = IrGetObjectValueImpl(
+        startOffset = UNDEFINED_OFFSET,
+        endOffset = UNDEFINED_OFFSET,
+        type = symbol.defaultType,
+        symbol = symbol,
     )
 
     private fun IrType.unwrapFlow(from: IrFile): IrType {

--- a/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
+++ b/compiler-plugin/compiler-plugin-backend/src/main/templates/kotlinx/rpc/codegen/VersionSpecificApiImpl.kt
@@ -306,7 +306,18 @@ object VersionSpecificApiImpl : VersionSpecificApi {
         }
 
         valueArguments.forEachIndexed { index, irExpression ->
-            access.arguments[offset + index] = irExpression
+            if (irExpression == null) {
+                // unset on purpose, the callee's default value applies;
+                // fake overrides carry defaults on their overridden declarations, so they are not checked
+                val callee = (access.symbol.owner as? IrSimpleFunction)?.takeIf { !it.isFakeOverride }
+
+                require(callee == null || callee.valueParametersVS().getOrNull(index)?.defaultValue != null) {
+                    "Unset argument at index $index for '${callee?.name}': " +
+                            "only parameters with default values can be skipped"
+                }
+            } else {
+                access.arguments[offset + index] = irExpression
+            }
         }
 
         typeArguments.forEachIndexed { index, irType ->

--- a/compiler-plugin/compiler-plugin-common/src/main/kotlin/kotlinx/rpc/codegen/common/Names.kt
+++ b/compiler-plugin/compiler-plugin-common/src/main/kotlin/kotlinx/rpc/codegen/common/Names.kt
@@ -31,6 +31,15 @@ object RpcNames {
     val CHECK_FOR_ARGUMENT_NAME = Name.identifier("checkFor")
 }
 
+object RpcLimits {
+    /**
+     * Invokators branch on every subset of absent optional parameters (2^n call sites),
+     * see `RpcStubGenerator.generateInvokator`.
+     * The FIR checker rejects functions above this limit to keep generated code bounded.
+     */
+    const val MAX_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION: Int = 8
+}
+
 object ProtoClassId {
     val protoMessageAnnotation = ClassId(FqName("kotlinx.rpc.protobuf.internal"), Name.identifier("GeneratedProtoMessage"))
     val protoDescriptor = ClassId(FqName("kotlinx.rpc.protobuf.internal"), Name.identifier("ProtoDescriptor"))

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirRpcServiceDeclarationChecker.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/FirRpcServiceDeclarationChecker.kt
@@ -8,6 +8,7 @@ import kotlinx.rpc.codegen.FirCheckersContext
 import kotlinx.rpc.codegen.FirRpcPredicates
 import kotlinx.rpc.codegen.checkers.diagnostics.FirRpcDiagnostics
 import kotlinx.rpc.codegen.common.RpcClassId
+import kotlinx.rpc.codegen.common.RpcLimits
 import kotlinx.rpc.codegen.vsApi
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
@@ -45,6 +46,17 @@ object FirRpcServiceDeclarationChecker {
                 reporter.reportOn(
                     source = function.source,
                     factory = FirRpcDiagnostics.TYPE_PARAMETERS_IN_RPC_FUNCTION,
+                    context = context,
+                )
+            }
+
+            // invokators branch on every subset of absent optional parameters (2^n call sites),
+            // unbounded n means unbounded generated code
+            if (function.valueParameterSymbols.count { it.hasDefaultValue } > RpcLimits.MAX_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION) {
+                reporter.reportOn(
+                    source = function.source,
+                    factory = FirRpcDiagnostics.TOO_MANY_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION,
+                    a = RpcLimits.MAX_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION,
                     context = context,
                 )
             }

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/FirRpcDiagnostics.kt
@@ -31,6 +31,7 @@ object FirRpcDiagnostics : RpcKtDiagnosticsContainer() {
     val AD_HOC_POLYMORPHISM_IN_RPC_SERVICE by error2<KtElement, Int, Name>()
     val TYPE_PARAMETERS_IN_RPC_FUNCTION by error0<KtElement>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
     val TYPE_PARAMETERS_IN_RPC_INTERFACE by error0<KtElement>(SourceElementPositioningStrategies.TYPE_PARAMETERS_LIST)
+    val TOO_MANY_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION by error1<KtElement, Int>()
 
     override fun getRendererFactoryVs(): BaseDiagnosticRendererFactory {
         return RpcDiagnosticRendererFactory

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/checkers/diagnostics/RpcDiagnosticRendererFactory.kt
@@ -48,6 +48,12 @@ object RpcDiagnosticRendererFactory : BaseDiagnosticRendererFactory() {
             factory = FirRpcDiagnostics.TYPE_PARAMETERS_IN_RPC_INTERFACE,
             message = "Type parameters are not allowed in @Rpc interfaces.",
         )
+
+        map.put(
+            factory = FirRpcDiagnostics.TOO_MANY_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION,
+            message = "Rpc functions can declare at most {0} parameters with default values.",
+            rendererA = Renderer { it.toString() },
+        )
     }
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -41,6 +41,11 @@ public abstract interface class kotlinx/rpc/descriptor/RpcCallable {
 public abstract interface class kotlinx/rpc/descriptor/RpcInvokator {
 }
 
+public final class kotlinx/rpc/descriptor/RpcInvokator$Absent {
+	public static final field INSTANCE Lkotlinx/rpc/descriptor/RpcInvokator$Absent;
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class kotlinx/rpc/descriptor/RpcInvokator$FlowResponse : kotlinx/rpc/descriptor/RpcInvokator {
 	public abstract fun call (Ljava/lang/Object;[Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -78,6 +78,10 @@ sealed interface <#A: kotlin/Any> kotlinx.rpc.descriptor/RpcInvokator { // kotli
     abstract fun interface <#A1: kotlin/Any> UnaryResponse : kotlinx.rpc.descriptor/RpcInvokator<#A1> { // kotlinx.rpc.descriptor/RpcInvokator.UnaryResponse|null[0]
         abstract suspend fun call(#A1, kotlin/Array<kotlin/Any?>): kotlin/Any? // kotlinx.rpc.descriptor/RpcInvokator.UnaryResponse.call|call(1:0;kotlin.Array<kotlin.Any?>){}[0]
     }
+
+    final object Absent { // kotlinx.rpc.descriptor/RpcInvokator.Absent|null[0]
+        final fun toString(): kotlin/String // kotlinx.rpc.descriptor/RpcInvokator.Absent.toString|toString(){}[0]
+    }
 }
 
 final class kotlinx.rpc/RpcCall { // kotlinx.rpc/RpcCall|null[0]

--- a/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
+++ b/core/src/commonMain/kotlin/kotlinx/rpc/descriptor/RpcServiceDescriptor.kt
@@ -80,6 +80,23 @@ public sealed interface RpcInvokator<@Rpc Service : Any> {
     public fun interface FlowResponse<@Rpc Service : Any> : RpcInvokator<Service> {
         public fun call(service: Service, arguments: Array<Any?>): Flow<Any?>
     }
+
+    /**
+     * Marker for an absent argument of an optional parameter (one declared with a default value,
+     * see [RpcParameter.isOptional]) in the `arguments` array of a
+     * [UnaryResponse.call] or [FlowResponse.call].
+     *
+     * When an element of `arguments` is [Absent], the default value of the corresponding parameter is used.
+     * For parameters of a non-nullable type, `null` is treated the same way as [Absent].
+     *
+     * [Absent] must remain a plain `object`: generated code compares it by identity (`===`),
+     * and stubs compiled against versions without absence handling rely on `Absent as? T`
+     * producing `null` for nullable parameter types.
+     */
+    @ExperimentalRpcApi
+    public object Absent {
+        override fun toString(): String = "Absent"
+    }
 }
 
 @ExperimentalRpcApi

--- a/krpc/krpc-core/src/commonMain/kotlin/kotlinx/rpc/krpc/internal/SerializationUtils.kt
+++ b/krpc/krpc-core/src/commonMain/kotlin/kotlinx/rpc/krpc/internal/SerializationUtils.kt
@@ -5,6 +5,7 @@
 package kotlinx.rpc.krpc.internal
 
 import kotlinx.rpc.descriptor.RpcCallable
+import kotlinx.rpc.descriptor.RpcInvokator
 import kotlinx.rpc.descriptor.RpcType
 import kotlinx.rpc.descriptor.RpcTypeKrpc
 import kotlinx.rpc.internal.rpcInternalKClass
@@ -98,6 +99,17 @@ public fun <T> decodeMessageData(
     }
 }
 
+/**
+ * Serializes RPC call arguments as a class-like structure keyed by parameter names.
+ *
+ * Optional parameters (declared with a default value):
+ * - elements absent from the payload decode as [RpcInvokator.Absent], and the invokator applies the default;
+ * - [RpcInvokator.Absent] elements are skipped on encode.
+ *
+ * Parameters unknown to the receiving side fail decoding unless the configured format
+ * ignores unknown keys — adding an optional parameter is backward compatible
+ * (old client, new server), not forward compatible (new client, old server).
+ */
 @InternalRpcApi
 public class CallableParametersSerializer(
     private val callable: RpcCallable<*>,
@@ -125,6 +137,15 @@ public class CallableParametersSerializer(
     ) {
         encoder.encodeStructure(descriptor) {
             for (i in callable.parameters.indices) {
+                if (value[i] === RpcInvokator.Absent) {
+                    check(callable.parameters[i].isOptional) {
+                        "Parameter '${callable.parameters[i].name}' of '${callable.name}' " +
+                                "is not optional, but no argument was provided"
+                    }
+
+                    continue
+                }
+
                 encodeSerializableElement(descriptor, i, callableSerializers[i], value[i])
             }
         }
@@ -132,11 +153,23 @@ public class CallableParametersSerializer(
 
     override fun deserialize(decoder: Decoder): Array<Any?> {
         return decoder.decodeStructure(descriptor) {
-            val result = arrayOfNulls<Any?>(callable.parameters.size)
+            // optional parameters not present in the payload stay Absent,
+            // the invokator substitutes their default values
+            val result = Array<Any?>(callable.parameters.size) { i ->
+                if (callable.parameters[i].isOptional) RpcInvokator.Absent else null
+            }
+
             while (true) {
                 val index = decodeElementIndex(descriptor)
                 if (index == CompositeDecoder.DECODE_DONE) {
                     break
+                }
+
+                if (index !in result.indices) {
+                    throw SerializationException(
+                        "Unexpected parameter index $index for '${callable.name}', " +
+                                "expected 0..${result.lastIndex}"
+                    )
                 }
 
                 result[index] = decodeSerializableElement(descriptor, index, callableSerializers[index])

--- a/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/OptionalParametersTest.kt
+++ b/krpc/krpc-test/src/commonTest/kotlin/kotlinx/rpc/krpc/test/OptionalParametersTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.krpc.test
+
+import kotlinx.rpc.annotations.Rpc
+import kotlinx.rpc.descriptor.RpcInvokator
+import kotlinx.rpc.descriptor.serviceDescriptorOf
+import kotlinx.rpc.descriptor.unaryInvokator
+import kotlinx.rpc.internal.utils.ExperimentalRpcApi
+import kotlinx.rpc.krpc.KrpcTransportMessage
+import kotlinx.rpc.krpc.internal.CallableParametersSerializer
+import kotlinx.rpc.registerService
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.cbor.Cbor
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Rpc
+interface OptionalParamsService {
+    suspend fun concat(a: Int, b: String = "default", c: String? = "nullable"): String
+}
+
+// "old client" view of OptionalParamsService: the same method before the optional parameters were added
+@Rpc
+interface OptionalParamsServiceV1 {
+    suspend fun concat(a: Int): String
+}
+
+private class OptionalParamsServiceImpl : OptionalParamsService {
+    override suspend fun concat(a: Int, b: String, c: String?): String = "$a-$b-$c"
+}
+
+@OptIn(ExperimentalRpcApi::class, ExperimentalSerializationApi::class)
+class OptionalParametersTest : ProtocolTestBase() {
+    private val callable = serviceDescriptorOf<OptionalParamsService>().getCallable("concat")
+        ?: error("No 'concat' callable found")
+
+    private val callableV1 = serviceDescriptorOf<OptionalParamsServiceV1>().getCallable("concat")
+        ?: error("No V1 'concat' callable found")
+
+    // simulates an old client that does not know about the optional parameters
+    // added to the method by a newer server (#543)
+    @Test
+    fun testAbsentOptionalParametersOnTheWire() = runTest {
+        defaultServer.registerService<OptionalParamsService> { OptionalParamsServiceImpl() }
+
+        val message = KrpcTransportMessage.StringMessage(
+            "{\"type\":\"org.jetbrains.krpc.RPCMessage.CallData\"," +
+                    "\"callId\":\"1:concat:1\"," +
+                    "\"serviceType\":\"kotlinx.rpc.krpc.test.OptionalParamsService\"," +
+                    "\"method\":\"concat\"," +
+                    "\"callType\":\"Method\"," +
+                    "\"data\":\"{\\\"a\\\":1}\"}"
+        )
+
+        transport.client.send(message)
+
+        val response = transport.client.receive() as KrpcTransportMessage.StringMessage
+        assertTrue(
+            response.value.contains("1-default-nullable"),
+            "Expected the server to apply default values, got: ${response.value}",
+        )
+    }
+
+    @Test
+    fun testAllOptionalParametersPresentOnTheWire() = runTest {
+        defaultServer.registerService<OptionalParamsService> { OptionalParamsServiceImpl() }
+
+        val message = KrpcTransportMessage.StringMessage(
+            "{\"type\":\"org.jetbrains.krpc.RPCMessage.CallData\"," +
+                    "\"callId\":\"1:concat:1\"," +
+                    "\"serviceType\":\"kotlinx.rpc.krpc.test.OptionalParamsService\"," +
+                    "\"method\":\"concat\"," +
+                    "\"callType\":\"Method\"," +
+                    "\"data\":\"{\\\"a\\\":5,\\\"b\\\":\\\"x\\\",\\\"c\\\":\\\"y\\\"}\"}"
+        )
+
+        transport.client.send(message)
+
+        val response = transport.client.receive() as KrpcTransportMessage.StringMessage
+        assertTrue(
+            response.value.contains("5-x-y"),
+            "Expected provided values to be used, got: ${response.value}",
+        )
+    }
+
+    @Test
+    fun testAbsentParametersSerialization() = runTest {
+        val json = Json
+        val serializer = CallableParametersSerializer(callable, json.serializersModule)
+        val service = OptionalParamsServiceImpl()
+
+        // absent optional parameters are not encoded
+        val encoded = json.encodeToString(serializer, arrayOf<Any?>(1, RpcInvokator.Absent, RpcInvokator.Absent))
+        assertEquals("""{"a":1}""", encoded)
+
+        // and are decoded back as absent
+        val decoded = json.decodeFromString(serializer, encoded)
+        assertEquals(listOf<Any?>(1, RpcInvokator.Absent, RpcInvokator.Absent), decoded.toList())
+
+        assertEquals("1-default-nullable", callable.unaryInvokator.call(service, decoded))
+
+        // explicit null for a parameter of a nullable type is preserved, not defaulted
+        val decodedNull = json.decodeFromString(serializer, """{"a":2,"c":null}""")
+        assertEquals("2-default-null", callable.unaryInvokator.call(service, decodedNull))
+    }
+
+    // the serializer always encodes explicit nulls, even with explicitNulls = false —
+    // so between kRPC peers, wire-field absence always means argument absence, never explicit null
+    @Test
+    fun testExplicitNullSurvivesExplicitNullsFalse() = runTest {
+        val json = Json { explicitNulls = false }
+        val serializer = CallableParametersSerializer(callable, json.serializersModule)
+
+        val encoded = json.encodeToString(serializer, arrayOf<Any?>(1, "b", null))
+        assertEquals("""{"a":1,"b":"b","c":null}""", encoded)
+
+        val decoded = json.decodeFromString(serializer, encoded)
+        assertEquals("1-b-null", callable.unaryInvokator.call(OptionalParamsServiceImpl(), decoded))
+    }
+
+    @Test
+    fun testAbsentOptionalParametersDecodeCbor() = runTest {
+        val cbor = Cbor
+        val v1Payload = cbor.encodeToByteArray(
+            CallableParametersSerializer(callableV1, cbor.serializersModule),
+            arrayOf<Any?>(1),
+        )
+
+        val decoded = cbor.decodeFromByteArray(CallableParametersSerializer(callable, cbor.serializersModule), v1Payload)
+        assertEquals(listOf<Any?>(1, RpcInvokator.Absent, RpcInvokator.Absent), decoded.toList())
+        assertEquals("1-default-nullable", callable.unaryInvokator.call(OptionalParamsServiceImpl(), decoded))
+    }
+
+    @Test
+    fun testAbsentOptionalParametersCborDefiniteLengthRoundTrip() = runTest {
+        val cbor = Cbor { useDefiniteLengthEncoding = true }
+        val serializer = CallableParametersSerializer(callable, cbor.serializersModule)
+
+        val encoded = cbor.encodeToByteArray(serializer, arrayOf<Any?>(1, RpcInvokator.Absent, RpcInvokator.Absent))
+        val decoded = cbor.decodeFromByteArray(serializer, encoded)
+
+        assertEquals(listOf<Any?>(1, RpcInvokator.Absent, RpcInvokator.Absent), decoded.toList())
+    }
+
+    @Test
+    fun testAbsentOptionalParametersDecodeProtobuf() = runTest {
+        val protobuf = ProtoBuf
+        val v1Payload = protobuf.encodeToByteArray(
+            CallableParametersSerializer(callableV1, protobuf.serializersModule),
+            arrayOf<Any?>(1),
+        )
+
+        val decoded = protobuf.decodeFromByteArray(
+            CallableParametersSerializer(callable, protobuf.serializersModule),
+            v1Payload,
+        )
+        assertEquals(listOf<Any?>(1, RpcInvokator.Absent, RpcInvokator.Absent), decoded.toList())
+        assertEquals("1-default-nullable", callable.unaryInvokator.call(OptionalParamsServiceImpl(), decoded))
+    }
+}

--- a/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
+++ b/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/BoxTestGenerated.java
@@ -45,6 +45,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
   }
 
   @Test
+  @TestMetadata("optionalParameters.kt")
+  public void testOptionalParameters() {
+    runTest("src/testData/box/optionalParameters.kt");
+  }
+
+  @Test
   @TestMetadata("protoMessage.kt")
   public void testProtoMessage() {
     runTest("src/testData/box/protoMessage.kt");

--- a/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/DiagnosticTestGenerated.java
+++ b/tests/compiler-plugin-tests/src/test-gen/kotlinx/rpc/codegen/test/runners/DiagnosticTestGenerated.java
@@ -33,6 +33,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
   }
 
   @Test
+  @TestMetadata("optionalParameters.kt")
+  public void testOptionalParameters() {
+    runTest("src/testData/diagnostics/optionalParameters.kt");
+  }
+
+  @Test
   @TestMetadata("protoMessage.kt")
   public void testProtoMessage() {
     runTest("src/testData/diagnostics/protoMessage.kt");

--- a/tests/compiler-plugin-tests/src/testData/box/optionalParameters.fir.ir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/optionalParameters.fir.ir.txt
@@ -1,0 +1,686 @@
+FILE fqName:<root> fileName:/optionalParameters.kt
+  CLASS CLASS name:BoxServiceImpl modality:FINAL visibility:public superTypes:[<root>.BoxService]
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxServiceImpl
+    CONSTRUCTOR visibility:public returnType:<root>.BoxServiceImpl [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:BoxServiceImpl modality:FINAL visibility:public superTypes:[<root>.BoxService]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BoxService
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in <root>.BoxService
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in <root>.BoxService
+    FUN name:streamWithDefaults visibility:public modality:OPEN returnType:kotlinx.coroutines.flow.Flow<kotlin.String>
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxServiceImpl
+      VALUE_PARAMETER kind:Regular name:a index:1 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:b index:2 type:kotlin.String
+      overridden:
+        public abstract fun streamWithDefaults (a: kotlin.Int, b: kotlin.String): kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxService
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun streamWithDefaults (a: kotlin.Int, b: kotlin.String): kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxServiceImpl'
+          CALL 'public final fun flowOf <T> (value: T of kotlinx.coroutines.flow.flowOf): kotlinx.coroutines.flow.Flow<T of kotlinx.coroutines.flow.flowOf> declared in kotlinx.coroutines.flow' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
+            TYPE_ARG T: kotlin.String
+            ARG value: STRING_CONCATENATION type=kotlin.String
+              GET_VAR 'a: kotlin.Int declared in <root>.BoxServiceImpl.streamWithDefaults' type=kotlin.Int origin=null
+              CONST String type=kotlin.String value="-"
+              GET_VAR 'b: kotlin.String declared in <root>.BoxServiceImpl.streamWithDefaults' type=kotlin.String origin=null
+    FUN name:withDefaults visibility:public modality:OPEN returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxServiceImpl
+      VALUE_PARAMETER kind:Regular name:a index:1 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:b index:2 type:kotlin.String
+      VALUE_PARAMETER kind:Regular name:c index:3 type:kotlin.String?
+      overridden:
+        public abstract fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxService
+      BLOCK_BODY
+        RETURN type=kotlin.Nothing from='public open fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxServiceImpl'
+          STRING_CONCATENATION type=kotlin.String
+            GET_VAR 'a: kotlin.Int declared in <root>.BoxServiceImpl.withDefaults' type=kotlin.Int origin=null
+            CONST String type=kotlin.String value="-"
+            GET_VAR 'b: kotlin.String declared in <root>.BoxServiceImpl.withDefaults' type=kotlin.String origin=null
+            CONST String type=kotlin.String value="-"
+            GET_VAR 'c: kotlin.String? declared in <root>.BoxServiceImpl.withDefaults' type=kotlin.String? origin=null
+  CLASS INTERFACE name:BoxService modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Rpc
+      WithServiceDescriptor(stub = CLASS_REFERENCE 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=kotlin.reflect.KClass<<root>.BoxService.$rpcServiceStub.Companion>)
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService
+    CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]
+      thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub
+      PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
+        FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]
+          EXPRESSION_BODY
+            GET_VAR '__rpc_stub_id: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlin.Long origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_stub_id> visibility:private modality:FINAL returnType:kotlin.Long
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+          correspondingProperty: PROPERTY name:__rpc_stub_id visibility:private modality:FINAL [val]
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_stub_id type:kotlin.Long visibility:private [final]' type=kotlin.Long origin=null
+                receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_stub_id>' type=<root>.BoxService.$rpcServiceStub origin=null
+      PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
+        FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]
+          EXPRESSION_BODY
+            GET_VAR '__rpc_client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.<init>' type=kotlinx.rpc.RpcClient origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+        FUN DEFAULT_PROPERTY_ACCESSOR name:<get-__rpc_client> visibility:private modality:FINAL returnType:kotlinx.rpc.RpcClient
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+          correspondingProperty: PROPERTY name:__rpc_client visibility:private modality:FINAL [val]
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub'
+              GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:__rpc_client type:kotlinx.rpc.RpcClient visibility:private [final]' type=kotlinx.rpc.RpcClient origin=null
+                receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.<get-__rpc_client>' type=<root>.BoxService.$rpcServiceStub origin=null
+      CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]
+        thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:<root>.BoxService.$rpcServiceStub.Companion
+        PROPERTY name:simpleName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract simpleName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-simpleName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:simpleName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-simpleName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-simpleName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:simpleName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-simpleName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:fqName visibility:public modality:FINAL [val]
+          overridden:
+            public abstract fqName: kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]
+            EXPRESSION_BODY
+              CONST String type=kotlin.String value="BoxService"
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-fqName> visibility:public modality:FINAL returnType:kotlin.String
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:fqName visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-fqName> (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-fqName> (): kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:fqName type:kotlin.String visibility:private [final]' type=kotlin.String origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-fqName>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:withDefaultsInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:withDefaultsInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.coroutines.SuspendFunction2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlin.Any?> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.Any? [suspend]
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:kotlin.Any? [val]
+                        CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                          ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                          ARG index: CONST Int type=kotlin.Int value=1
+                      VAR IR_TEMPORARY_VARIABLE name:tmp_1 type:kotlin.Any? [val]
+                        CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                          ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                          ARG index: CONST Int type=kotlin.Int value=2
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator'
+                        WHEN type=kotlin.String origin=null
+                          BRANCH
+                            if: WHEN type=kotlin.Boolean origin=OROR
+                              BRANCH
+                                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                                  ARG arg0: GET_VAR 'val tmp_0: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                                then: CONST Boolean type=kotlin.Boolean value=true
+                              BRANCH
+                                if: CONST Boolean type=kotlin.Boolean value=true
+                                then: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+                                  ARG arg0: GET_VAR 'val tmp_0: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                                  ARG arg1: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Absent modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlinx.rpc.descriptor.RpcInvokator.Absent
+                            then: WHEN type=kotlin.String origin=null
+                              BRANCH
+                                if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+                                  ARG arg0: GET_VAR 'val tmp_1: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                                  ARG arg1: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Absent modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlinx.rpc.descriptor.RpcInvokator.Absent
+                                then: CALL 'public abstract fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
+                                  ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=<root>.BoxService origin=null
+                                  ARG a: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+                                    CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                                      ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                                      ARG index: CONST Int type=kotlin.Int value=0
+                              BRANCH
+                                if: CONST Boolean type=kotlin.Boolean value=true
+                                then: CALL 'public abstract fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
+                                  ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=<root>.BoxService origin=null
+                                  ARG a: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+                                    CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                                      ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                                      ARG index: CONST Int type=kotlin.Int value=0
+                                  ARG c: TYPE_OP type=kotlin.String? origin=SAFE_CAST typeOperand=kotlin.String?
+                                    GET_VAR 'val tmp_1: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                          BRANCH
+                            if: CONST Boolean type=kotlin.Boolean value=true
+                            then: WHEN type=kotlin.String origin=null
+                              BRANCH
+                                if: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+                                  ARG arg0: GET_VAR 'val tmp_1: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                                  ARG arg1: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Absent modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlinx.rpc.descriptor.RpcInvokator.Absent
+                                then: CALL 'public abstract fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
+                                  ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=<root>.BoxService origin=null
+                                  ARG a: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+                                    CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                                      ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                                      ARG index: CONST Int type=kotlin.Int value=0
+                                  ARG b: TYPE_OP type=kotlin.String origin=CAST typeOperand=kotlin.String
+                                    GET_VAR 'val tmp_0: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                              BRANCH
+                                if: CONST Boolean type=kotlin.Boolean value=true
+                                then: CALL 'public abstract fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxService' type=kotlin.String origin=null
+                                  ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=<root>.BoxService origin=null
+                                  ARG a: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+                                    CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                                      ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                                      ARG index: CONST Int type=kotlin.Int value=0
+                                  ARG b: TYPE_OP type=kotlin.String origin=CAST typeOperand=kotlin.String
+                                    GET_VAR 'val tmp_0: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                                  ARG c: TYPE_OP type=kotlin.String? origin=SAFE_CAST typeOperand=kotlin.String?
+                                    GET_VAR 'val tmp_1: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.withDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-withDefaultsInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:withDefaultsInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-withDefaultsInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:withDefaultsInvokator type:kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-withDefaultsInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:streamWithDefaultsInvokator visibility:private modality:FINAL [val]
+          FIELD PROPERTY_BACKING_FIELD name:streamWithDefaultsInvokator type:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> visibility:private [final]
+            EXPRESSION_BODY
+              TYPE_OP type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=SAM_CONVERSION typeOperand=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService>
+                FUN_EXPR type=kotlin.Function2<<root>.BoxService, kotlin.Array<out kotlin.Any?>, kotlinx.coroutines.flow.Flow<kotlin.Any?>> origin=LAMBDA
+                  FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlinx.coroutines.flow.Flow<kotlin.Any?>
+                    VALUE_PARAMETER kind:Regular name:service index:0 type:<root>.BoxService
+                    VALUE_PARAMETER kind:Regular name:arguments index:1 type:kotlin.Array<out kotlin.Any?>
+                    BLOCK_BODY
+                      VAR IR_TEMPORARY_VARIABLE name:tmp_2 type:kotlin.Any? [val]
+                        CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                          ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                          ARG index: CONST Int type=kotlin.Int value=1
+                      RETURN type=kotlin.Nothing from='local final fun <anonymous> (service: <root>.BoxService, arguments: kotlin.Array<out kotlin.Any?>): kotlinx.coroutines.flow.Flow<kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator'
+                        WHEN type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
+                          BRANCH
+                            if: WHEN type=kotlin.Boolean origin=OROR
+                              BRANCH
+                                if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                                  ARG arg0: GET_VAR 'val tmp_2: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                                  ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                                then: CONST Boolean type=kotlin.Boolean value=true
+                              BRANCH
+                                if: CONST Boolean type=kotlin.Boolean value=true
+                                then: CALL 'public final fun EQEQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQEQ
+                                  ARG arg0: GET_VAR 'val tmp_2: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+                                  ARG arg1: GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Absent modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlinx.rpc.descriptor.RpcInvokator.Absent
+                            then: CALL 'public abstract fun streamWithDefaults (a: kotlin.Int, b: kotlin.String): kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxService' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
+                              ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=<root>.BoxService origin=null
+                              ARG a: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+                                CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                                  ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                                  ARG index: CONST Int type=kotlin.Int value=0
+                          BRANCH
+                            if: CONST Boolean type=kotlin.Boolean value=true
+                            then: CALL 'public abstract fun streamWithDefaults (a: kotlin.Int, b: kotlin.String): kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxService' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
+                              ARG <this>: GET_VAR 'service: <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=<root>.BoxService origin=null
+                              ARG a: TYPE_OP type=kotlin.Int origin=CAST typeOperand=kotlin.Int
+                                CALL 'public final fun get (index: kotlin.Int): T of kotlin.Array declared in kotlin.Array' type=kotlin.Any? origin=GET_ARRAY_ELEMENT
+                                  ARG <this>: GET_VAR 'arguments: kotlin.Array<out kotlin.Any?> declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=kotlin.Array<out kotlin.Any?> origin=null
+                                  ARG index: CONST Int type=kotlin.Int value=0
+                              ARG b: TYPE_OP type=kotlin.String origin=CAST typeOperand=kotlin.String
+                                GET_VAR 'val tmp_2: kotlin.Any? declared in <root>.BoxService.$rpcServiceStub.Companion.streamWithDefaultsInvokator.<anonymous>' type=kotlin.Any? origin=null
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-streamWithDefaultsInvokator> visibility:private modality:FINAL returnType:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:streamWithDefaultsInvokator visibility:private modality:FINAL [val]
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='private final fun <get-streamWithDefaultsInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:streamWithDefaultsInvokator type:kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> visibility:private [final]' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-streamWithDefaultsInvokator>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        PROPERTY name:callables visibility:public modality:FINAL [val]
+          overridden:
+            public abstract callables: kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          FIELD PROPERTY_BACKING_FIELD name:callables type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]
+            EXPRESSION_BODY
+              CALL 'public final fun mapOf <K, V> (vararg pairs: kotlin.Pair<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf>): kotlin.collections.Map<K of kotlin.collections.mapOf, V of kotlin.collections.mapOf> declared in kotlin.collections' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                TYPE_ARG K: kotlin.String
+                TYPE_ARG V: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                ARG pairs: VARARG type=kotlin.Array<out kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>> varargElementType=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="withDefaults"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="withDefaults"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-withDefaultsInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="a"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlin.Int
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="b"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlin.String
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=true
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="c"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlin.String?
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=true
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                  CALL 'public final fun to <A, B> (<this>: A of kotlin.to, that: B of kotlin.to): kotlin.Pair<A of kotlin.to, B of kotlin.to> declared in kotlin' type=kotlin.Pair<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                    TYPE_ARG A: kotlin.String
+                    TYPE_ARG B: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>
+                    ARG <this>: CONST String type=kotlin.String value="streamWithDefaults"
+                    ARG that: CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, returnType: kotlinx.rpc.descriptor.RpcType, invokator: kotlinx.rpc.descriptor.RpcInvokator<Service of kotlinx.rpc.descriptor.RpcCallableDefault>, parameters: kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter>) declared in kotlinx.rpc.descriptor.RpcCallableDefault' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG name: CONST String type=kotlin.String value="streamWithDefaults"
+                      ARG returnType: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                        ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                          TYPE_ARG T: kotlin.String
+                        ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                          TYPE_ARG T: kotlin.Annotation
+                      ARG invokator: CALL 'private final fun <get-streamWithDefaultsInvokator> (): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=GET_PROPERTY
+                        ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                      ARG parameters: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> origin=null
+                        TYPE_ARG T: kotlinx.rpc.descriptor.RpcParameter
+                        ARG elements: VARARG type=kotlin.Array<out kotlinx.rpc.descriptor.RpcParameter> varargElementType=kotlinx.rpc.descriptor.RpcParameter
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="a"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlin.Int
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=false
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+                          CONSTRUCTOR_CALL 'public constructor <init> (name: kotlin.String, type: kotlinx.rpc.descriptor.RpcType, isOptional: kotlin.Boolean, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcParameterDefault' type=kotlinx.rpc.descriptor.RpcParameter origin=null
+                            ARG name: CONST String type=kotlin.String value="b"
+                            ARG type: CONSTRUCTOR_CALL 'public constructor <init> (kType: kotlin.reflect.KType, annotations: kotlin.collections.List<kotlin.Annotation>) declared in kotlinx.rpc.descriptor.RpcTypeDefault' type=kotlinx.rpc.descriptor.RpcType origin=null
+                              ARG kType: CALL 'public final fun typeOf <T> (): kotlin.reflect.KType declared in kotlin.reflect' type=kotlin.reflect.KType origin=null
+                                TYPE_ARG T: kotlin.String
+                              ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                                TYPE_ARG T: kotlin.Annotation
+                            ARG isOptional: CONST Boolean type=kotlin.Boolean value=true
+                            ARG annotations: CALL 'public final fun emptyList <T> (): kotlin.collections.List<T of kotlin.collections.emptyList> declared in kotlin.collections' type=kotlin.collections.List<kotlin.Annotation> origin=null
+                              TYPE_ARG T: kotlin.Annotation
+          FUN DEFAULT_PROPERTY_ACCESSOR name:<get-callables> visibility:public modality:FINAL returnType:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>>
+            VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+            correspondingProperty: PROPERTY name:callables visibility:public modality:FINAL [val]
+            overridden:
+              public abstract fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>> declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+            BLOCK_BODY
+              RETURN type=kotlin.Nothing from='public final fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion'
+                GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:callables type:kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> visibility:private [final]' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=null
+                  receiver: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.<get-callables>' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+        CONSTRUCTOR visibility:private returnType:<root>.BoxService.$rpcServiceStub.Companion [primary]
+          BLOCK_BODY
+            DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+            INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=kotlin.Unit
+        FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+          overridden:
+            public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+        FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun hashCode (): kotlin.Int declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+        FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+          overridden:
+            public open fun toString (): kotlin.String declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+        FUN name:createInstance visibility:public modality:OPEN returnType:<root>.BoxService
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:serviceId index:1 type:kotlin.Long
+          VALUE_PARAMETER kind:Regular name:client index:2 type:kotlinx.rpc.RpcClient
+          overridden:
+            public abstract fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): Service of kotlinx.rpc.descriptor.RpcServiceDescriptor declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public open fun createInstance (serviceId: kotlin.Long, client: kotlinx.rpc.RpcClient): <root>.BoxService declared in <root>.BoxService.$rpcServiceStub.Companion'
+              CONSTRUCTOR_CALL 'public constructor <init> (__rpc_stub_id: kotlin.Long, __rpc_client: kotlinx.rpc.RpcClient) declared in <root>.BoxService.$rpcServiceStub' type=<root>.BoxService.$rpcServiceStub origin=null
+                ARG __rpc_stub_id: GET_VAR 'serviceId: kotlin.Long declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlin.Long origin=null
+                ARG __rpc_client: GET_VAR 'client: kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub.Companion.createInstance' type=kotlinx.rpc.RpcClient origin=null
+        FUN name:getCallable visibility:public modality:FINAL returnType:kotlinx.rpc.descriptor.RpcCallable?
+          VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub.Companion
+          VALUE_PARAMETER kind:Regular name:name index:1 type:kotlin.String
+          overridden:
+            public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor
+          BLOCK_BODY
+            RETURN type=kotlin.Nothing from='public final fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable? declared in <root>.BoxService.$rpcServiceStub.Companion'
+              CALL 'public abstract fun get (key: K of kotlin.collections.Map): V of kotlin.collections.Map? declared in kotlin.collections.Map' type=kotlinx.rpc.descriptor.RpcCallable? origin=GET_ARRAY_ELEMENT
+                ARG <this>: CALL 'public final fun <get-callables> (): kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> declared in <root>.BoxService.$rpcServiceStub.Companion' type=kotlin.collections.Map<kotlin.String, kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>> origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub.Companion declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=<root>.BoxService.$rpcServiceStub.Companion origin=null
+                ARG key: GET_VAR 'name: kotlin.String declared in <root>.BoxService.$rpcServiceStub.Companion.getCallable' type=kotlin.String origin=null
+      CONSTRUCTOR visibility:public returnType:<root>.BoxService.$rpcServiceStub [primary]
+        VALUE_PARAMETER kind:Regular name:__rpc_stub_id index:0 type:kotlin.Long
+        VALUE_PARAMETER kind:Regular name:__rpc_client index:1 type:kotlinx.rpc.RpcClient
+        BLOCK_BODY
+          DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+          INSTANCE_INITIALIZER_CALL classDescriptor='CLASS GENERATED[kotlinx.rpc.codegen.RpcGeneratedStubKey] CLASS name:$rpcServiceStub modality:FINAL visibility:public superTypes:[<root>.BoxService]' type=kotlin.Unit
+      FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+        overridden:
+          public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in <root>.BoxService
+      FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun hashCode (): kotlin.Int declared in <root>.BoxService
+      FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+        overridden:
+          public open fun toString (): kotlin.String declared in <root>.BoxService
+      FUN name:streamWithDefaults visibility:public modality:OPEN returnType:kotlinx.coroutines.flow.Flow<kotlin.String>
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:a index:1 type:kotlin.Int
+        VALUE_PARAMETER kind:Regular name:b index:2 type:kotlin.String
+        overridden:
+          public abstract fun streamWithDefaults (a: kotlin.Int, b: kotlin.String): kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxService
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun streamWithDefaults (a: kotlin.Int, b: kotlin.String): kotlinx.coroutines.flow.Flow<kotlin.String> declared in <root>.BoxService.$rpcServiceStub'
+            CALL 'public abstract fun callServerStreaming <T> (call: kotlinx.rpc.RpcCall): kotlinx.coroutines.flow.Flow<T of kotlinx.rpc.RpcClient.callServerStreaming> declared in kotlinx.rpc.RpcClient' type=kotlinx.coroutines.flow.Flow<kotlin.String> origin=null
+              TYPE_ARG T: kotlinx.coroutines.flow.Flow<kotlin.String>
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.streamWithDefaults' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="streamWithDefaults"
+                ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                  ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+                    GET_VAR 'a: kotlin.Int declared in <root>.BoxService.$rpcServiceStub.streamWithDefaults' type=kotlin.Int origin=null
+                    GET_VAR 'b: kotlin.String declared in <root>.BoxService.$rpcServiceStub.streamWithDefaults' type=kotlin.String origin=null
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.streamWithDefaults' type=<root>.BoxService.$rpcServiceStub origin=null
+      FUN name:withDefaults visibility:public modality:OPEN returnType:kotlin.String [suspend]
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService.$rpcServiceStub
+        VALUE_PARAMETER kind:Regular name:a index:1 type:kotlin.Int
+        VALUE_PARAMETER kind:Regular name:b index:2 type:kotlin.String
+        VALUE_PARAMETER kind:Regular name:c index:3 type:kotlin.String?
+        overridden:
+          public abstract fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxService
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public open fun withDefaults (a: kotlin.Int, b: kotlin.String, c: kotlin.String?): kotlin.String declared in <root>.BoxService.$rpcServiceStub'
+            CALL 'public abstract fun call <T> (call: kotlinx.rpc.RpcCall): T of kotlinx.rpc.RpcClient.call declared in kotlinx.rpc.RpcClient' type=kotlin.String origin=null
+              TYPE_ARG T: kotlin.String
+              ARG <this>: CALL 'private final fun <get-__rpc_client> (): kotlinx.rpc.RpcClient declared in <root>.BoxService.$rpcServiceStub' type=kotlinx.rpc.RpcClient origin=GET_PROPERTY
+                ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.withDefaults' type=<root>.BoxService.$rpcServiceStub origin=null
+              ARG call: CONSTRUCTOR_CALL 'public constructor <init> (descriptor: kotlinx.rpc.descriptor.RpcServiceDescriptor<*>, callableName: kotlin.String, arguments: kotlin.Array<kotlin.Any?>, serviceId: kotlin.Long) declared in kotlinx.rpc.RpcCall' type=kotlinx.rpc.RpcCall origin=null
+                ARG descriptor: GET_OBJECT 'CLASS GENERATED[kotlinx.rpc.codegen.FirRpcServiceStubCompanionObject] OBJECT name:Companion modality:FINAL visibility:public [companion] superTypes:[kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService>]' type=<root>.BoxService.$rpcServiceStub.Companion
+                ARG callableName: CONST String type=kotlin.String value="withDefaults"
+                ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<out kotlin.Any?> origin=null
+                  TYPE_ARG T: kotlin.Any?
+                  ARG elements: VARARG type=kotlin.Array<kotlin.Any?> varargElementType=kotlin.Any?
+                    GET_VAR 'a: kotlin.Int declared in <root>.BoxService.$rpcServiceStub.withDefaults' type=kotlin.Int origin=null
+                    GET_VAR 'b: kotlin.String declared in <root>.BoxService.$rpcServiceStub.withDefaults' type=kotlin.String origin=null
+                    GET_VAR 'c: kotlin.String? declared in <root>.BoxService.$rpcServiceStub.withDefaults' type=kotlin.String? origin=null
+                ARG serviceId: CALL 'private final fun <get-__rpc_stub_id> (): kotlin.Long declared in <root>.BoxService.$rpcServiceStub' type=kotlin.Long origin=GET_PROPERTY
+                  ARG <this>: GET_VAR '<this>: <root>.BoxService.$rpcServiceStub declared in <root>.BoxService.$rpcServiceStub.withDefaults' type=<root>.BoxService.$rpcServiceStub origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+    FUN name:streamWithDefaults visibility:public modality:ABSTRACT returnType:kotlinx.coroutines.flow.Flow<kotlin.String>
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:a index:1 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:b index:2 type:kotlin.String
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="s"
+    FUN name:withDefaults visibility:public modality:ABSTRACT returnType:kotlin.String [suspend]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:<root>.BoxService
+      VALUE_PARAMETER kind:Regular name:a index:1 type:kotlin.Int
+      VALUE_PARAMETER kind:Regular name:b index:2 type:kotlin.String
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="b"
+      VALUE_PARAMETER kind:Regular name:c index:3 type:kotlin.String?
+        EXPRESSION_BODY
+          CONST String type=kotlin.String value="c"
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    annotations:
+      OptIn(markerClass = [CLASS_REFERENCE 'CLASS IR_EXTERNAL_DECLARATION_STUB ANNOTATION_CLASS name:ExperimentalRpcApi modality:OPEN visibility:public superTypes:[kotlin.Annotation]' type=kotlin.reflect.KClass<kotlinx.rpc.internal.utils.ExperimentalRpcApi>] type=kotlin.Array<out kotlin.reflect.KClass<out kotlin.Annotation>> varargElementType=kotlin.reflect.KClass<out kotlin.Annotation>)
+    BLOCK_BODY
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in <root>'
+        CALL 'public final fun runBlocking <T> (context: kotlin.coroutines.CoroutineContext, block: @[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, T of kotlinx.coroutines.runBlocking>): T of kotlinx.coroutines.runBlocking declared in kotlinx.coroutines' type=kotlin.String origin=null
+          TYPE_ARG T: kotlin.String
+          ARG block: FUN_EXPR type=@[ExtensionFunctionType] kotlin.coroutines.SuspendFunction1<kotlinx.coroutines.CoroutineScope, kotlin.String> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL returnType:kotlin.String [suspend]
+              VALUE_PARAMETER kind:ExtensionReceiver name:$this$runBlocking index:0 type:kotlinx.coroutines.CoroutineScope
+              BLOCK_BODY
+                VAR name:callable type:kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> [val]
+                  BLOCK type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=ELVIS
+                    VAR IR_TEMPORARY_VARIABLE name:tmp_3 type:kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? [val]
+                      CALL 'public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? origin=null
+                        ARG <this>: CALL 'public final fun serviceDescriptorOf <Service> (): kotlinx.rpc.descriptor.RpcServiceDescriptor<Service of kotlinx.rpc.descriptor.serviceDescriptorOf> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService> origin=null
+                          TYPE_ARG Service: <root>.BoxService
+                        ARG name: CONST String type=kotlin.String value="withDefaults"
+                    WHEN type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      BRANCH
+                        if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                          ARG arg0: GET_VAR 'val tmp_3: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? origin=null
+                          ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                        then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                          CONST String type=kotlin.String value="Fail: no callable"
+                      BRANCH
+                        if: CONST Boolean type=kotlin.Boolean value=true
+                        then: GET_VAR 'val tmp_3: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? origin=null
+                VAR name:service type:<root>.BoxServiceImpl [val]
+                  CONSTRUCTOR_CALL 'public constructor <init> () declared in <root>.BoxServiceImpl' type=<root>.BoxServiceImpl origin=null
+                VAR name:allAbsent type:kotlin.Any? [val]
+                  CALL 'public abstract fun call (service: Service of kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse, arguments: kotlin.Array<kotlin.Any?>): kotlin.Any? declared in kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse' type=kotlin.Any? origin=null
+                    ARG <this>: CALL 'public final fun <get-unaryInvokator> <Service> (<this>: kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>>): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG <this>: GET_VAR 'val callable: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                    ARG service: GET_VAR 'val service: <root>.BoxServiceImpl declared in <root>.box.<anonymous>' type=<root>.BoxServiceImpl origin=null
+                    ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<kotlin.Any?> origin=null
+                      TYPE_ARG T: kotlin.Any?
+                      ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                        CONST Int type=kotlin.Int value=1
+                        GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Absent modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlinx.rpc.descriptor.RpcInvokator.Absent
+                        GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Absent modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlinx.rpc.descriptor.RpcInvokator.Absent
+                WHEN type=kotlin.Unit origin=IF
+                  BRANCH
+                    if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                      ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                        ARG arg0: GET_VAR 'val allAbsent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                        ARG arg1: CONST String type=kotlin.String value="1-b-c"
+                    then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                      STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="Fail: "
+                        GET_VAR 'val allAbsent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                VAR name:nullForNonNullable type:kotlin.Any? [val]
+                  CALL 'public abstract fun call (service: Service of kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse, arguments: kotlin.Array<kotlin.Any?>): kotlin.Any? declared in kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse' type=kotlin.Any? origin=null
+                    ARG <this>: CALL 'public final fun <get-unaryInvokator> <Service> (<this>: kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>>): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG <this>: GET_VAR 'val callable: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                    ARG service: GET_VAR 'val service: <root>.BoxServiceImpl declared in <root>.box.<anonymous>' type=<root>.BoxServiceImpl origin=null
+                    ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<kotlin.Any?> origin=null
+                      TYPE_ARG T: kotlin.Any?
+                      ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                        CONST Int type=kotlin.Int value=2
+                        CONST Null type=kotlin.Nothing? value=null
+                        CONST String type=kotlin.String value="override"
+                WHEN type=kotlin.Unit origin=IF
+                  BRANCH
+                    if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                      ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                        ARG arg0: GET_VAR 'val nullForNonNullable: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                        ARG arg1: CONST String type=kotlin.String value="2-b-override"
+                    then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                      STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="Fail: "
+                        GET_VAR 'val nullForNonNullable: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                VAR name:explicitNull type:kotlin.Any? [val]
+                  CALL 'public abstract fun call (service: Service of kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse, arguments: kotlin.Array<kotlin.Any?>): kotlin.Any? declared in kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse' type=kotlin.Any? origin=null
+                    ARG <this>: CALL 'public final fun <get-unaryInvokator> <Service> (<this>: kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>>): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG <this>: GET_VAR 'val callable: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                    ARG service: GET_VAR 'val service: <root>.BoxServiceImpl declared in <root>.box.<anonymous>' type=<root>.BoxServiceImpl origin=null
+                    ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<kotlin.Any?> origin=null
+                      TYPE_ARG T: kotlin.Any?
+                      ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                        CONST Int type=kotlin.Int value=3
+                        CONST String type=kotlin.String value="override"
+                        CONST Null type=kotlin.Nothing? value=null
+                WHEN type=kotlin.Unit origin=IF
+                  BRANCH
+                    if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                      ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                        ARG arg0: GET_VAR 'val explicitNull: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                        ARG arg1: CONST String type=kotlin.String value="3-override-null"
+                    then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                      STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="Fail: "
+                        GET_VAR 'val explicitNull: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                VAR name:allPresent type:kotlin.Any? [val]
+                  CALL 'public abstract fun call (service: Service of kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse, arguments: kotlin.Array<kotlin.Any?>): kotlin.Any? declared in kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse' type=kotlin.Any? origin=null
+                    ARG <this>: CALL 'public final fun <get-unaryInvokator> <Service> (<this>: kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>>): kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<Service of kotlinx.rpc.descriptor.<get-unaryInvokator>> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcInvokator.UnaryResponse<<root>.BoxService> origin=GET_PROPERTY
+                      TYPE_ARG Service: <root>.BoxService
+                      ARG <this>: GET_VAR 'val callable: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                    ARG service: GET_VAR 'val service: <root>.BoxServiceImpl declared in <root>.box.<anonymous>' type=<root>.BoxServiceImpl origin=null
+                    ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<kotlin.Any?> origin=null
+                      TYPE_ARG T: kotlin.Any?
+                      ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                        CONST Int type=kotlin.Int value=4
+                        CONST String type=kotlin.String value="b2"
+                        CONST String type=kotlin.String value="c2"
+                WHEN type=kotlin.Unit origin=IF
+                  BRANCH
+                    if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                      ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                        ARG arg0: GET_VAR 'val allPresent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                        ARG arg1: CONST String type=kotlin.String value="4-b2-c2"
+                    then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                      STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="Fail: "
+                        GET_VAR 'val allPresent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                VAR name:streamCallable type:kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> [val]
+                  BLOCK type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=ELVIS
+                    VAR IR_TEMPORARY_VARIABLE name:tmp_4 type:kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? [val]
+                      CALL 'public abstract fun getCallable (name: kotlin.String): kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.RpcServiceDescriptor>? declared in kotlinx.rpc.descriptor.RpcServiceDescriptor' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? origin=null
+                        ARG <this>: CALL 'public final fun serviceDescriptorOf <Service> (): kotlinx.rpc.descriptor.RpcServiceDescriptor<Service of kotlinx.rpc.descriptor.serviceDescriptorOf> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcServiceDescriptor<<root>.BoxService> origin=null
+                          TYPE_ARG Service: <root>.BoxService
+                        ARG name: CONST String type=kotlin.String value="streamWithDefaults"
+                    WHEN type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      BRANCH
+                        if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+                          ARG arg0: GET_VAR 'val tmp_4: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? origin=null
+                          ARG arg1: CONST Null type=kotlin.Nothing? value=null
+                        then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                          CONST String type=kotlin.String value="Fail: no stream callable"
+                      BRANCH
+                        if: CONST Boolean type=kotlin.Boolean value=true
+                        then: GET_VAR 'val tmp_4: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService>? origin=null
+                VAR name:streamAbsent type:kotlin.Any? [val]
+                  CALL 'public final fun single <T> (<this>: kotlinx.coroutines.flow.Flow<T of kotlinx.coroutines.flow.single>): T of kotlinx.coroutines.flow.single declared in kotlinx.coroutines.flow' type=kotlin.Any? origin=null
+                    TYPE_ARG T: kotlin.Any?
+                    ARG <this>: CALL 'public abstract fun call (service: Service of kotlinx.rpc.descriptor.RpcInvokator.FlowResponse, arguments: kotlin.Array<kotlin.Any?>): kotlinx.coroutines.flow.Flow<kotlin.Any?> declared in kotlinx.rpc.descriptor.RpcInvokator.FlowResponse' type=kotlinx.coroutines.flow.Flow<kotlin.Any?> origin=null
+                      ARG <this>: CALL 'public final fun <get-flowInvokator> <Service> (<this>: kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.<get-flowInvokator>>): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<Service of kotlinx.rpc.descriptor.<get-flowInvokator>> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=GET_PROPERTY
+                        TYPE_ARG Service: <root>.BoxService
+                        ARG <this>: GET_VAR 'val streamCallable: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      ARG service: GET_VAR 'val service: <root>.BoxServiceImpl declared in <root>.box.<anonymous>' type=<root>.BoxServiceImpl origin=null
+                      ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<kotlin.Any?> origin=null
+                        TYPE_ARG T: kotlin.Any?
+                        ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                          CONST Int type=kotlin.Int value=5
+                          GET_OBJECT 'CLASS IR_EXTERNAL_DECLARATION_STUB OBJECT name:Absent modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlinx.rpc.descriptor.RpcInvokator.Absent
+                WHEN type=kotlin.Unit origin=IF
+                  BRANCH
+                    if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                      ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                        ARG arg0: GET_VAR 'val streamAbsent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                        ARG arg1: CONST String type=kotlin.String value="5-s"
+                    then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                      STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="Fail: "
+                        GET_VAR 'val streamAbsent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                VAR name:streamNullForNonNullable type:kotlin.Any? [val]
+                  CALL 'public final fun single <T> (<this>: kotlinx.coroutines.flow.Flow<T of kotlinx.coroutines.flow.single>): T of kotlinx.coroutines.flow.single declared in kotlinx.coroutines.flow' type=kotlin.Any? origin=null
+                    TYPE_ARG T: kotlin.Any?
+                    ARG <this>: CALL 'public abstract fun call (service: Service of kotlinx.rpc.descriptor.RpcInvokator.FlowResponse, arguments: kotlin.Array<kotlin.Any?>): kotlinx.coroutines.flow.Flow<kotlin.Any?> declared in kotlinx.rpc.descriptor.RpcInvokator.FlowResponse' type=kotlinx.coroutines.flow.Flow<kotlin.Any?> origin=null
+                      ARG <this>: CALL 'public final fun <get-flowInvokator> <Service> (<this>: kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.<get-flowInvokator>>): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<Service of kotlinx.rpc.descriptor.<get-flowInvokator>> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=GET_PROPERTY
+                        TYPE_ARG Service: <root>.BoxService
+                        ARG <this>: GET_VAR 'val streamCallable: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      ARG service: GET_VAR 'val service: <root>.BoxServiceImpl declared in <root>.box.<anonymous>' type=<root>.BoxServiceImpl origin=null
+                      ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<kotlin.Any?> origin=null
+                        TYPE_ARG T: kotlin.Any?
+                        ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                          CONST Int type=kotlin.Int value=6
+                          CONST Null type=kotlin.Nothing? value=null
+                WHEN type=kotlin.Unit origin=IF
+                  BRANCH
+                    if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                      ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                        ARG arg0: GET_VAR 'val streamNullForNonNullable: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                        ARG arg1: CONST String type=kotlin.String value="6-s"
+                    then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                      STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="Fail: "
+                        GET_VAR 'val streamNullForNonNullable: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                VAR name:streamPresent type:kotlin.Any? [val]
+                  CALL 'public final fun single <T> (<this>: kotlinx.coroutines.flow.Flow<T of kotlinx.coroutines.flow.single>): T of kotlinx.coroutines.flow.single declared in kotlinx.coroutines.flow' type=kotlin.Any? origin=null
+                    TYPE_ARG T: kotlin.Any?
+                    ARG <this>: CALL 'public abstract fun call (service: Service of kotlinx.rpc.descriptor.RpcInvokator.FlowResponse, arguments: kotlin.Array<kotlin.Any?>): kotlinx.coroutines.flow.Flow<kotlin.Any?> declared in kotlinx.rpc.descriptor.RpcInvokator.FlowResponse' type=kotlinx.coroutines.flow.Flow<kotlin.Any?> origin=null
+                      ARG <this>: CALL 'public final fun <get-flowInvokator> <Service> (<this>: kotlinx.rpc.descriptor.RpcCallable<Service of kotlinx.rpc.descriptor.<get-flowInvokator>>): kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<Service of kotlinx.rpc.descriptor.<get-flowInvokator>> declared in kotlinx.rpc.descriptor' type=kotlinx.rpc.descriptor.RpcInvokator.FlowResponse<<root>.BoxService> origin=GET_PROPERTY
+                        TYPE_ARG Service: <root>.BoxService
+                        ARG <this>: GET_VAR 'val streamCallable: kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> declared in <root>.box.<anonymous>' type=kotlinx.rpc.descriptor.RpcCallable<<root>.BoxService> origin=null
+                      ARG service: GET_VAR 'val service: <root>.BoxServiceImpl declared in <root>.box.<anonymous>' type=<root>.BoxServiceImpl origin=null
+                      ARG arguments: CALL 'public final fun arrayOf <T> (vararg elements: T of kotlin.arrayOf): kotlin.Array<T of kotlin.arrayOf> declared in kotlin' type=kotlin.Array<kotlin.Any?> origin=null
+                        TYPE_ARG T: kotlin.Any?
+                        ARG elements: VARARG type=kotlin.Array<out kotlin.Any?> varargElementType=kotlin.Any?
+                          CONST Int type=kotlin.Int value=7
+                          CONST String type=kotlin.String value="s2"
+                WHEN type=kotlin.Unit origin=IF
+                  BRANCH
+                    if: CALL 'public final fun not (): kotlin.Boolean declared in kotlin.Boolean' type=kotlin.Boolean origin=EXCLEQ
+                      ARG <this>: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EXCLEQ
+                        ARG arg0: GET_VAR 'val streamPresent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                        ARG arg1: CONST String type=kotlin.String value="7-s2"
+                    then: RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                      STRING_CONCATENATION type=kotlin.String
+                        CONST String type=kotlin.String value="Fail: "
+                        GET_VAR 'val streamPresent: kotlin.Any? declared in <root>.box.<anonymous>' type=kotlin.Any? origin=null
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> ($this$runBlocking: kotlinx.coroutines.CoroutineScope): kotlin.String declared in <root>.box'
+                  CONST String type=kotlin.String value="OK"

--- a/tests/compiler-plugin-tests/src/testData/box/optionalParameters.fir.txt
+++ b/tests/compiler-plugin-tests/src/testData/box/optionalParameters.fir.txt
@@ -1,0 +1,85 @@
+FILE: optionalParameters.kt
+    @R|kotlinx/rpc/annotations/Rpc|() public abstract interface BoxService : R|kotlin/Any| {
+        public abstract suspend fun withDefaults(a: R|kotlin/Int|, b: R|kotlin/String| = String(b), c: R|kotlin/String?| = String(c)): R|kotlin/String|
+
+        public abstract fun streamWithDefaults(a: R|kotlin/Int|, b: R|kotlin/String| = String(s)): R|kotlinx/coroutines/flow/Flow<kotlin/String>|
+
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final class $rpcServiceStub : R|kotlin/Any| {
+            public final companion object Companion : R|kotlin/Any| {
+            }
+
+        }
+
+    }
+    public final class BoxServiceImpl : R|BoxService| {
+        public constructor(): R|BoxServiceImpl| {
+            super<R|kotlin/Any|>()
+        }
+
+        public open override suspend fun withDefaults(a: R|kotlin/Int|, b: R|kotlin/String|, c: R|kotlin/String?|): R|kotlin/String| {
+            ^withDefaults <strcat>(R|<local>/a|, String(-), R|<local>/b|, String(-), R|<local>/c|)
+        }
+
+        public open override fun streamWithDefaults(a: R|kotlin/Int|, b: R|kotlin/String|): R|kotlinx/coroutines/flow/Flow<kotlin/String>| {
+            ^streamWithDefaults R|kotlinx/coroutines/flow/flowOf|<R|kotlin/String|>(<strcat>(R|<local>/a|, String(-), R|<local>/b|))
+        }
+
+    }
+    @R|kotlin/OptIn|(markerClass = vararg(<getClass>(Q|kotlinx/rpc/internal/utils/ExperimentalRpcApi|))) public final fun box(): R|kotlin/String| {
+        ^box R|kotlinx/coroutines/runBlocking|<R|kotlin/String|>(<L> = runBlocking@fun R|kotlinx/coroutines/CoroutineScope|.<anonymous>(): R|kotlin/String| <inline=NoInline, kind=EXACTLY_ONCE>  {
+            lval callable: R|kotlinx/rpc/descriptor/RpcCallable<BoxService>| = R|kotlinx/rpc/descriptor/serviceDescriptorOf|<R|BoxService|>().R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcServiceDescriptor.getCallable: R|kotlinx/rpc/descriptor/RpcCallable<BoxService>?|>|(String(withDefaults)) ?: ^@runBlocking String(Fail: no callable)
+            lval service: R|BoxServiceImpl| = R|/BoxServiceImpl.BoxServiceImpl|()
+            lval allAbsent: R|kotlin/Any?| = R|<local>/callable|.R|kotlinx/rpc/descriptor/unaryInvokator|<R|BoxService|>.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcInvokator.UnaryResponse.call: R|kotlin/Any?|>|(R|<local>/service|, R|kotlin/arrayOf|<R|kotlin/Any?|>(vararg(Int(1), Q|kotlinx/rpc/descriptor/RpcInvokator.Absent|, Q|kotlinx/rpc/descriptor/RpcInvokator.Absent|)))
+            when () {
+                !=(R|<local>/allAbsent|, String(1-b-c)) ->  {
+                    ^@runBlocking <strcat>(String(Fail: ), R|<local>/allAbsent|)
+                }
+            }
+
+            lval nullForNonNullable: R|kotlin/Any?| = R|<local>/callable|.R|kotlinx/rpc/descriptor/unaryInvokator|<R|BoxService|>.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcInvokator.UnaryResponse.call: R|kotlin/Any?|>|(R|<local>/service|, R|kotlin/arrayOf|<R|kotlin/Any?|>(vararg(Int(2), Null(null), String(override))))
+            when () {
+                !=(R|<local>/nullForNonNullable|, String(2-b-override)) ->  {
+                    ^@runBlocking <strcat>(String(Fail: ), R|<local>/nullForNonNullable|)
+                }
+            }
+
+            lval explicitNull: R|kotlin/Any?| = R|<local>/callable|.R|kotlinx/rpc/descriptor/unaryInvokator|<R|BoxService|>.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcInvokator.UnaryResponse.call: R|kotlin/Any?|>|(R|<local>/service|, R|kotlin/arrayOf|<R|kotlin/Any?|>(vararg(Int(3), String(override), Null(null))))
+            when () {
+                !=(R|<local>/explicitNull|, String(3-override-null)) ->  {
+                    ^@runBlocking <strcat>(String(Fail: ), R|<local>/explicitNull|)
+                }
+            }
+
+            lval allPresent: R|kotlin/Any?| = R|<local>/callable|.R|kotlinx/rpc/descriptor/unaryInvokator|<R|BoxService|>.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcInvokator.UnaryResponse.call: R|kotlin/Any?|>|(R|<local>/service|, R|kotlin/arrayOf|<R|kotlin/Any?|>(vararg(Int(4), String(b2), String(c2))))
+            when () {
+                !=(R|<local>/allPresent|, String(4-b2-c2)) ->  {
+                    ^@runBlocking <strcat>(String(Fail: ), R|<local>/allPresent|)
+                }
+            }
+
+            lval streamCallable: R|kotlinx/rpc/descriptor/RpcCallable<BoxService>| = R|kotlinx/rpc/descriptor/serviceDescriptorOf|<R|BoxService|>().R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcServiceDescriptor.getCallable: R|kotlinx/rpc/descriptor/RpcCallable<BoxService>?|>|(String(streamWithDefaults)) ?: ^@runBlocking String(Fail: no stream callable)
+            lval streamAbsent: R|kotlin/Any?| = R|<local>/streamCallable|.R|kotlinx/rpc/descriptor/flowInvokator|<R|BoxService|>.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcInvokator.FlowResponse.call: R|kotlinx/coroutines/flow/Flow<kotlin/Any?>|>|(R|<local>/service|, R|kotlin/arrayOf|<R|kotlin/Any?|>(vararg(Int(5), Q|kotlinx/rpc/descriptor/RpcInvokator.Absent|))).R|kotlinx/coroutines/flow/single|<R|kotlin/Any?|>()
+            when () {
+                !=(R|<local>/streamAbsent|, String(5-s)) ->  {
+                    ^@runBlocking <strcat>(String(Fail: ), R|<local>/streamAbsent|)
+                }
+            }
+
+            lval streamNullForNonNullable: R|kotlin/Any?| = R|<local>/streamCallable|.R|kotlinx/rpc/descriptor/flowInvokator|<R|BoxService|>.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcInvokator.FlowResponse.call: R|kotlinx/coroutines/flow/Flow<kotlin/Any?>|>|(R|<local>/service|, R|kotlin/arrayOf|<R|kotlin/Any?|>(vararg(Int(6), Null(null)))).R|kotlinx/coroutines/flow/single|<R|kotlin/Any?|>()
+            when () {
+                !=(R|<local>/streamNullForNonNullable|, String(6-s)) ->  {
+                    ^@runBlocking <strcat>(String(Fail: ), R|<local>/streamNullForNonNullable|)
+                }
+            }
+
+            lval streamPresent: R|kotlin/Any?| = R|<local>/streamCallable|.R|kotlinx/rpc/descriptor/flowInvokator|<R|BoxService|>.R|SubstitutionOverride<kotlinx/rpc/descriptor/RpcInvokator.FlowResponse.call: R|kotlinx/coroutines/flow/Flow<kotlin/Any?>|>|(R|<local>/service|, R|kotlin/arrayOf|<R|kotlin/Any?|>(vararg(Int(7), String(s2)))).R|kotlinx/coroutines/flow/single|<R|kotlin/Any?|>()
+            when () {
+                !=(R|<local>/streamPresent|, String(7-s2)) ->  {
+                    ^@runBlocking <strcat>(String(Fail: ), R|<local>/streamPresent|)
+                }
+            }
+
+            ^ String(OK)
+        }
+        )
+    }

--- a/tests/compiler-plugin-tests/src/testData/box/optionalParameters.kt
+++ b/tests/compiler-plugin-tests/src/testData/box/optionalParameters.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// RUN_PIPELINE_TILL: BACKEND
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.runBlocking
+import kotlinx.rpc.annotations.Rpc
+import kotlinx.rpc.descriptor.RpcInvokator
+import kotlinx.rpc.descriptor.flowInvokator
+import kotlinx.rpc.descriptor.serviceDescriptorOf
+import kotlinx.rpc.descriptor.unaryInvokator
+import kotlinx.rpc.internal.utils.ExperimentalRpcApi
+
+@Rpc
+interface BoxService {
+    suspend fun withDefaults(a: Int, b: String = "b", c: String? = "c"): String
+
+    fun streamWithDefaults(a: Int, b: String = "s"): Flow<String>
+}
+
+class BoxServiceImpl : BoxService {
+    override suspend fun withDefaults(a: Int, b: String, c: String?): String = "$a-$b-$c"
+
+    override fun streamWithDefaults(a: Int, b: String): Flow<String> = flowOf("$a-$b")
+}
+
+@OptIn(ExperimentalRpcApi::class)
+fun box(): String = runBlocking {
+    val callable = serviceDescriptorOf<BoxService>().getCallable("withDefaults")
+        ?: return@runBlocking "Fail: no callable"
+
+    val service = BoxServiceImpl()
+
+    val allAbsent = callable.unaryInvokator.call(service, arrayOf<Any?>(1, RpcInvokator.Absent, RpcInvokator.Absent))
+    if (allAbsent != "1-b-c") return@runBlocking "Fail: $allAbsent"
+
+    // null is treated as absent for parameters of non-nullable types (#543)
+    val nullForNonNullable = callable.unaryInvokator.call(service, arrayOf<Any?>(2, null, "override"))
+    if (nullForNonNullable != "2-b-override") return@runBlocking "Fail: $nullForNonNullable"
+
+    // explicit null for a parameter of a nullable type is not absent
+    val explicitNull = callable.unaryInvokator.call(service, arrayOf<Any?>(3, "override", null))
+    if (explicitNull != "3-override-null") return@runBlocking "Fail: $explicitNull"
+
+    val allPresent = callable.unaryInvokator.call(service, arrayOf<Any?>(4, "b2", "c2"))
+    if (allPresent != "4-b2-c2") return@runBlocking "Fail: $allPresent"
+
+    val streamCallable = serviceDescriptorOf<BoxService>().getCallable("streamWithDefaults")
+        ?: return@runBlocking "Fail: no stream callable"
+
+    val streamAbsent = streamCallable.flowInvokator.call(service, arrayOf<Any?>(5, RpcInvokator.Absent)).single()
+    if (streamAbsent != "5-s") return@runBlocking "Fail: $streamAbsent"
+
+    val streamNullForNonNullable = streamCallable.flowInvokator.call(service, arrayOf<Any?>(6, null)).single()
+    if (streamNullForNonNullable != "6-s") return@runBlocking "Fail: $streamNullForNonNullable"
+
+    val streamPresent = streamCallable.flowInvokator.call(service, arrayOf<Any?>(7, "s2")).single()
+    if (streamPresent != "7-s2") return@runBlocking "Fail: $streamPresent"
+
+    "OK"
+}

--- a/tests/compiler-plugin-tests/src/testData/diagnostics/optionalParameters.fir.txt
+++ b/tests/compiler-plugin-tests/src/testData/diagnostics/optionalParameters.fir.txt
@@ -1,0 +1,21 @@
+FILE: optionalParameters.kt
+    @R|kotlinx/rpc/annotations/Rpc|() public abstract interface WithinLimit : R|kotlin/Any| {
+        public abstract suspend fun atLimit(required: R|kotlin/Int|, p1: R|kotlin/Int| = Int(1), p2: R|kotlin/Int| = Int(2), p3: R|kotlin/Int| = Int(3), p4: R|kotlin/Int| = Int(4), p5: R|kotlin/Int| = Int(5), p6: R|kotlin/Int| = Int(6), p7: R|kotlin/Int| = Int(7), p8: R|kotlin/Int| = Int(8)): R|kotlin/Int|
+
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final class $rpcServiceStub : R|kotlin/Any| {
+            public final companion object Companion : R|kotlin/Any| {
+            }
+
+        }
+
+    }
+    @R|kotlinx/rpc/annotations/Rpc|() public abstract interface OverLimit : R|kotlin/Any| {
+        public abstract suspend fun tooMany(required: R|kotlin/Int|, p1: R|kotlin/Int| = Int(1), p2: R|kotlin/Int| = Int(2), p3: R|kotlin/Int| = Int(3), p4: R|kotlin/Int| = Int(4), p5: R|kotlin/Int| = Int(5), p6: R|kotlin/Int| = Int(6), p7: R|kotlin/Int| = Int(7), p8: R|kotlin/Int| = Int(8), p9: R|kotlin/Int| = Int(9)): R|kotlin/Int|
+
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final class $rpcServiceStub : R|kotlin/Any| {
+            public final companion object Companion : R|kotlin/Any| {
+            }
+
+        }
+
+    }

--- a/tests/compiler-plugin-tests/src/testData/diagnostics/optionalParameters.kt
+++ b/tests/compiler-plugin-tests/src/testData/diagnostics/optionalParameters.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+// RUN_PIPELINE_TILL: FRONTEND
+
+import kotlinx.rpc.annotations.Rpc
+
+@Rpc
+interface WithinLimit {
+    suspend fun atLimit(
+        required: Int,
+        p1: Int = 1,
+        p2: Int = 2,
+        p3: Int = 3,
+        p4: Int = 4,
+        p5: Int = 5,
+        p6: Int = 6,
+        p7: Int = 7,
+        p8: Int = 8,
+    ): Int
+}
+
+@Rpc
+interface OverLimit {
+    <!TOO_MANY_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION!>suspend fun tooMany(
+        required: Int,
+        p1: Int = 1,
+        p2: Int = 2,
+        p3: Int = 3,
+        p4: Int = 4,
+        p5: Int = 5,
+        p6: Int = 6,
+        p7: Int = 7,
+        p8: Int = 8,
+        p9: Int = 9,
+    ): Int<!>
+}
+
+/* GENERATED_FIR_TAGS: functionDeclaration, integerLiteral, interfaceDeclaration, suspend */


### PR DESCRIPTION
**Subsystem**
Compiler plugin (IR codegen + FIR checkers), Core (`kotlinx.rpc.descriptor`), kRPC serialization

**Problem Description**

Fixes #543.

Invoking an `@Rpc` method through its generated invokator with an absent optional (defaulted) parameter throws `NullPointerException: null cannot be cast to non-null type kotlin.String` instead of applying the parameter's default value.

Root cause: the generated invokator blindly casts every element of the arguments array (`arguments[i] as T`), and `CallableParametersSerializer` leaves parameters that are absent from the payload as `null`. This breaks two scenarios:

1. **Direct invokator calls** — `RpcInvokator.call(service, args)` with `null` for an optional parameter (the reported case).
2. **Schema evolution over kRPC** — an old client calling a newer server whose method gained an optional parameter: the field is missing from the payload, decodes to `null`, and the invokator crashes instead of using the default. Additionally, for *nullable* optional parameters, "absent" and "explicit null" were conflated, so a default could never apply.

**Solution**

Default value expressions only exist in source, so the only place they can be applied is a call site the compiler generates — the invokator. The fix has three layers:

1. **Compiler plugin (IR):** `RpcStubGenerator` hoists optional-parameter arguments into locals, checks them for absence, and branches to calls that leave absent arguments *unset*, so the compiler's own default-argument lowering fills them in on every backend. Absence means `=== RpcInvokator.Absent`, plus `== null` for non-nullable parameter types (where `null` can never be a valid argument — this fixes the exact repro in #543). Codegen for methods without optional parameters is byte-identical to before (no existing golden IR dump changed).
2. **Core API:** new `RpcInvokator.Absent` marker object (`@ExperimentalRpcApi`) so callers — and the serializer — can express "not provided" distinctly from an explicit `null` for nullable parameters. ABI dumps updated via `updateLegacyAbi`.
3. **kRPC serialization:** `CallableParametersSerializer` prefills optional parameters with `Absent` on decode (absent-on-wire → default applies server-side) and skips `Absent` elements on encode (so a hand-built `RpcCall` through the public `RpcClient.call` can request defaults). The wire format is unchanged — parameters were already marked `isOptional` in the serial descriptor.

The branch tree generates 2^n call sites for n optional parameters, which is the only way to get compiler-evaluated defaults without copying default-expression IR (fragile across compiler versions) or bitmask `$default` dispatch (not expressible in common IR before lowering). To keep that bounded, a new FIR diagnostic `TOO_MANY_OPTIONAL_PARAMETERS_IN_RPC_FUNCTION` rejects `@Rpc` methods with more than 8 defaulted parameters (256 branches max).

Hardening included: `deserialize` reports a clear `SerializationException` for out-of-range element indexes (previously an `ArrayIndexOutOfBoundsException` path), and the IR argument builder validates that only parameters with defaults can be skipped.

**Compatibility**

- Wire format: unchanged. Old client → new server now gets defaults instead of an NPE; new client → old server is unchanged (clients always materialize defaults at the call site).
- Stubs compiled with an older plugin running against this runtime: nullable optionals safe-cast `Absent` to `null` (exactly the old behavior); non-nullable optionals were already broken (NPE) and now fail with a CCE instead.
- New stubs against an older runtime: degrade to pre-fix semantics (absent nullable → `null`), no crash.
- `Json { explicitNulls = false }`: verified by test that the serializer still encodes explicit nulls, so field absence always means argument absence between kRPC peers.

**Testing**

- Box test (`testData/box/optionalParameters.kt`): direct invokator invocation across all argument shapes — `Absent`, null-as-absent, explicit null preserved for nullable types, all-present — for both suspend (unary) and `Flow`-returning (streaming) methods.
- Diagnostics test (`testData/diagnostics/optionalParameters.kt`): the 8-optional-parameter cap.
- `OptionalParametersTest` (krpc-test, commonTest — runs on JVM, JS, and Native): raw legacy `CallData` wire message with the optional field missing → defaults applied end-to-end; old-client payloads decoded via JSON, CBOR, and Protobuf; CBOR definite-length round-trip; `explicitNulls = false` behavior pinned.
- Full local runs: compiler-plugin box + diagnostic suites, krpc-test on JVM/JS/linuxX64, `krpc-compatibility-tests`, `krpc-protocol-compatibility-tests`, `checkLegacyAbi`, detekt.

**Disclosure**

This PR was developed with AI assistance (Claude Code), including an adversarial multi-agent review pass whose accepted findings (the FIR cap, per-format tests, `explicitNulls` verification, and hardening above) are part of this change. All code has been human-reviewed and verified locally.
