### PR TITLE
Fix compiler plugin compilation against Kotlin master 2.5.0

### DIFF
--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirProtobufMessageGenerator.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirProtobufMessageGenerator.kt
@@ -5,12 +5,10 @@
 package kotlinx.rpc.codegen
 
 import kotlinx.rpc.codegen.common.ProtoNames
-import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
-import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
@@ -113,7 +111,7 @@ class FirProtobufMessageGenerator(
                     modality = Modality.ABSTRACT
                     superType { owner.defaultType() }
                     vsApi {
-                        sourceVS = owner.source?.fakeElement(pluginGeneratedElementKindVS())
+                        sourceVS = owner.source?.fakeElementVS(pluginGeneratedElementKindVS())
                     }
                 }.symbol
             }
@@ -167,7 +165,7 @@ class FirProtobufMessageGenerator(
                     isOverride = true
                 }
                 vsApi {
-                    sourceVS = property.source?.fakeElement(pluginGeneratedElementKindVS())
+                    sourceVS = property.source?.fakeElementVS(pluginGeneratedElementKindVS())
                 }
             }.symbol
         )
@@ -195,7 +193,7 @@ class FirProtobufMessageGenerator(
                 visibility = Visibilities.Public
                 modality = Modality.ABSTRACT
                 vsApi {
-                    sourceVS = property.source?.fakeElement(pluginGeneratedElementKindVS())
+                    sourceVS = property.source?.fakeElementVS(pluginGeneratedElementKindVS())
                 }
             }.symbol
         )

--- a/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirVersionSpecificApi.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/kotlin/kotlinx/rpc/codegen/FirVersionSpecificApi.kt
@@ -60,6 +60,8 @@ interface FirVersionSpecificApi {
 
     fun pluginGeneratedElementKindVS(marker: Any? = null): KtFakeSourceElementKind
 
+    fun KtSourceElement.fakeElementVS(kind: KtFakeSourceElementKind): KtSourceElement
+
     fun ConeTypeParameterType.typeParameterSymbolVS(): FirTypeParameterSymbol?
 }
 

