### PR TITLE
KRPC-573: Reduce Gradle and Kotlin daemon heaps

### DIFF
--- a/compiler-plugin/gradle.properties
+++ b/compiler-plugin/gradle.properties
@@ -6,10 +6,11 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
+# Gradle and Kotlin run in separate JVMs; don't give each the full memory of 8 GiB CI agents.
+kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 # org.gradle.workers.max is intentionally absent — Gradle defaults to available CPU cores (KRPC-573)

--- a/dokka-plugin/gradle.properties
+++ b/dokka-plugin/gradle.properties
@@ -6,10 +6,11 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
+# Gradle and Kotlin run in separate JVMs; don't give each the full memory of 8 GiB CI agents.
+kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 # org.gradle.workers.max is intentionally absent — Gradle defaults to available CPU cores (KRPC-573)

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -6,10 +6,11 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
+# Gradle and Kotlin run in separate JVMs; don't give each the full memory of 8 GiB CI agents.
+kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 # org.gradle.workers.max is intentionally absent — Gradle defaults to available CPU cores (KRPC-573)

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,11 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
+# Gradle and Kotlin run in separate JVMs; don't give each the full memory of 8 GiB CI agents.
+kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 # org.gradle.workers.max is intentionally absent — Gradle defaults to available CPU cores (KRPC-573)

--- a/protoc-gen/gradle.properties
+++ b/protoc-gen/gradle.properties
@@ -6,10 +6,11 @@ kotlin.code.style=official
 
 kotlin.native.ignoreDisabledTargets=true
 
-kotlin.daemon.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError
+# Gradle and Kotlin run in separate JVMs; don't give each the full memory of 8 GiB CI agents.
+kotlin.daemon.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallbackStrategy=false
 
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=768m
 org.gradle.daemon=true
 org.gradle.parallel=true
 # org.gradle.workers.max is intentionally absent — Gradle defaults to available CPU cores (KRPC-573)


### PR DESCRIPTION
### Subsystem

Infra (Gradle build configuration)

### Problem

The Latest Public Unstable build runs on a 7.6 GiB agent while both the Gradle daemon and Kotlin daemon are configured with 8 GiB maximum heaps. Builds 63879, 63883, and 63886 reached 95–97% RAM and then lost either daemon without producing a JVM heap dump. TeamCity reported the resulting process loss as an internal compiler error.

Failing build: https://krpc.teamcity.com/buildConfiguration/Build_Compiler_Plugins_Latest_Public_Unstable/63886

YouTrack: https://youtrack.jetbrains.com/issue/KRPC-573

### Solution

Reduce both maximum heaps to 4 GiB in the root build and all four included builds. This preserves CPU-based worker scaling while preventing the two long-lived JVMs from each targeting the full memory of small CI agents.

### Verification

- Latest Public Unstable build 63888 passed: 3,477 tests, 12 ignored
- Peak agent RAM fell from 97% to 91%
- Samples at or above 85% RAM fell from 505 to 232
- All synchronized gradle.properties files are byte-identical
- git diff --check passed

Successful build: https://krpc.teamcity.com/buildConfiguration/Build_Compiler_Plugins_Latest_Public_Unstable/63888