### PR TITLE
Fix unhandled exception crash in NativeClientCall.runBatch on iOS

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,39 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,39 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <JavaCodeStyleSettings>
-      <option name="IMPORT_LAYOUT_TABLE">
-        <value>
-          <package name="android" withSubpackages="true" static="true" />
-          <package name="androidx" withSubpackages="true" static="true" />
-          <package name="com" withSubpackages="true" static="true" />
-          <package name="junit" withSubpackages="true" static="true" />
-          <package name="net" withSubpackages="true" static="true" />
-          <package name="org" withSubpackages="true" static="true" />
-          <package name="java" withSubpackages="true" static="true" />
-          <package name="javax" withSubpackages="true" static="true" />
-          <package name="" withSubpackages="true" static="true" />
-          <emptyLine />
-          <package name="android" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="androidx" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="com" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="junit" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="net" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="org" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="java" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="javax" withSubpackages="true" static="false" />
-          <emptyLine />
-          <package name="" withSubpackages="true" static="false" />
-          <emptyLine />
-        </value>
-      </option>
-    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/NativeClientCall.kt
+++ b/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/NativeClientCall.kt
@@ -352,6 +352,17 @@ internal class NativeClientCall<Request, Response>(
                             // if the batch doesn't succeed, this is reflected in the recv status op batch.
                             onSuccess()
                         }