--- a/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/FirVersionSpecificApiImpl.kt
+++ b/compiler-plugin/compiler-plugin-k2/src/main/templates/kotlinx/rpc/codegen/FirVersionSpecificApiImpl.kt
@@ -8,6 +8,7 @@ package kotlinx.rpc.codegen
 //##csm specific=[2.2.0...2.2.10]
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
@@ -40,6 +41,7 @@ import org.jetbrains.kotlin.fir.types.ConeTypeParameterType
 //##csm specific=[2.2.20...2.2.*]
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
@@ -72,6 +74,7 @@ import org.jetbrains.kotlin.fir.types.ConeTypeParameterType
 //##csm specific=[2.3.0...2.4.*]
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.fakeElement
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
@@ -236,6 +239,13 @@ object FirVersionSpecificApiImpl : FirVersionSpecificApi {
         return KtFakeSourceElementKind.PluginGenerated
         //##csm /specific
         //##csm /ClassBuildingContext.sourceVS
+    }
+
+    // Since 2.5.0 `fakeElement` is a member of `KtSourceElement`;
+    // before that it was a top-level extension in `org.jetbrains.kotlin`.
+    // Only the import differs, see the import section above.
+    override fun KtSourceElement.fakeElementVS(kind: KtFakeSourceElementKind): KtSourceElement {
+        return fakeElement(kind)
     }
 
     override fun ConeTypeParameterType.typeParameterSymbolVS(): FirTypeParameterSymbol? {

--- a/gradle/artifacts/publishApplePublicationToBuildRepoRepository.txt
+++ b/gradle/artifacts/publishApplePublicationToBuildRepoRepository.txt
@@ -58,7 +58,6 @@ org.jetbrains.kotlinx:kotlinx-rpc-grpc-client-tvossimulatorarm64/.klib
 org.jetbrains.kotlinx:kotlinx-rpc-grpc-client-tvossimulatorarm64/javadoc.jar
 org.jetbrains.kotlinx:kotlinx-rpc-grpc-client-tvossimulatorarm64/metadata.jar
 org.jetbrains.kotlinx:kotlinx-rpc-grpc-client-tvossimulatorarm64/sources.jar
-
 org.jetbrains.kotlinx:kotlinx-rpc-grpc-client-watchosarm64/.klib
 org.jetbrains.kotlinx:kotlinx-rpc-grpc-client-watchosarm64/javadoc.jar
 org.jetbrains.kotlinx:kotlinx-rpc-grpc-client-watchosarm64/metadata.jar

--- a/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
+++ b/krpc/krpc-test/src/commonMain/kotlin/kotlinx/rpc/krpc/test/KrpcTransportTestBase.kt
@@ -496,11 +496,15 @@ abstract class KrpcTransportTestBase {
     @Test
     fun testPR445() = runTest {
         assertFailsWith<SerializationException> {
-            val result = client.returnTestClassThatThrowsWhileDeserialization(42)
-            @Suppress("SENSELESS_COMPARISON")
-            if (result == null) {
-                assertNotNull(result, "result must not be null")
-            }
+            // The declared return type is non-null, but an unchecked cast can still let a null through
+            // at runtime -- that is exactly what this test guards against. The type is spelled out as
+            // nullable on purpose: with a non-null declared type the `== null` branch narrows to
+            // `Nothing` instead of `Nothing?`, which crashes Fir2Ir on Kotlin 2.5.0 with
+            // "Expected argument type to be Nothing?". Reported upstream; revert once that is fixed.
+            val result: TestClassThatThrowsWhileDeserialization? =
+                client.returnTestClassThatThrowsWhileDeserialization(42)
+
+            assertNotNull(result, "result must not be null")
         }
     }
 


### PR DESCRIPTION
Addresses [Build_Compiler_Plugins_Latest_Kotlin_Master #63881](https://krpc.teamcity.com/buildConfiguration/Build_Compiler_Plugins_Latest_Kotlin_Master/63881) (Kotlin `2.5.0-dev-5734` / `2.5.0-public`).

## 1. `fakeElement` is no longer a top-level extension

The reported failure:

```
e: FirProtobufMessageGenerator.kt:13:29 Unresolved reference 'fakeElement'.
> Compilation error: :compiler-plugin:compiler-plugin-k2:compileKotlin
```

In 2.5.0 `fakeElement` moved from a top-level extension in `org.jetbrains.kotlin` to an abstract member of `KtSourceElement`:

```kotlin
sealed class KtSourceElement : AbstractKtSourceElement() {
    abstract fun fakeElement(
        newKind: KtFakeSourceElementKind,
        offsetStrategy: KtSourceElementOffsetStrategy = KtSourceElementOffsetStrategy.Default,
    ): KtSourceElement
}
```

Only the import differs between versions, so this goes through the existing VS abstraction rather than turning `FirProtobufMessageGenerator.kt` into a CSM template:

- `FirVersionSpecificApi` gains `KtSourceElement.fakeElementVS(kind)`.
- `FirVersionSpecificApiImpl.kt` implements it with a single body; `import org.jetbrains.kotlin.fakeElement` is added to the three pre-2.5.0 CSM import blocks and left out of `[2.5.0...2.*]`.
- The three call sites in `FirProtobufMessageGenerator.kt` use `fakeElementVS`. The already-unused `KtFakeSourceElementKind` import is dropped.

Verified with `clean compileKotlin` on the compiler-plugin across every CSM range:

| Kotlin | CSM range | Result |
|---|---|---|
| 2.2.0 | `[2.2.0...2.2.10]` | pass |
| 2.2.20 | `[2.2.20...2.2.*]` | pass |
| 2.3.0 | `[2.3.0...2.4.*]` | pass |
| 2.4.10 | `[2.3.0...2.4.*]` | pass |
| 2.5.0-public | `[2.5.0...2.*]` | pass |

## 2. Kotlin 2.5.0 Fir2Ir crash exposed downstream

With the plugin compiling again the build reaches `:krpc:krpc-test`, which then dies on `compileKotlin{Jvm,Js,WasmJs,WasmWasi}`:

```
java.lang.IllegalStateException: Expected argument type to be Nothing?
  at Fir2IrImplicitCastInserter.insertCastToNullableNothingOrSelf(Fir2IrImplicitCastInserter.kt:163)
```

**This is an upstream Kotlin regression, not a kotlinx-rpc bug.** Reproduced with the stock `kotlin-compiler-embeddable-2.5.0-public`, no kotlinx-rpc plugin on the classpath:

```kotlin
fun <T : Any> take(value: T?): T = value!!
fun produce(): String = "x"
fun main() {
    val result = produce()
    @Suppress("SENSELESS_COMPARISON")
    if (result == null) { take(result) }
}
```

Compiles fine on 2.3.0 and 2.4.10. Bisected trigger — all three required:

| Variant | Result |
|---|---|
| non-null value + `== null` branch + generic callee inferring `T` from it | crash |
| value declared `String?` | ok |
| callee non-generic (`value: String?`) | ok |
| type argument pinned (`take<String>(result)`) | ok |

Inside the branch, data-flow narrows to `String & Nothing?`; with a non-nullable original that collapses to plain `Nothing`, not `Nothing?`. Inference then picks `T = Nothing`, the expected parameter type becomes `Nothing?`, and `insertCastToNullableNothingOrSelf` hard-asserts the lower bound *is* `Nothing?` — which it isn't.

The second commit works around it in `testPR445` by spelling the type as nullable. The runtime guard from #445 is unchanged: `assertNotNull` still fails if a null slips through the unchecked cast. **Revert once the Kotlin bug is fixed.**

## Verification

Full TeamCity command (`test jvmTest jsTest wasmJsTest wasmWasiTest -Pkotlinx.rpc.kotlinMasterBuild=true --continue -x checkLegacyAbi`) against `2.5.0-public`: **green**. `testPR445` passes on master and on 2.3.0; `:krpc:krpc-test:jvmTest` green on the default version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)