+                    } catch (e: Throwable) {
+                        // Catch exceptions to prevent them from escaping onto the native gRPC
+                        // completion queue thread, where no coroutine can handle them — causing
+                        // terminateWithUnhandledException → SIGABRT on iOS. Convert to a gRPC
+                        // cancellation so the error is routed through RECV_STATUS_ON_CLIENT →
+                        // listener → coroutine, where application-level try/catch can handle it.
+                        // See https://github.com/Kotlin/kotlinx-rpc/issues/749
+                        cancelInternal(
+                            grpc_status_code.GRPC_STATUS_INTERNAL,
+                            "Batch callback failed: ${e.message}"
+                        )
                     } finally {
                         // ignore failure, as it is reflected in the client status op
                         cleanup()

--- a/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/NativeClientCall.kt
+++ b/grpc/grpc-client/src/nativeMain/kotlin/kotlinx/rpc/grpc/client/internal/NativeClientCall.kt
@@ -353,12 +353,6 @@ internal class NativeClientCall<Request, Response>(
                             onSuccess()
                         }
                     } catch (e: Throwable) {
-                        // Catch exceptions to prevent them from escaping onto the native gRPC
-                        // completion queue thread, where no coroutine can handle them — causing
-                        // terminateWithUnhandledException → SIGABRT on iOS. Convert to a gRPC
-                        // cancellation so the error is routed through RECV_STATUS_ON_CLIENT →
-                        // listener → coroutine, where application-level try/catch can handle it.
-                        // See https://github.com/Kotlin/kotlinx-rpc/issues/749
                         cancelInternal(
                             grpc_status_code.GRPC_STATUS_INTERNAL,
                             "Batch callback failed: ${e.message}"

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/test/utils.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/test/utils.kt
@@ -42,6 +42,14 @@ expect val runtime: Runtime
  */
 expect suspend fun captureStdErr(block: suspend () -> Unit): String
 
+/**
+ * Captures the standard output written during the execution of the provided suspending block.
+ *
+ * @param block A suspending lambda function whose standard output will be captured.
+ * @return A string containing the captured standard output.
+ */
+expect suspend fun captureStdOut(block: suspend () -> Unit): String
+
 expect suspend fun captureGrpcLogs(
     jvmLogLevel: String = "DEBUG",
     jvmLoggers: List<String> = listOf("io.grpc"),

--- a/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/test/utils.kt
+++ b/grpc/grpc-core/src/commonTest/kotlin/kotlinx/rpc/grpc/test/utils.kt
@@ -42,12 +42,6 @@ expect val runtime: Runtime
  */
 expect suspend fun captureStdErr(block: suspend () -> Unit): String
 
-/**
- * Captures the standard output written during the execution of the provided suspending block.
- *
- * @param block A suspending lambda function whose standard output will be captured.
- * @return A string containing the captured standard output.
- */
 expect suspend fun captureStdOut(block: suspend () -> Unit): String
 
 expect suspend fun captureGrpcLogs(

--- a/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/raw/RunBatchExceptionTest.kt
+++ b/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/raw/RunBatchExceptionTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023-2025 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.rpc.grpc.test.raw
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import kotlinx.rpc.grpc.GrpcStatusException
+import kotlinx.rpc.grpc.client.GrpcClient
+import kotlinx.rpc.grpc.client.internal.unaryRpc
+import kotlinx.rpc.grpc.descriptor.GrpcMethodType
+import kotlinx.rpc.grpc.descriptor.methodDescriptor
+import kotlinx.rpc.grpc.internal.serviceDescriptor
+import kotlinx.rpc.grpc.marshaller.GrpcMarshaller
+import kotlinx.rpc.grpc.marshaller.GrpcMarshallerConfig
+import kotlinx.rpc.grpc.server.internal.PlatformServer
+import kotlinx.rpc.grpc.server.internal.ServerBuilder
+import kotlinx.rpc.grpc.server.internal.unaryServerMethodDefinition
+import kotlinx.rpc.grpc.server.serverServiceDefinition
+import kotlinx.rpc.grpc.test.captureStdErr
+import kotlinx.rpc.grpc.test.captureStdOut
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Regression test for https://github.com/Kotlin/kotlinx-rpc/issues/749
+ *
+ * Verifies that an exception thrown inside the `onSuccess` callback of
+ * `NativeClientCall.runBatch` does not escape onto the native gRPC
+ * completion queue thread as an unhandled exception.
+ *
+ * The test uses a response marshaller that throws on `decode()`. This call
+ * sits inside `runBatch`'s `onSuccess` lambda (in `request()`) but outside
+ * `safeUserCode`, so without the catch block the exception propagates through
+ * `CallbackFuture.complete()` → `opsCompleteCb()` → native gRPC thread,
+ * producing an "Uncaught Kotlin exception" warning (and SIGABRT on iOS).
+ *
+ * - Without the fix: stderr contains "Uncaught Kotlin exception" → test fails.
+ * - With the fix: exception is caught in runBatch, no uncaught exception → test passes.
+ */
+class RunBatchExceptionTest {
+
+    @Test
+    fun `exception in response marshaller should not produce uncaught exception`() =
+        kotlinx.coroutines.test.runTest {
+            val serverJob = Job()
+            val serverScope = CoroutineScope(serverJob)
+
+            val serverDescriptor = methodDescriptor(
+                fullMethodName = "$SERVICE_NAME/Unary",
+                requestMarshaller = normalMarshaller,
+                responseMarshaller = normalMarshaller,
+                type = GrpcMethodType.UNARY,
+                schemaDescriptor = Unit,
+                idempotent = true,
+                safe = true,
+                sampledToLocalTracing = true,
+            )
+
+            val clientDescriptor = methodDescriptor(
+                fullMethodName = "$SERVICE_NAME/Unary",
+                requestMarshaller = normalMarshaller,
+                responseMarshaller = throwingDecodeMarshaller,
+                type = GrpcMethodType.UNARY,
+                schemaDescriptor = Unit,
+                idempotent = true,
+                safe = true,
+                sampledToLocalTracing = true,
+            )
+
+            val methods = listOf(serverDescriptor)
+
+            val builder = ServerBuilder(0).addService(
+                serverServiceDefinition(
+                    serviceDescriptor = serviceDescriptor(
+                        name = SERVICE_NAME,
+                        methods = methods,
+                        schemaDescriptor = Unit,
+                    ),
+                    methods = listOf(
+                        serverScope.unaryServerMethodDefinition(
+                            serverDescriptor,
+                            typeOf<String>(),
+                            emptyList(),
+                        ) { it + it }
+                    ),
+                )
+            )
+            val server = PlatformServer(builder)
+            server.start()
+
+            val client = GrpcClient("localhost", server.port) {
+                credentials = plaintext()
+            }
+
+            try {
+                val output = captureStdOut {
+                    assertFailsWith<GrpcStatusException> {
+                        client.unaryRpc(clientDescriptor, "Hello")
+                    }
+                }
+
+                assertFalse(
+                    output.contains("Uncaught Kotlin exception"),
+                    "Exception from response marshaller should be caught in runBatch, " +
+                        "not escape as an uncaught exception onto the gRPC thread. " +
+                        "Captured stdout: $output"
+                )
+            } finally {
+                serverJob.cancelAndJoin()
+                client.shutdownNow()
+                server.shutdownNow()
+                server.awaitTermination(30.seconds)
+                client.awaitTermination(30.seconds)
+            }
+        }
+
+    companion object {
+        private const val SERVICE_NAME = "TestService"
+
+        private val normalMarshaller = object : GrpcMarshaller<String> {
+            override fun encode(value: String, config: GrpcMarshallerConfig?): Source {
+                return Buffer().apply { writeString(value) }
+            }
+
+            override fun decode(source: Source, config: GrpcMarshallerConfig?): String {
+                return source.readString()
+            }
+        }
+
+        private val throwingDecodeMarshaller = object : GrpcMarshaller<String> {
+            override fun encode(value: String, config: GrpcMarshallerConfig?): Source {
+                return Buffer().apply { writeString(value) }
+            }
+
+            override fun decode(source: Source, config: GrpcMarshallerConfig?): String {
+                throw RuntimeException("Simulated decode failure (e.g. corrupted response)")
+            }
+        }
+    }
+}

--- a/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/raw/RunBatchExceptionTest.kt
+++ b/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/raw/RunBatchExceptionTest.kt
@@ -7,6 +7,7 @@ package kotlinx.rpc.grpc.test.raw
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runTest
 import kotlinx.io.Buffer
 import kotlinx.io.Source
 import kotlinx.io.readString
@@ -23,7 +24,6 @@ import kotlinx.rpc.grpc.server.internal.PlatformServer
 import kotlinx.rpc.grpc.server.internal.ServerBuilder
 import kotlinx.rpc.grpc.server.internal.unaryServerMethodDefinition
 import kotlinx.rpc.grpc.server.serverServiceDefinition
-import kotlinx.rpc.grpc.test.captureStdErr
 import kotlinx.rpc.grpc.test.captureStdOut
 import kotlin.reflect.typeOf
 import kotlin.test.Test
@@ -31,120 +31,92 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * Regression test for https://github.com/Kotlin/kotlinx-rpc/issues/749
- *
- * Verifies that an exception thrown inside the `onSuccess` callback of
- * `NativeClientCall.runBatch` does not escape onto the native gRPC
- * completion queue thread as an unhandled exception.
- *
- * The test uses a response marshaller that throws on `decode()`. This call
- * sits inside `runBatch`'s `onSuccess` lambda (in `request()`) but outside
- * `safeUserCode`, so without the catch block the exception propagates through
- * `CallbackFuture.complete()` → `opsCompleteCb()` → native gRPC thread,
- * producing an "Uncaught Kotlin exception" warning (and SIGABRT on iOS).
- *
- * - Without the fix: stderr contains "Uncaught Kotlin exception" → test fails.
- * - With the fix: exception is caught in runBatch, no uncaught exception → test passes.
- */
+// Regression test for https://github.com/Kotlin/kotlinx-rpc/issues/749
 class RunBatchExceptionTest {
 
     @Test
-    fun `exception in response marshaller should not produce uncaught exception`() =
-        kotlinx.coroutines.test.runTest {
-            val serverJob = Job()
-            val serverScope = CoroutineScope(serverJob)
-
-            val serverDescriptor = methodDescriptor(
-                fullMethodName = "$SERVICE_NAME/Unary",
-                requestMarshaller = normalMarshaller,
-                responseMarshaller = normalMarshaller,
-                type = GrpcMethodType.UNARY,
-                schemaDescriptor = Unit,
-                idempotent = true,
-                safe = true,
-                sampledToLocalTracing = true,
-            )
-
-            val clientDescriptor = methodDescriptor(
-                fullMethodName = "$SERVICE_NAME/Unary",
-                requestMarshaller = normalMarshaller,
-                responseMarshaller = throwingDecodeMarshaller,
-                type = GrpcMethodType.UNARY,
-                schemaDescriptor = Unit,
-                idempotent = true,
-                safe = true,
-                sampledToLocalTracing = true,
-            )
-
-            val methods = listOf(serverDescriptor)
-
-            val builder = ServerBuilder(0).addService(
-                serverServiceDefinition(
-                    serviceDescriptor = serviceDescriptor(
-                        name = SERVICE_NAME,
-                        methods = methods,
-                        schemaDescriptor = Unit,
-                    ),
-                    methods = listOf(
-                        serverScope.unaryServerMethodDefinition(
-                            serverDescriptor,
-                            typeOf<String>(),
-                            emptyList(),
-                        ) { it + it }
-                    ),
-                )
-            )
-            val server = PlatformServer(builder)
-            server.start()
-
-            val client = GrpcClient("localhost", server.port) {
-                credentials = plaintext()
-            }
-
-            try {
-                val output = captureStdOut {
-                    assertFailsWith<GrpcStatusException> {
-                        client.unaryRpc(clientDescriptor, "Hello")
-                    }
+    fun `exception in response marshaller should not produce uncaught exception`() = runTest {
+        runWithThrowingMarshaller { client, descriptor ->
+            val output = captureStdOut {
+                assertFailsWith<GrpcStatusException> {
+                    client.unaryRpc(descriptor, "Hello")
                 }
-
-                assertFalse(
-                    output.contains("Uncaught Kotlin exception"),
-                    "Exception from response marshaller should be caught in runBatch, " +
-                        "not escape as an uncaught exception onto the gRPC thread. " +
-                        "Captured stdout: $output"
-                )
-            } finally {
-                serverJob.cancelAndJoin()
-                client.shutdownNow()
-                server.shutdownNow()
-                server.awaitTermination(30.seconds)
-                client.awaitTermination(30.seconds)
             }
+
+            assertFalse(
+                output.contains("Uncaught Kotlin exception"),
+                "Exception should be caught in runBatch, not escape onto the gRPC thread. Stdout: $output"
+            )
         }
+    }
+
+    private suspend fun runWithThrowingMarshaller(
+        block: suspend (GrpcClient, descriptor: kotlinx.rpc.grpc.descriptor.GrpcMethodDescriptor<String, String>) -> Unit,
+    ) {
+        val serverJob = Job()
+        val serverScope = CoroutineScope(serverJob)
+
+        val serverDescriptor = stringDescriptor(normalMarshaller)
+        val clientDescriptor = stringDescriptor(throwingDecodeMarshaller)
+
+        val builder = ServerBuilder(0).addService(
+            serverServiceDefinition(
+                serviceDescriptor = serviceDescriptor(
+                    name = SERVICE_NAME,
+                    methods = listOf(serverDescriptor),
+                    schemaDescriptor = Unit,
+                ),
+                methods = listOf(
+                    serverScope.unaryServerMethodDefinition(
+                        serverDescriptor, typeOf<String>(), emptyList(),
+                    ) { it + it }
+                ),
+            )
+        )
+        val server = PlatformServer(builder)
+        server.start()
+
+        val client = GrpcClient("localhost", server.port) { credentials = plaintext() }
+
+        try {
+            block(client, clientDescriptor)
+        } finally {
+            serverJob.cancelAndJoin()
+            client.shutdownNow()
+            server.shutdownNow()
+            server.awaitTermination(30.seconds)
+            client.awaitTermination(30.seconds)
+        }
+    }
 
     companion object {
         private const val SERVICE_NAME = "TestService"
 
-        private val normalMarshaller = object : GrpcMarshaller<String> {
-            override fun encode(value: String, config: GrpcMarshallerConfig?): Source {
-                return Buffer().apply { writeString(value) }
-            }
+        private fun stringDescriptor(responseMarshaller: GrpcMarshaller<String>) = methodDescriptor(
+            fullMethodName = "$SERVICE_NAME/Unary",
+            requestMarshaller = normalMarshaller,
+            responseMarshaller = responseMarshaller,
+            type = GrpcMethodType.UNARY,
+            schemaDescriptor = Unit,
+            idempotent = true,
+            safe = true,
+            sampledToLocalTracing = true,
+        )
 
-            override fun decode(source: Source, config: GrpcMarshallerConfig?): String {
-                return source.readString()
-            }
+        private val normalMarshaller = object : GrpcMarshaller<String> {
+            override fun encode(value: String, config: GrpcMarshallerConfig?): Source =
+                Buffer().apply { writeString(value) }
+
+            override fun decode(source: Source, config: GrpcMarshallerConfig?): String =
+                source.readString()
         }
 
         private val throwingDecodeMarshaller = object : GrpcMarshaller<String> {
-            override fun encode(value: String, config: GrpcMarshallerConfig?): Source {
-                return Buffer().apply { writeString(value) }
-            }
+            override fun encode(value: String, config: GrpcMarshallerConfig?): Source =
+                Buffer().apply { writeString(value) }
 
-            override fun decode(source: Source, config: GrpcMarshallerConfig?): String {
-                throw RuntimeException("Simulated decode failure (e.g. corrupted response)")
-            }
+            override fun decode(source: Source, config: GrpcMarshallerConfig?): String =
+                throw RuntimeException("Simulated decode failure")
         }
     }
 }

--- a/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/raw/RunBatchExceptionTest.kt
+++ b/grpc/grpc-core/src/desktopTest/kotlin/kotlinx/rpc/grpc/test/raw/RunBatchExceptionTest.kt
@@ -5,8 +5,6 @@
 package kotlinx.rpc.grpc.test.raw
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.Buffer
 import kotlinx.io.Source
@@ -15,6 +13,7 @@ import kotlinx.io.writeString
 import kotlinx.rpc.grpc.GrpcStatusException
 import kotlinx.rpc.grpc.client.GrpcClient
 import kotlinx.rpc.grpc.client.internal.unaryRpc
+import kotlinx.rpc.grpc.descriptor.GrpcMethodDescriptor
 import kotlinx.rpc.grpc.descriptor.GrpcMethodType
 import kotlinx.rpc.grpc.descriptor.methodDescriptor
 import kotlinx.rpc.grpc.internal.serviceDescriptor
@@ -50,12 +49,9 @@ class RunBatchExceptionTest {
         }
     }
 
-    private suspend fun runWithThrowingMarshaller(
-        block: suspend (GrpcClient, descriptor: kotlinx.rpc.grpc.descriptor.GrpcMethodDescriptor<String, String>) -> Unit,
+    private suspend fun CoroutineScope.runWithThrowingMarshaller(
+        block: suspend (GrpcClient, descriptor: GrpcMethodDescriptor<String, String>) -> Unit,
     ) {
-        val serverJob = Job()
-        val serverScope = CoroutineScope(serverJob)
-
         val serverDescriptor = stringDescriptor(normalMarshaller)
         val clientDescriptor = stringDescriptor(throwingDecodeMarshaller)
 
@@ -67,7 +63,7 @@ class RunBatchExceptionTest {
                     schemaDescriptor = Unit,
                 ),
                 methods = listOf(
-                    serverScope.unaryServerMethodDefinition(
+                    unaryServerMethodDefinition(
                         serverDescriptor, typeOf<String>(), emptyList(),
                     ) { it + it }
                 ),
@@ -81,7 +77,6 @@ class RunBatchExceptionTest {
         try {
             block(client, clientDescriptor)
         } finally {
-            serverJob.cancelAndJoin()
             client.shutdownNow()
             server.shutdownNow()
             server.awaitTermination(30.seconds)

--- a/grpc/grpc-core/src/jvmTest/kotlin/kotlinx/rpc/grpc/test/utils.jvm.kt
+++ b/grpc/grpc-core/src/jvmTest/kotlin/kotlinx/rpc/grpc/test/utils.jvm.kt
@@ -26,6 +26,18 @@ actual suspend fun captureStdErr(block: suspend () -> Unit): String {
     }
 }
 
+actual suspend fun captureStdOut(block: suspend () -> Unit): String {
+    val orig = System.out
+    val baos = ByteArrayOutputStream()
+    System.setOut(PrintStream(baos))
+    try {
+        block()
+        return baos.toString()
+    } finally {
+        System.setOut(orig)
+    }
+}
+
 actual suspend fun captureGrpcLogs(
     jvmLogLevel: String,
     jvmLoggers: List<String>,

--- a/grpc/grpc-core/src/nativeTest/kotlin/kotlinx/rpc/grpc/test/utils.native.kt
+++ b/grpc/grpc-core/src/nativeTest/kotlin/kotlinx/rpc/grpc/test/utils.native.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import platform.posix.STDERR_FILENO
+import platform.posix.STDOUT_FILENO
 import platform.posix.close
 import platform.posix.dup
 import platform.posix.dup2
@@ -28,6 +29,7 @@ import platform.posix.fflush
 import platform.posix.pipe
 import platform.posix.read
 import platform.posix.stderr
+import platform.posix.stdout
 import kotlinx.rpc.grpc.internal.cinterop.grpc_tracer_set_enabled
 import kotlinx.rpc.grpc.internal.shim.InternalNativeRpcApi
 import platform.posix.unsetenv
@@ -76,6 +78,41 @@ actual suspend fun captureStdErr(block: suspend () -> Unit): String = coroutineS
         }
 
         // wait reading to finish
+        readJob.join()
+        outputBuf.toString()
+    }
+}
+
+@OptIn(UnsafeNumber::class)
+actual suspend fun captureStdOut(block: suspend () -> Unit): String = coroutineScope {
+    memScoped {
+        val pipeOut = allocArray<IntVar>(2)
+        check(pipe(pipeOut) == 0) { "pipe stdout failed" }
+
+        val savedStdout = dup(STDOUT_FILENO)
+
+        check(dup2(pipeOut[1], STDOUT_FILENO) != -1) { "dup2 stdout failed" }
+        close(pipeOut[1])
+
+        val outputBuf = StringBuilder()
+        val readJob = launch(Dispatchers.IO) {
+            val buf = ByteArray(4096)
+            var r: Long
+            do {
+                r = read(pipeOut[0], buf.refTo(0), buf.size.convert()).convert()
+                if (r > 0) outputBuf.append(buf.decodeToString(0, r.convert()))
+            } while (r > 0)
+            close(pipeOut[0])
+        }
+
+        try {
+            block()
+        } finally {
+            fflush(stdout)
+            dup2(savedStdout, STDOUT_FILENO)
+            close(savedStdout)
+        }
+
         readJob.join()
         outputBuf.toString()
     }

--- a/grpc/grpc-core/src/nativeTest/kotlin/kotlinx/rpc/grpc/test/utils.native.kt
+++ b/grpc/grpc-core/src/nativeTest/kotlin/kotlinx/rpc/grpc/test/utils.native.kt
@@ -8,7 +8,6 @@ package kotlinx.rpc.grpc.test
 
 import platform.posix.setenv
 
-import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.IntVar
 import kotlinx.cinterop.UnsafeNumber
@@ -29,7 +28,6 @@ import platform.posix.dup2
 import platform.posix.fflush
 import platform.posix.pipe
 import platform.posix.read
-import platform.posix.FILE
 import platform.posix.stderr
 import platform.posix.stdout
 import kotlinx.rpc.grpc.internal.cinterop.grpc_tracer_set_enabled
@@ -48,48 +46,78 @@ fun clearNativeEnv(key: String) {
 }
 
 @OptIn(UnsafeNumber::class)
-private suspend fun captureFileDescriptor(
-    fileno: Int,
-    stream: CPointer<FILE>,
-    block: suspend () -> Unit,
-): String = coroutineScope {
+actual suspend fun captureStdErr(block: suspend () -> Unit): String = coroutineScope {
     memScoped {
-        val pipeFd = allocArray<IntVar>(2)
-        check(pipe(pipeFd) == 0) { "pipe failed" }
+        val pipeErr = allocArray<IntVar>(2)
+        check(pipe(pipeErr) == 0) { "pipe stderr failed" }
 
-        val saved = dup(fileno)
-        check(dup2(pipeFd[1], fileno) != -1) { "dup2 failed" }
-        close(pipeFd[1])
+        val savedStderr = dup(STDERR_FILENO)
+
+        // redirect stderr write end
+        check(dup2(pipeErr[1], STDERR_FILENO) != -1) { "dup2 stderr failed" }
+        close(pipeErr[1])
 
         val outputBuf = StringBuilder()
         val readJob = launch(Dispatchers.IO) {
             val buf = ByteArray(4096)
             var r: Long
             do {
-                r = read(pipeFd[0], buf.refTo(0), buf.size.convert()).convert()
+                r = read(pipeErr[0], buf.refTo(0), buf.size.convert()).convert()
                 if (r > 0) outputBuf.append(buf.decodeToString(0, r.convert()))
             } while (r > 0)
-            close(pipeFd[0])
+            close(pipeErr[0])
         }
 
         try {
             block()
         } finally {
-            fflush(stream)
-            dup2(saved, fileno)
-            close(saved)
+            fflush(stderr)
+            // restore stderr
+            dup2(savedStderr, STDERR_FILENO)
+            close(savedStderr)
+        }
+
+        // wait reading to finish
+        readJob.join()
+        outputBuf.toString()
+    }
+}
+
+// Same as captureStdErr but for stdout.
+@OptIn(UnsafeNumber::class)
+actual suspend fun captureStdOut(block: suspend () -> Unit): String = coroutineScope {
+    memScoped {
+        val pipeOut = allocArray<IntVar>(2)
+        check(pipe(pipeOut) == 0) { "pipe stdout failed" }
+
+        val savedStdout = dup(STDOUT_FILENO)
+
+        check(dup2(pipeOut[1], STDOUT_FILENO) != -1) { "dup2 stdout failed" }
+        close(pipeOut[1])
+
+        val outputBuf = StringBuilder()
+        val readJob = launch(Dispatchers.IO) {
+            val buf = ByteArray(4096)
+            var r: Long
+            do {
+                r = read(pipeOut[0], buf.refTo(0), buf.size.convert()).convert()
+                if (r > 0) outputBuf.append(buf.decodeToString(0, r.convert()))
+            } while (r > 0)
+            close(pipeOut[0])
+        }
+
+        try {
+            block()
+        } finally {
+            fflush(stdout)
+            dup2(savedStdout, STDOUT_FILENO)
+            close(savedStdout)
         }
 
         readJob.join()
         outputBuf.toString()
     }
 }
-
-actual suspend fun captureStdErr(block: suspend () -> Unit): String =
-    captureFileDescriptor(STDERR_FILENO, stderr!!, block)
-
-actual suspend fun captureStdOut(block: suspend () -> Unit): String =
-    captureFileDescriptor(STDOUT_FILENO, stdout!!, block)
 
 actual suspend fun captureGrpcLogs(
     jvmLogLevel: String,

--- a/grpc/grpc-core/src/nativeTest/kotlin/kotlinx/rpc/grpc/test/utils.native.kt
+++ b/grpc/grpc-core/src/nativeTest/kotlin/kotlinx/rpc/grpc/test/utils.native.kt
@@ -8,6 +8,7 @@ package kotlinx.rpc.grpc.test
 
 import platform.posix.setenv
 
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.IntVar
 import kotlinx.cinterop.UnsafeNumber
@@ -28,6 +29,7 @@ import platform.posix.dup2
 import platform.posix.fflush
 import platform.posix.pipe
 import platform.posix.read
+import platform.posix.FILE
 import platform.posix.stderr
 import platform.posix.stdout
 import kotlinx.rpc.grpc.internal.cinterop.grpc_tracer_set_enabled
@@ -46,77 +48,48 @@ fun clearNativeEnv(key: String) {
 }
 
 @OptIn(UnsafeNumber::class)
-actual suspend fun captureStdErr(block: suspend () -> Unit): String = coroutineScope {
+private suspend fun captureFileDescriptor(
+    fileno: Int,
+    stream: CPointer<FILE>,
+    block: suspend () -> Unit,
+): String = coroutineScope {
     memScoped {
-        val pipeErr = allocArray<IntVar>(2)
-        check(pipe(pipeErr) == 0) { "pipe stderr failed" }
+        val pipeFd = allocArray<IntVar>(2)
+        check(pipe(pipeFd) == 0) { "pipe failed" }
 
-        val savedStderr = dup(STDERR_FILENO)
-
-        // redirect stderr write end
-        check(dup2(pipeErr[1], STDERR_FILENO) != -1) { "dup2 stderr failed" }
-        close(pipeErr[1])
+        val saved = dup(fileno)
+        check(dup2(pipeFd[1], fileno) != -1) { "dup2 failed" }
+        close(pipeFd[1])
 
         val outputBuf = StringBuilder()
         val readJob = launch(Dispatchers.IO) {
             val buf = ByteArray(4096)
             var r: Long
             do {
-                r = read(pipeErr[0], buf.refTo(0), buf.size.convert()).convert()
+                r = read(pipeFd[0], buf.refTo(0), buf.size.convert()).convert()
                 if (r > 0) outputBuf.append(buf.decodeToString(0, r.convert()))
             } while (r > 0)
-            close(pipeErr[0])
+            close(pipeFd[0])
         }
 
         try {
             block()
         } finally {
-            fflush(stderr)
-            // restore stderr
-            dup2(savedStderr, STDERR_FILENO)
-            close(savedStderr)
-        }
-
-        // wait reading to finish
-        readJob.join()
-        outputBuf.toString()
-    }
-}
-
-@OptIn(UnsafeNumber::class)
-actual suspend fun captureStdOut(block: suspend () -> Unit): String = coroutineScope {
-    memScoped {
-        val pipeOut = allocArray<IntVar>(2)
-        check(pipe(pipeOut) == 0) { "pipe stdout failed" }
-
-        val savedStdout = dup(STDOUT_FILENO)
-
-        check(dup2(pipeOut[1], STDOUT_FILENO) != -1) { "dup2 stdout failed" }
-        close(pipeOut[1])
-
-        val outputBuf = StringBuilder()
-        val readJob = launch(Dispatchers.IO) {
-            val buf = ByteArray(4096)
-            var r: Long
-            do {
-                r = read(pipeOut[0], buf.refTo(0), buf.size.convert()).convert()
-                if (r > 0) outputBuf.append(buf.decodeToString(0, r.convert()))
-            } while (r > 0)
-            close(pipeOut[0])
-        }
-
-        try {
-            block()
-        } finally {
-            fflush(stdout)
-            dup2(savedStdout, STDOUT_FILENO)
-            close(savedStdout)
+            fflush(stream)
+            dup2(saved, fileno)
+            close(saved)
         }
 
         readJob.join()
         outputBuf.toString()
     }
 }
+
+actual suspend fun captureStdErr(block: suspend () -> Unit): String =
+    captureFileDescriptor(STDERR_FILENO, stderr!!, block)
+
+actual suspend fun captureStdOut(block: suspend () -> Unit): String =
+    captureFileDescriptor(STDOUT_FILENO, stdout!!, block)
 
 actual suspend fun captureGrpcLogs(
     jvmLogLevel: String,


### PR DESCRIPTION
## Summary

- Fix crash (`SIGABRT`) on iOS caused by an unhandled Kotlin exception escaping onto the native gRPC completion queue thread
- Add `catch` block in `NativeClientCall.runBatch` `onComplete` callback to convert exceptions into gRPC cancellations

## Problem

The `onComplete` callback in `runBatch` had `try/finally` but no `catch`. When `onSuccess()` threw (e.g. due to a gRPC connection drop), the exception escaped through `CallbackFuture.complete()` → `opsCompleteCb()` onto the native gRPC thread, where no coroutine could catch it — causing `terminateWithUnhandledException` → `SIGABRT`.

## Fix

Add a `catch` block that calls `cancelInternal()` with `GRPC_STATUS_INTERNAL`, converting the exception into a gRPC cancellation. The error is then properly routed through `RECV_STATUS_ON_CLIENT` → listener → coroutine, where application-level `try/catch` can handle it.

Fixes #749

🤖 Generated with [Claude Code](https://claude.ai/claude-code)